### PR TITLE
fix: improve variable naming in zoom component

### DIFF
--- a/packages/lector/package.json
+++ b/packages/lector/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@anaralabs/lector",
 	"version": "0.0.0-semantically-released",
-	"description": "Headless PDF viewer for React",
+	"description": "A headless PDF viewer for React",
 	"author": "andrewdr (https://github.com/andrewdoro)",
 	"license": "MIT",
 	"type": "module",

--- a/packages/lector/src/components/zoom.tsx
+++ b/packages/lector/src/components/zoom.tsx
@@ -34,14 +34,14 @@ export const ZoomOut = ({ ...props }: HTMLProps<HTMLButtonElement>) => {
 };
 
 export const CurrentZoom = ({ ...props }: HTMLProps<HTMLInputElement>) => {
-	const setRealZoom = usePdf((state) => state.updateZoom);
+	const updateZoom = usePdf((state) => state.updateZoom);
 	const realZoom = usePdf((state) => state.zoom);
 
 	const [zoom, setZoom] = useState<string>((realZoom * 100).toFixed(0));
-	const isSelected = useRef<boolean>(false);
+	const isInputFocused = useRef<boolean>(false);
 
 	useEffect(() => {
-		if (isSelected.current) {
+		if (isInputFocused.current) {
 			return;
 		}
 
@@ -53,14 +53,14 @@ export const CurrentZoom = ({ ...props }: HTMLProps<HTMLInputElement>) => {
 			{...props}
 			value={zoom}
 			onClick={() => {
-				isSelected.current = true;
+				isInputFocused.current = true;
 			}}
 			onChange={(e) => {
-				setRealZoom(Number(e.target.value) / 100);
+				updateZoom(Number(e.target.value) / 100);
 				setZoom(e.target.value);
 			}}
 			onBlur={() => {
-				isSelected.current = false;
+				isInputFocused.current = false;
 
 				setZoom((realZoom * 100).toFixed(0));
 			}}


### PR DESCRIPTION
## Summary
- Rename `setRealZoom` → `updateZoom` to match the store method name
- Rename `isSelected` → `isInputFocused` for clarity
- Update package description

## Test plan
- [ ] Verify zoom in/out/input still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Rename variables in `CurrentZoom` component for clarity
> Renames `setRealZoom` to `updateZoom` and `isSelected` to `isInputFocused` in [zoom.tsx](https://github.com/anaralabs/lector/pull/107/files#diff-b7e4a82691ee7d7698cd71c3df41fd88419893c1c8a62c9df6101e18cc102d38). Also fixes the article in the package description. No logic or behavior changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51ce573.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->