### PR TITLE
feature: add resolution control

### DIFF
--- a/packages/docs/components/resolution-comparison.tsx
+++ b/packages/docs/components/resolution-comparison.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import {
+  CanvasLayer,
+  CurrentZoom,
+  Page,
+  Pages,
+  Root,
+  TextLayer,
+  usePdf,
+  ZoomIn,
+  ZoomOut,
+} from "@anaralabs/lector";
+
+import "@/lib/setup";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+
+const fileUrl = "/pdf/large.pdf";
+function ResolutionPicker() {
+  const resolution = usePdf((state) => state.resolution);
+  const setResolution = usePdf((state) => state.setResolution);
+  return (
+    <>
+      <label htmlFor="resolution">Resolution</label>
+      <input
+        type="number"
+        value={resolution}
+        onChange={(e) => setResolution(Number(e.target.value))}
+        className="bg-white rounded-full px-3 py-1 border text-center w-16"
+      />
+    </>
+  );
+}
+const ViewerResolutionComparison = () => {
+  const [fullscreen, setFullscreen] = useState(false);
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap gap-4",
+        fullscreen ? "w-full h-full fixed inset-0 z-50 bg-black/50" : "",
+      )}
+    >
+      <Root
+        resolution={1}
+        zoom={2}
+        source={fileUrl}
+        className={cn(
+          "bg-gray-100 px-4 border rounded-md overflow-hidden relative flex flex-col justify-stretch w-full",
+          fullscreen ? "h-full fixed inset-0 z-50" : "h-[500px]",
+        )}
+        loader={<div className="p-4">Loading...</div>}
+      >
+        <div className="bg-gray-100 border-b p-1 flex items-center justify-center text-sm text-gray-600 gap-2">
+          Zoom
+          <ZoomOut className="px-3 py-1 -mr-2 text-gray-900">-</ZoomOut>
+          <CurrentZoom className="bg-white rounded-full px-3 py-1 border text-center w-16" />
+          <ZoomIn className="px-3 py-1 -ml-2 text-gray-900">+</ZoomIn>
+          <button
+            onClick={() => setFullscreen(!fullscreen)}
+            className="px-3 py-1 -ml-2 text-gray-900"
+          >
+            {fullscreen ? "Exit Fullscreen" : "Fullscreen"}
+          </button>
+          <ResolutionPicker />
+        </div>
+        <Pages className="p-4 h-full">
+          <Page>
+            <CanvasLayer />
+            <TextLayer />
+          </Page>
+        </Pages>
+      </Root>
+    </div>
+  );
+};
+
+export default ViewerResolutionComparison;

