### PR TITLE
Module '"@unriddle-ai/lector"' has no exported member 'PageCount'.ts(2305)

### DIFF
--- a/packages/docs/content/docs/basic-usage.mdx
+++ b/packages/docs/content/docs/basic-usage.mdx
@@ -121,13 +121,13 @@ function PDFViewerWithZoom() {
 ### Adding Page Navigation
 
 ```tsx
-import { CurrentPage, PageCount } from "@unriddle-ai/lector";
+import { CurrentPage, TotalPages } from "@unriddle-ai/lector";
 
 function PDFViewerWithNavigation() {
   return (
     <Root source='/sample.pdf'>
       <div className='flex items-center gap-2 p-2'>
-        <CurrentPage /> of <PageCount />
+        <CurrentPage /> of <TotalPages />
       </div>
       <Pages>
         <Page>


### PR DESCRIPTION
Guys thanks for open sourcing this - it's a huge help.

Looks like `PageCount` has been renamed to `TotalPages` in `v2.1.0`.

On a somewhat related note could be nice to add a section to the README about how to contribute to the docs (or add a link to the pages). I'm pretty comfortable searching around repos but others may not be. 

Regardless awesome library!