### PR TITLE
make every style overridable in Pages component

### DIFF
--- a/packages/lector/src/components/pages.tsx
+++ b/packages/lector/src/components/pages.tsx
@@ -121,9 +121,9 @@ export const Pages = ({
         display: "flex",
         justifyContent: "center",
         height: "100%",
-        ...props.style,
         position: "relative",
         overflow: "auto",
+        ...props.style,
       }}
     >
       <div


### PR DESCRIPTION
Hi!

We are using your awesome PDF component and looking to use programmatic page navigation. 

This programmatic navigation is modifying the internal state to keep track of the current page the user is seeing. Still, the user could also scroll and create confusion about which page the user is looking at.

The simplest way to avoid the user shooting themselves in the foot is to remove the overflow control, which at the moment is not possible because the style property in the Pages component is always overwriting it as `overflow: auto`.