--- a/packages/docs/content/docs/code/resolution.mdx
+++ b/packages/docs/content/docs/code/resolution.mdx
@@ -1,0 +1,64 @@
+---
+title: Resolution
+description: Control the sharpness and quality of the PDF rendering
+---
+
+import ResolutionComparison from "@/components/resolution-comparison.tsx";
+
+
+
+<ResolutionComparison />
+
+## Usage
+### Using the `resolution` prop
+```tsx
+"use client";
+
+import {
+  CanvasLayer,
+  Page,
+  Pages,
+  Root,
+  TextLayer,
+} from "@anaralabs/lector";
+
+const ViewerResolution = () => {
+  return (
+    <Root
+      source="/pdf/document.pdf"
+      //          v------ Default is 1, but 2 is a good balance between speed and quality
+      resolution={2}
+    >
+      <Pages className="p-4 h-full">
+        <Page>
+          <CanvasLayer />
+          <TextLayer />
+        </Page>
+      </Pages>
+    </Root>
+  );
+};
+
+export default ViewerResolution;
+```
+
+### Using the `usePdf` hook
+Remember to use the `usePdf` hook inside the `Root` component.
+
+```tsx
+const resolution = usePdf((state) => state.resolution);
+const setResolution = usePdf((state) => state.setResolution);
+```
+
+## Features
+
+- Control the sharpness and quality of the PDF rendering at the cost of heavier rendering tasks.
+  - 1 is the fastest render (but the lowest quality)
+  - 4 is the slowest render (but the highest quality)
+- Configurable through the `resolution` prop on the `Root` component or the `usePdf` hook
+- Limited values from 1 to 4 to avoid freezing the browser.
+
+## Best Practices
+
+- Use 2 as a default value for the `resolution` prop. It's a good balance between speed and quality.
+- For mobile devices, do not use a value higher than 2.

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -17,6 +17,7 @@ export const Root = forwardRef(
       isZoomFitWidth,
       zoom,
       zoomOptions,
+      resolution,
       ...props
     }: HTMLProps<HTMLDivElement> &
       usePDFDocumentParams & {
@@ -30,6 +31,7 @@ export const Root = forwardRef(
       isZoomFitWidth,
       zoom,
       zoomOptions,
+      resolution,
     });
 
     return (

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -28,6 +28,14 @@ export interface usePDFDocumentParams {
   isZoomFitWidth?: boolean;
   zoom?: number;
   zoomOptions?: ZoomOptions;
+  /**
+   * An arbitrary value between 1 and 4
+   * @description 1 it's the fastest render (but the lowest quality) and 4 is the slowest render (but the highest quality)
+   * @important If you set it to a very high value, it will cause the PDF to render very slowly and even freeze the browser.
+   * @note In some browsers and devices like Safari in Mac, setting resolution to 1 will generate blurry PDFs.
+   * @default 1
+  */
+  resolution?: InitialPDFState["resolution"];
 }
 
 export type Source =
@@ -44,6 +52,7 @@ export const usePDFDocumentContext = ({
   isZoomFitWidth,
   zoom = 1,
   zoomOptions,
+  resolution = 1,
 }: usePDFDocumentParams) => {
   const [_, setProgress] = useState(0);
 
@@ -81,6 +90,7 @@ export const usePDFDocumentContext = ({
         pdfDocumentProxy: pdf,
         zoom,
         zoomOptions,
+        resolution,
       }));
     };
 

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -10,7 +10,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
   const pageNumber = usePDFPageNumber();
 
   const dpr = useDpr();
-
+  const resolution = usePdf((state) => state.resolution);
   const bouncyZoom = usePdf((state) => state.zoom);
   const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 
@@ -28,7 +28,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 
     const canvas = canvasRef.current;
 
-    const scale = dpr * zoom;
+    const scale = dpr * zoom * resolution;
 
     canvas.height = viewport.height * scale;
     canvas.width = viewport.width * scale;
@@ -56,7 +56,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
     return () => {
       void renderingTask.cancel();
     };
-  }, [pdfPageProxy, dpr, zoom]);
+  }, [pdfPageProxy, dpr, zoom, resolution]);
 
   return {
     canvasRef,

--- a/packages/lector/src/internal.ts
+++ b/packages/lector/src/internal.ts
@@ -77,6 +77,16 @@ interface PDFState {
   coloredHighlights: ColoredHighlight[];
   addColoredHighlight: (value: ColoredHighlight) => void;
   deleteColoredHighlight: (uuid: string) => void;
+
+  /**
+   * An arbitrary value between 1 and 4
+   * @description 1 it's the fastest render (but the lowest quality) and 4 is the slowest render (but the highest quality)
+   * @important If you set it to a very high value, it will cause the PDF to render very slowly and even freeze the browser.
+   * @note In some browsers and devices like Safari in Mac, setting resolution to 1 will generate blurry PDFs.
+   * @default 1
+   */
+  resolution: number;
+  setResolution: (val: number) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -89,6 +99,7 @@ export interface InitialPDFState {
   zoom: number;
   isZoomFitWidth?: boolean;
   zoomOptions?: ZoomOptions;
+  resolution?: PDFState["resolution"];
 }
 
 export const PDFStore = createZustandContext(
@@ -198,6 +209,13 @@ export const PDFStore = createZustandContext(
             (rect) => rect.uuid !== uuid,
           ),
         })),
+
+      resolution: Math.min(initialState.resolution ?? 1, 4),
+      setResolution: (val) => {
+        set({
+          resolution: Math.min(Math.max(val, 1), 4),
+        });
+      },
     }));
   },
 );


### PR DESCRIPTION
Hi! In this opportunity I'm introducing a 'resolution' concept to improve the sharpness and quality of the pdf rendering.

In high DPI screens the difference is huge.

## Demo
This is an image with the comparison between resolution 1 (the default) and resolution 3


<img width="4290" height="2315" alt="Group 1 (2)" src="https://github.com/user-attachments/assets/7a03788b-509b-4da1-8ea5-0461d7484aef" />
