### PR TITLE
Fix: Remove hardcoded zoomOptions

### DIFF
--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -79,10 +79,7 @@ export const usePDFDocumentContext = ({
         pageProxies: sortedPageProxies,
         pdfDocumentProxy: pdf,
         zoom,
-        zoomOptions: {
-          minZoom: zoomOptions.minZoom ?? 0.5,
-          maxZoom: zoomOptions.maxZoom ?? 10,
-        },
+        zoomOptions,
       });
     };
 

--- a/packages/lector/src/internal.ts
+++ b/packages/lector/src/internal.ts
@@ -85,7 +85,7 @@ export const PDFStore = createZustandContext(
       zoom: initialState.zoom,
       isZoomFitWidth: initialState.isZoomFitWidth ?? false,
       zoomOptions: {
-        minZoom: initialState.zoomOptions?.minZoom ?? 0.1,
+        minZoom: initialState.zoomOptions?.minZoom ?? 0.5,
         maxZoom: initialState.zoomOptions?.maxZoom ?? 10,
       },
 


### PR DESCRIPTION
Addresses #51. Follow up to #41 (Add configurable zoom limits via props). The previous PR added zoomOptions via props, but an oversight in document.ts prevented custom values from being properly passed through.

Bug Fix
The zoomOptions prop added in #41 wasn't working because values were being hardcoded in document.ts:

`zoomOptions = {
  minZoom: 0.5,
  maxZoom: 10,
}`

This prevented custom minZoom/maxZoom values from being passed through. 

## Changes
- Remove hardcoded zoomOptions in document.ts
- Now properly passing through user-provided zoomOptions
- Maintains default values