### PR TITLE
fix: add onError and onPassword callbacks to Root

### DIFF
--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -19,6 +19,8 @@ export const Root = forwardRef(
 			source,
 			loader,
 			onDocumentLoad,
+			onError,
+			onPassword,
 			isZoomFitWidth,
 			zoom,
 			zoomOptions,
@@ -33,6 +35,8 @@ export const Root = forwardRef(
 		const { initialState } = usePDFDocumentContext({
 			source,
 			onDocumentLoad,
+			onError,
+			onPassword,
 			isZoomFitWidth,
 			zoom,
 			zoomOptions,

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -25,6 +25,20 @@ export interface usePDFDocumentParams {
 		proxy: PDFDocumentProxy;
 		source: Source;
 	}) => void;
+	/**
+	 * Called when the PDF fails to load (network error, corrupt file, etc.).
+	 * Without this, errors are silently logged to the console and the loader renders indefinitely.
+	 */
+	onError?: (error: Error) => void;
+	/**
+	 * Called when a password-protected PDF is opened.
+	 * Receives a callback to provide the password and a reason code
+	 * (NEED_PASSWORD for first attempt, INCORRECT_PASSWORD for retries).
+	 */
+	onPassword?: (
+		callback: (password: string) => void,
+		reason: number,
+	) => void;
 	initialRotation?: number;
 	isZoomFitWidth?: boolean;
 	zoom?: number;
@@ -77,6 +91,8 @@ function buildDocumentInitParams(
 
 export const usePDFDocumentContext = ({
 	onDocumentLoad,
+	onError,
+	onPassword,
 	source,
 	initialRotation = 0,
 	isZoomFitWidth,
@@ -145,6 +161,9 @@ export const usePDFDocumentContext = ({
 					loadingTask = getDocument(
 						buildDocumentInitParams(source, documentOptionsRef.current),
 					);
+					if (onPassword) {
+						loadingTask.onPassword = onPassword;
+					}
 					loadingTask.onProgress = (progressEvent: OnProgressParameters) => {
 						if (progressEvent.loaded === progressEvent.total) {
 							return;
@@ -169,7 +188,11 @@ export const usePDFDocumentContext = ({
 								return;
 							}
 
-							console.error("Error loading PDF document", error);
+							if (onError) {
+								onError(error);
+							} else {
+								console.error("Error loading PDF document", error);
+							}
 						});
 				})
 				.catch((error) => {
@@ -177,7 +200,11 @@ export const usePDFDocumentContext = ({
 						return;
 					}
 
-					console.error("Error loading PDF.js", error);
+					if (onError) {
+						onError(error);
+					} else {
+						console.error("Error loading PDF.js", error);
+					}
 				});
 
 			return () => {


### PR DESCRIPTION
## Summary
- Add `onError` callback to `Root` — called when PDF loading fails (network error, corrupt file, etc.), preventing the loader from rendering indefinitely with no way to detect failure
- Add `onPassword` callback to `Root` — exposes pdfjs-dist's password prompt mechanism for password-protected PDFs
- Backwards compatible: without these callbacks, behavior is unchanged (errors logged to console)

Closes #96

## Test plan
- [ ] Verify normal PDF loading still works
- [ ] Test `onError` fires on invalid/corrupt PDF source
- [ ] Test `onPassword` is called for password-protected PDFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `onError` and `onPassword` callbacks to the `Root` PDF component
> - Adds optional `onError` and `onPassword` props to [root.tsx](https://github.com/anaralabs/lector/pull/108/files#diff-d9723dd7c868885ce3529c0089de347a7ea349cd8ed1b3d9fb36b3aa7032a9a3) and forwards them to `usePDFDocumentContext`.
> - In [document.ts](https://github.com/anaralabs/lector/pull/108/files#diff-76ae8d556756568456ebb2cf14621df2c1af3e72c69e1c9093ec3384e2a15c9b), `onPassword` is assigned to `loadingTask.onPassword` to handle password-protected PDFs, and `onError` is called on load failures instead of `console.error`.
> - Behavioral Change: callers that previously relied on `console.error` for PDF load errors must now provide `onError` to observe those errors; existing behavior is preserved when neither prop is provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 541a962.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->