### PR TITLE
Fix: missing zoomOptions implementation

### DIFF
--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -16,6 +16,7 @@ export const Root = forwardRef(
       onDocumentLoad,
       isZoomFitWidth,
       zoom,
+      zoomOptions,
       ...props
     }: HTMLProps<HTMLDivElement> &
       usePDFDocumentParams & {
@@ -28,6 +29,7 @@ export const Root = forwardRef(
       onDocumentLoad,
       isZoomFitWidth,
       zoom,
+      zoomOptions,
     });
 
     return (

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -119,7 +119,7 @@ export const usePDFDocumentContext = ({
     };
     loadDocument();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [source]);
+  }, [source, zoomOptions]);
 
   return {
     initialState,

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -43,7 +43,7 @@ export const usePDFDocumentContext = ({
   initialRotation = 0,
   isZoomFitWidth,
   zoom = 1,
-  zoomOptions = {},
+  zoomOptions,
 }: usePDFDocumentParams) => {
   const [_, setProgress] = useState(0);
 


### PR DESCRIPTION
his PR adds some missing implementation for zoomOptions that was meant to go with the previous PR (#49) 🤦

Changes:
- Add zoomOptions prop passing from Root to PDF context
- Add zoomOptions to useEffect dependencies to handle updates
- Remove redundant default value for zoomOptions parameter