### PR TITLE
fix: firefox pinch flash

### DIFF
--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,6 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": -16
+    "size": 38222,
+    "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,6 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 38222,
-    "sizeLimit": 150000
+    "size": -16
   }
 ]

--- a/packages/lector/src/components/pages.tsx
+++ b/packages/lector/src/components/pages.tsx
@@ -234,6 +234,7 @@ export const Pages = ({
 						alignItems: "center",
 						flexDirection: "column",
 						transformOrigin: "0 0",
+						willChange: "transform",
 						// width: "max-content",
 						width: largestPageWidth,
 						margin: "0 auto",

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -31,10 +31,18 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 
 	// Cache base viewport dimensions — they never change for a given page proxy.
 	// Avoids allocating a new viewport object on every effect run.
-	const pageDimsRef = useRef<{ width: number; height: number; proxy: unknown } | null>(null);
+	const pageDimsRef = useRef<{
+		width: number;
+		height: number;
+		proxy: unknown;
+	} | null>(null);
 	if (!pageDimsRef.current || pageDimsRef.current.proxy !== pdfPageProxy) {
 		const vp = pdfPageProxy.getViewport({ scale: 1 });
-		pageDimsRef.current = { width: vp.width, height: vp.height, proxy: pdfPageProxy };
+		pageDimsRef.current = {
+			width: vp.width,
+			height: vp.height,
+			proxy: pdfPageProxy,
+		};
 	}
 
 	// useLayoutEffect for cache hits — synchronous draw before paint, no flash.

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -29,6 +29,14 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 	const lastBackgroundRef = useRef(background);
 	const lastPageProxyRef = useRef(pdfPageProxy);
 
+	// Cache base viewport dimensions — they never change for a given page proxy.
+	// Avoids allocating a new viewport object on every effect run.
+	const pageDimsRef = useRef<{ width: number; height: number; proxy: unknown } | null>(null);
+	if (!pageDimsRef.current || pageDimsRef.current.proxy !== pdfPageProxy) {
+		const vp = pdfPageProxy.getViewport({ scale: 1 });
+		pageDimsRef.current = { width: vp.width, height: vp.height, proxy: pdfPageProxy };
+	}
+
 	// useLayoutEffect for cache hits — synchronous draw before paint, no flash.
 	// Cache misses enqueue async work via the render queue (non-blocking).
 	useLayoutEffect(() => {
@@ -46,9 +54,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 			lastRenderedScaleRef.current = 0;
 		}
 
-		const baseViewport = pdfPageProxy.getViewport({ scale: 1 });
-		const pageWidth = baseViewport.width;
-		const pageHeight = baseViewport.height;
+		const { width: pageWidth, height: pageHeight } = pageDimsRef.current;
 		const bgColor = background ?? "white";
 
 		const targetBaseScale = dpr * Math.min(zoom, 1);

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -62,7 +62,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 			lastRenderedScaleRef.current = 0;
 		}
 
-		const { width: pageWidth, height: pageHeight } = pageDimsRef.current;
+		const { width: pageWidth, height: pageHeight } = pageDimsRef.current!;
 		const bgColor = background ?? "white";
 
 		const targetBaseScale = dpr * Math.min(zoom, 1);

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -76,7 +76,7 @@ export const useDetailCanvasLayer = ({
 				return;
 			}
 
-			const { width: pageWidth, height: pageHeight } = pageDimsRef.current;
+			const { width: pageWidth, height: pageHeight } = pageDimsRef.current!;
 
 			const scrollX = scrollContainer.scrollLeft / zoom;
 			const scrollY = scrollContainer.scrollTop / zoom;

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -31,10 +31,18 @@ export const useDetailCanvasLayer = ({
 	const [zoom] = useDebounce(bouncyZoom, 200);
 
 	// Cache base viewport dimensions — they never change for a given page proxy.
-	const pageDimsRef = useRef<{ width: number; height: number; proxy: unknown } | null>(null);
+	const pageDimsRef = useRef<{
+		width: number;
+		height: number;
+		proxy: unknown;
+	} | null>(null);
 	if (!pageDimsRef.current || pageDimsRef.current.proxy !== pdfPageProxy) {
 		const vp = pdfPageProxy.getViewport({ scale: 1 });
-		pageDimsRef.current = { width: vp.width, height: vp.height, proxy: pdfPageProxy };
+		pageDimsRef.current = {
+			width: vp.width,
+			height: vp.height,
+			proxy: pdfPageProxy,
+		};
 	}
 
 	useLayoutEffect(() => {

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -30,6 +30,13 @@ export const useDetailCanvasLayer = ({
 
 	const [zoom] = useDebounce(bouncyZoom, 200);
 
+	// Cache base viewport dimensions — they never change for a given page proxy.
+	const pageDimsRef = useRef<{ width: number; height: number; proxy: unknown } | null>(null);
+	if (!pageDimsRef.current || pageDimsRef.current.proxy !== pdfPageProxy) {
+		const vp = pdfPageProxy.getViewport({ scale: 1 });
+		pageDimsRef.current = { width: vp.width, height: vp.height, proxy: pdfPageProxy };
+	}
+
 	useLayoutEffect(() => {
 		const scrollContainer = viewportRef?.current;
 		if (!scrollContainer) {
@@ -61,9 +68,7 @@ export const useDetailCanvasLayer = ({
 				return;
 			}
 
-			const baseViewport = pdfPageProxy.getViewport({ scale: 1 });
-			const pageWidth = baseViewport.width;
-			const pageHeight = baseViewport.height;
+			const { width: pageWidth, height: pageHeight } = pageDimsRef.current;
 
 			const scrollX = scrollContainer.scrollLeft / zoom;
 			const scrollY = scrollContainer.scrollTop / zoom;

--- a/packages/lector/src/hooks/viewport/useViewportContainer.tsx
+++ b/packages/lector/src/hooks/viewport/useViewportContainer.tsx
@@ -4,7 +4,6 @@ import {
 	useCallback,
 	useEffect,
 	useRef,
-	useState,
 } from "react";
 
 import { usePdf } from "../../internal";
@@ -25,7 +24,9 @@ export const useViewportContainer = ({
 	elementWrapperRef: RefObject<HTMLDivElement | null>;
 	elementRef: RefObject<HTMLDivElement | null>;
 }) => {
-	const [origin, setOrigin] = useState<[number, number]>([0, 0]);
+	// Ref instead of useState — the return value isn't consumed by any caller,
+	// so useState was causing a wasted React re-render on every pinch start.
+	const originRef = useRef<[number, number]>([0, 0]);
 	const wheelInertia = useRef<{
 		active: boolean;
 		lastTime: number;
@@ -59,6 +60,12 @@ export const useViewportContainer = ({
 		zoom,
 	});
 
+	// rAF handle for debouncing Zustand store updates during pinch.
+	// The imperative DOM transform runs every frame; the store update
+	// (which triggers React re-renders in all zoom subscribers) is
+	// coalesced to at most one per animation frame.
+	const zoomRafRef = useRef<number | null>(null);
+
 	const updateTransform = useCallback(
 		(zoomUpdate?: boolean) => {
 			if (
@@ -89,10 +96,24 @@ export const useViewportContainer = ({
 			containerRef.current.scrollTop = translateY;
 			containerRef.current.scrollLeft = translateX;
 
-			if (zoomUpdate) updateZoom(() => transformations.current.zoom);
+			if (zoomUpdate && zoomRafRef.current === null) {
+				zoomRafRef.current = requestAnimationFrame(() => {
+					zoomRafRef.current = null;
+					updateZoom(() => transformations.current.zoom);
+				});
+			}
 		},
 		[containerRef, elementRef, elementWrapperRef, updateZoom],
 	);
+
+	// Cancel pending rAF on unmount
+	useEffect(() => {
+		return () => {
+			if (zoomRafRef.current !== null) {
+				cancelAnimationFrame(zoomRafRef.current);
+			}
+		};
+	}, []);
 
 	useEffect(() => {
 		if (transformations.current.zoom === zoom || !containerRef.current) {
@@ -226,10 +247,10 @@ export const useViewportContainer = ({
 						origin[1] - containerRect.top,
 					];
 
-					setOrigin([
+					originRef.current = [
 						contentPosition[0] / currentZoom,
 						contentPosition[1] / currentZoom,
-					]);
+					];
 
 					return {
 						contentPosition,
@@ -292,6 +313,6 @@ export const useViewportContainer = ({
 	);
 
 	return {
-		origin,
+		origin: originRef.current,
 	};
 };

--- a/packages/lector/src/hooks/viewport/useViewportContainer.tsx
+++ b/packages/lector/src/hooks/viewport/useViewportContainer.tsx
@@ -1,10 +1,5 @@
 import { useGesture } from "@use-gesture/react";
-import {
-	type RefObject,
-	useCallback,
-	useEffect,
-	useRef,
-} from "react";
+import { type RefObject, useCallback, useEffect, useRef } from "react";
 
 import { usePdf } from "../../internal";
 import { clamp } from "../../lib/clamp";
@@ -65,6 +60,12 @@ export const useViewportContainer = ({
 	// (which triggers React re-renders in all zoom subscribers) is
 	// coalesced to at most one per animation frame.
 	const zoomRafRef = useRef<number | null>(null);
+	// Track the last zoom value we pushed to the store so the sync effect
+	// can distinguish our own rAF-deferred updates from external changes
+	// (e.g. zoom slider). Without this, the sync effect sees a mismatch
+	// between the store (stale rAF value) and transformations.current
+	// (already advanced by a newer pinch frame) and snaps back.
+	const lastPushedZoomRef = useRef(zoom);
 
 	const updateTransform = useCallback(
 		(zoomUpdate?: boolean) => {
@@ -99,7 +100,9 @@ export const useViewportContainer = ({
 			if (zoomUpdate && zoomRafRef.current === null) {
 				zoomRafRef.current = requestAnimationFrame(() => {
 					zoomRafRef.current = null;
-					updateZoom(() => transformations.current.zoom);
+					const z = transformations.current.zoom;
+					lastPushedZoomRef.current = z;
+					updateZoom(() => z);
 				});
 			}
 		},
@@ -115,8 +118,15 @@ export const useViewportContainer = ({
 		};
 	}, []);
 
+	// Sync external zoom changes (e.g. zoom slider, programmatic setZoom)
+	// into the imperative transform. Skip updates that originated from our
+	// own rAF-deferred store push to avoid overwriting a newer pinch value.
 	useEffect(() => {
 		if (transformations.current.zoom === zoom || !containerRef.current) {
+			return;
+		}
+
+		if (zoom === lastPushedZoomRef.current) {
 			return;
 		}
 

--- a/packages/lector/src/hooks/viewport/useViewportContainer.tsx
+++ b/packages/lector/src/hooks/viewport/useViewportContainer.tsx
@@ -71,16 +71,21 @@ export const useViewportContainer = ({
 
 			const { zoom, translateX, translateY } = transformations.current;
 
+			// Read natural dimensions BEFORE writing the transform — avoids
+			// forced synchronous layout. getBoundingClientRect() after a
+			// transform write forces Firefox to re-rasterize the compositor
+			// layer mid-frame, briefly flashing the canvas background color.
+			const naturalWidth =
+				parseFloat(elementRef.current.style.width) ||
+				elementRef.current.offsetWidth;
+			const naturalHeight =
+				parseFloat(elementRef.current.style.height) ||
+				elementRef.current.offsetHeight;
+
+			// Batch all writes — no layout reads after this point.
 			elementRef.current.style.transform = `scale3d(${zoom}, ${zoom}, 1)`;
-			elementRef.current.style.willChange = "scale3d";
-
-			const elementBoundingBox = elementRef.current.getBoundingClientRect();
-
-			const width = elementBoundingBox.width;
-
-			elementWrapperRef.current.style.width = `${width}px`;
-			elementWrapperRef.current.style.height = `${elementBoundingBox.height}px`;
-
+			elementWrapperRef.current.style.width = `${naturalWidth * zoom}px`;
+			elementWrapperRef.current.style.height = `${naturalHeight * zoom}px`;
 			containerRef.current.scrollTop = translateY;
 			containerRef.current.scrollLeft = translateX;
 

--- a/packages/lector/src/lib/render-cache.ts
+++ b/packages/lector/src/lib/render-cache.ts
@@ -19,7 +19,7 @@ class RenderCache {
 	// don't insert orphaned entries after invalidateDocument() runs.
 	private invalidatedDocs = new Set<string>();
 
-	constructor(maxEntries = 30) {
+	constructor(maxEntries = 60) {
 		this.maxEntries = maxEntries;
 	}
 
@@ -46,6 +46,36 @@ class RenderCache {
 		this.cache.delete(k);
 		this.cache.set(k, entry);
 		return entry;
+	}
+
+	/**
+	 * Return the best cached entry for a page at ANY scale.
+	 * Prefers the closest scale to `targetScale`. Used as a placeholder
+	 * when the exact scale isn't cached yet (e.g. during zoom transitions).
+	 */
+	getNearest(
+		documentId: string,
+		pageNumber: number,
+		targetScale: number,
+		background?: string,
+	): CacheEntry | undefined {
+		const prefix = `${documentId}-${pageNumber}-`;
+		const suffix = `-${background ?? "white"}`;
+		let best: CacheEntry | undefined;
+		let bestDist = Infinity;
+
+		for (const [k, entry] of this.cache) {
+			if (!k.startsWith(prefix) || !k.endsWith(suffix)) continue;
+			const scaleStr = k.slice(prefix.length, k.length - suffix.length);
+			const s = Number(scaleStr);
+			if (!Number.isFinite(s)) continue;
+			const dist = Math.abs(s - targetScale);
+			if (dist < bestDist) {
+				bestDist = dist;
+				best = entry;
+			}
+		}
+		return best;
 	}
 
 	async set(

--- a/packages/lector/src/lib/render-cache.ts
+++ b/packages/lector/src/lib/render-cache.ts
@@ -48,36 +48,6 @@ class RenderCache {
 		return entry;
 	}
 
-	/**
-	 * Return the best cached entry for a page at ANY scale.
-	 * Prefers the closest scale to `targetScale`. Used as a placeholder
-	 * when the exact scale isn't cached yet (e.g. during zoom transitions).
-	 */
-	getNearest(
-		documentId: string,
-		pageNumber: number,
-		targetScale: number,
-		background?: string,
-	): CacheEntry | undefined {
-		const prefix = `${documentId}-${pageNumber}-`;
-		const suffix = `-${background ?? "white"}`;
-		let best: CacheEntry | undefined;
-		let bestDist = Infinity;
-
-		for (const [k, entry] of this.cache) {
-			if (!k.startsWith(prefix) || !k.endsWith(suffix)) continue;
-			const scaleStr = k.slice(prefix.length, k.length - suffix.length);
-			const s = Number(scaleStr);
-			if (!Number.isFinite(s)) continue;
-			const dist = Math.abs(s - targetScale);
-			if (dist < bestDist) {
-				bestDist = dist;
-				best = entry;
-			}
-		}
-		return best;
-	}
-
 	async set(
 		documentId: string,
 		pageNumber: number,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix Firefox pinch flash in viewport container zoom handling
- Replaces `useState`-based pinch origin with a ref in [`useViewportContainer`](https://github.com/anaralabs/lector/pull/110/files#diff-47bea89be68e90ad3ef7badd691780cc40a106c963d7f52ca97daaf7369d9b53) to avoid React re-renders on every pinch gesture update.
- Coalesces zoom store updates via `requestAnimationFrame` so at most one update fires per animation frame during pinch/transform.
- Derives element wrapper dimensions from pre-transform natural dimensions instead of reading layout after writes.
- Adds `will-change: transform` to the scaled container div in [`pages.tsx`](https://github.com/anaralabs/lector/pull/110/files#diff-b6a56e43c4970c3f8472ca65ee4721869c20b0d0c723d0d925f64e6906c7bd23) to promote the layer and reduce repaint flashes.
- Doubles the [`RenderCache`](https://github.com/anaralabs/lector/pull/110/files#diff-0cc2c7a33d8696de31b2e2fce3624e47dfe58a4e26d11b44f524ae8f926bc442) default from 30 to 60 entries and adds a `getNearest` method to retrieve the closest-scale cached bitmap during pinch zoom.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5ca676.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->