### PR TITLE
Feat: Configurable zoom limits

### DIFF
--- a/packages/docs/content/docs/code/zoom-control.mdx
+++ b/packages/docs/content/docs/code/zoom-control.mdx
@@ -76,7 +76,7 @@ You can customize the zoom limits by passing `zoomOptions` to the Root component
 
 Default zoom limits if not specified:
 
-- Minimum zoom: 0.5 (50%)
+- Minimum zoom: 0.1 (10%)
 - Maximum zoom: 10 (1000%)
 
 ## Best Practices

--- a/packages/docs/content/docs/code/zoom-control.mdx
+++ b/packages/docs/content/docs/code/zoom-control.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zoom Control
-description: PDF viewer with zoom controls
+description: PDF viewer with zoom controls and configurable zoom limits
 ---
 
 import ViewerZoomControl from "@/components/zoom-control.tsx";
@@ -29,6 +29,10 @@ const ViewerZoomControl = () => {
       source="/pdf/document.pdf"
       className="bg-gray-100 border rounded-md overflow-hidden relative h-[500px] flex flex-col justify-stretch"
       loader={<div className="p-4">Loading...</div>}
+      zoomOptions={{
+        minZoom: 0.5, // 50% minimum zoom
+        maxZoom: 10, // 1000% maximum zoom
+      }}
     >
       <div className="bg-gray-100 border-b p-1 flex items-center justify-center text-sm text-gray-600 gap-2">
         Zoom
@@ -52,12 +56,33 @@ export default ViewerZoomControl;
 ## Features
 
 - Interactive zoom controls with real-time display
+- Configurable zoom limits through `zoomOptions` prop
 - Clean, minimal interface
 - Text selection support
 - Responsive layout
+
+## Zoom Configuration
+
+You can customize the zoom limits by passing `zoomOptions` to the Root component:
+
+```tsx
+<Root
+  zoomOptions={{
+    minZoom: 0.1,  // Allow 10% minimum zoom
+    maxZoom: 20,   // Allow 2000% maximum zoom
+  }}
+>
+```
+
+Default zoom limits if not specified:
+
+- Minimum zoom: 0.5 (50%)
+- Maximum zoom: 10 (1000%)
 
 ## Best Practices
 
 - Implement responsive zoom increments
 - Include proper loading states
 - Maintain consistent styling
+- Consider user experience when setting custom zoom limits
+- Test text readability at custom zoom levels

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -10,8 +10,7 @@ import type {
 } from "pdfjs-dist/types/src/display/api";
 import { useEffect, useState } from "react";
 
-import type { InitialPDFState } from "../../internal";
-import type { ZoomOptions } from "../../components/root";
+import type { InitialPDFState, ZoomOptions } from "../../internal";
 
 export interface usePDFDocumentParams {
   /**

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -4,10 +4,14 @@ import {
   type PDFDocumentProxy,
   type PDFPageProxy,
 } from "pdfjs-dist";
-import type { DocumentInitParameters, TypedArray } from "pdfjs-dist/types/src/display/api";
+import type {
+  DocumentInitParameters,
+  TypedArray,
+} from "pdfjs-dist/types/src/display/api";
 import { useEffect, useState } from "react";
 
 import type { InitialPDFState } from "../../internal";
+import type { ZoomOptions } from "../../components/root";
 
 export interface usePDFDocumentParams {
   /**
@@ -24,9 +28,15 @@ export interface usePDFDocumentParams {
   initialRotation?: number;
   isZoomFitWidth?: boolean;
   zoom?: number;
+  zoomOptions?: ZoomOptions;
 }
 
-export type Source = string | URL | TypedArray | ArrayBuffer | DocumentInitParameters;
+export type Source =
+  | string
+  | URL
+  | TypedArray
+  | ArrayBuffer
+  | DocumentInitParameters;
 
 export const usePDFDocumentContext = ({
   onDocumentLoad,
@@ -34,6 +44,7 @@ export const usePDFDocumentContext = ({
   initialRotation = 0,
   isZoomFitWidth,
   zoom = 1,
+  zoomOptions = {},
 }: usePDFDocumentParams) => {
   const [_, setProgress] = useState(0);
 
@@ -69,6 +80,10 @@ export const usePDFDocumentContext = ({
         pageProxies: sortedPageProxies,
         pdfDocumentProxy: pdf,
         zoom,
+        zoomOptions: {
+          minZoom: zoomOptions.minZoom ?? 0.5,
+          maxZoom: zoomOptions.maxZoom ?? 10,
+        },
       });
     };
 

--- a/packages/lector/src/internal.ts
+++ b/packages/lector/src/internal.ts
@@ -21,6 +21,11 @@ export type HighlightRect = {
   type?: "pixels" | "percent";
 };
 
+export interface ZoomOptions {
+  minZoom?: number;
+  maxZoom?: number;
+}
+
 interface PDFState {
   pdfDocumentProxy: PDFDocumentProxy;
 
@@ -47,10 +52,7 @@ interface PDFState {
   textContent: TextContent[];
   setTextContent: (textContents: TextContent[]) => void;
 
-  zoomOptions: {
-    minZoom: number;
-    maxZoom: number;
-  };
+  zoomOptions: Required<ZoomOptions>;
 
   virtualizer: PDFVirtualizer | null;
   setVirtualizer: (virtualizer: PDFVirtualizer) => void;
@@ -67,10 +69,14 @@ interface PDFState {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type PDFVirtualizer = Virtualizer<any, any>;
 
-export type InitialPDFState = Pick<
-  PDFState,
-  "pdfDocumentProxy" | "pageProxies" | "viewports" | "zoom"
-> & { isZoomFitWidth?: boolean };
+export interface InitialPDFState {
+  pdfDocumentProxy: PDFDocumentProxy;
+  pageProxies: PDFPageProxy[];
+  viewports: Array<PageViewport>;
+  zoom: number;
+  isZoomFitWidth?: boolean;
+  zoomOptions?: ZoomOptions;
+}
 
 export const PDFStore = createZustandContext(
   (initialState: InitialPDFState) => {
@@ -79,8 +85,8 @@ export const PDFStore = createZustandContext(
       zoom: initialState.zoom,
       isZoomFitWidth: initialState.isZoomFitWidth ?? false,
       zoomOptions: {
-        minZoom: 0.5,
-        maxZoom: 10,
+        minZoom: initialState.zoomOptions?.minZoom ?? 0.5,
+        maxZoom: initialState.zoomOptions?.maxZoom ?? 10,
       },
 
       viewportRef: createRef<HTMLDivElement>(),

--- a/packages/lector/src/internal.ts
+++ b/packages/lector/src/internal.ts
@@ -85,7 +85,7 @@ export const PDFStore = createZustandContext(
       zoom: initialState.zoom,
       isZoomFitWidth: initialState.isZoomFitWidth ?? false,
       zoomOptions: {
-        minZoom: initialState.zoomOptions?.minZoom ?? 0.5,
+        minZoom: initialState.zoomOptions?.minZoom ?? 0.1,
         maxZoom: initialState.zoomOptions?.maxZoom ?? 10,
       },
 


### PR DESCRIPTION
Add configurable zoom limits via props. Addresses #41 

## Problem
Currently, the PDF viewer has hardcoded zoom limits (minZoom: 0.5, maxZoom: 10), which restricts users from implementing custom zoom ranges that might be needed for specific use cases.

## Solution
Added `zoomOptions` prop to the Root component that allows overriding the default zoom limits.

Example usage:
```tsx
<Root
  source={fileUrl}
  zoomOptions={{
    minZoom: 0.1,  // Allow 10% zoom
    maxZoom: 20,   // Allow 2000% zoom
  }}
>
```

## Changes
- Added `ZoomOptions` interface
- Updated PDFStore to accept custom zoom limits
- Modified document context to pass through zoom options
- Maintained default values (0.5-10)