### PR TITLE
fix: default wasmUrl/cMapUrl/standardFontDataUrl/iccUrl so JPEG2000 + JBIG2 PDFs render

### DIFF
--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -11,7 +11,7 @@ import type {
 import { useEffect, useRef, useState } from "react";
 
 import type { InitialPDFState, ZoomOptions } from "../../internal";
-import { loadPdfJs } from "../../lib/pdfjs";
+import { getDefaultPdfJsAssetUrls, loadPdfJs } from "../../lib/pdfjs";
 
 export interface usePDFDocumentParams {
 	/**
@@ -46,6 +46,7 @@ export type Source =
 
 function buildDocumentInitParams(
 	source: Source,
+	pdfJsVersion: string,
 	overrides?: Partial<DocumentInitParameters>,
 ): DocumentInitParameters {
 	let params: DocumentInitParameters;
@@ -57,6 +58,8 @@ function buildDocumentInitParams(
 	} else {
 		params = { ...source };
 	}
+
+	const assetUrls = getDefaultPdfJsAssetUrls(pdfJsVersion);
 
 	const defaults: Partial<DocumentInitParameters> = {
 		// Skip the slow _guessMax binary-search auto-detection of max canvas area.
@@ -70,6 +73,21 @@ function buildDocumentInitParams(
 		// Explicitly opt-in to OffscreenCanvas in the worker for image processing.
 		// Already the browser default, but being explicit avoids edge cases.
 		isOffscreenCanvasSupported: true,
+		// PDF.js 5.x split out auxiliary resources that are loaded on demand.
+		// Without these URLs, several content types render as blank pages
+		// because pdf.js silently fails to load decoders / fonts / colour
+		// profiles. The most visible symptom: scanned PDFs with JPEG2000 or
+		// JBIG2 images (Internet Archive, government archives) render as
+		// completely blank pages — every image fails with
+		// "OpenJPEG failed to initialize". Defaulting these to a versioned
+		// jsDelivr URL gets the viewer working out of the box; production
+		// deployments should self-host and pass overrides via
+		// `documentOptions`.
+		wasmUrl: assetUrls.wasmUrl,
+		cMapUrl: assetUrls.cMapUrl,
+		cMapPacked: true,
+		standardFontDataUrl: assetUrls.standardFontDataUrl,
+		iccUrl: assetUrls.iccUrl,
 	};
 
 	return { ...defaults, ...params, ...overrides };
@@ -137,13 +155,17 @@ export const usePDFDocumentContext = ({
 			let isDisposed = false;
 
 			void loadPdfJs()
-				.then(({ getDocument }) => {
+				.then(({ getDocument, version }) => {
 					if (isDisposed) {
 						return;
 					}
 
 					loadingTask = getDocument(
-						buildDocumentInitParams(source, documentOptionsRef.current),
+						buildDocumentInitParams(
+							source,
+							version,
+							documentOptionsRef.current,
+						),
 					);
 					loadingTask.onProgress = (progressEvent: OnProgressParameters) => {
 						if (progressEvent.loaded === progressEvent.total) {

--- a/packages/lector/src/lib/pdfjs.ts
+++ b/packages/lector/src/lib/pdfjs.ts
@@ -15,3 +15,46 @@ export const loadPdfJs = () => {
 
 	return pdfJsPromise;
 };
+
+/**
+ * Default asset URLs for PDF.js auxiliary resources.
+ *
+ * PDF.js 5.x ships these resources separately and requires URLs to fetch them
+ * at runtime. Without them, certain content types fail to render entirely:
+ *
+ * - `wasmUrl`: WASM decoders for JPEG2000 (`openjpeg.wasm`) and JBIG2
+ *   (`jbig2.wasm`), plus the JS fallback. Required for scanned PDFs from
+ *   the Internet Archive, government archives, and any PDF using JPX or
+ *   JBIG2 image streams. Without `wasmUrl`, JPEG2000 images fail with
+ *   "OpenJPEG failed to initialize" and the page renders as a blank canvas.
+ * - `cMapUrl`: Character maps for CJK / non-Latin fonts.
+ * - `standardFontDataUrl`: Substitutions for the 14 PDF base fonts when
+ *   not embedded.
+ * - `iccUrl`: ICC color profiles for accurate color rendering.
+ *
+ * We default to a versioned jsDelivr URL so consumers get a working viewer
+ * out of the box. Production deployments should self-host these assets and
+ * pass them via `documentOptions` for offline support, CSP compliance, and
+ * to avoid third-party CDN latency.
+ *
+ * jsDelivr is preferred over unpkg because it serves with permissive CORS
+ * headers, has higher uptime, and supports range requests.
+ */
+const ASSET_CDN_BASE = "https://cdn.jsdelivr.net/npm/pdfjs-dist";
+
+export interface PdfJsAssetUrls {
+	wasmUrl: string;
+	cMapUrl: string;
+	standardFontDataUrl: string;
+	iccUrl: string;
+}
+
+export const getDefaultPdfJsAssetUrls = (version: string): PdfJsAssetUrls => {
+	const base = `${ASSET_CDN_BASE}@${version}`;
+	return {
+		wasmUrl: `${base}/wasm/`,
+		cMapUrl: `${base}/cmaps/`,
+		standardFontDataUrl: `${base}/standard_fonts/`,
+		iccUrl: `${base}/iccs/`,
+	};
+};


### PR DESCRIPTION
## Summary

Defaults the four PDF.js 5.x asset URLs (`wasmUrl`, `cMapUrl`, `standardFontDataUrl`, `iccUrl`) to a versioned jsDelivr CDN, pinned to whatever `pdfjs-dist` version is loaded at runtime. Without these, scanned PDFs that use JPEG2000 or JBIG2 image streams render as completely blank pages because the worker can't initialize the WASM decoders.

## Why

PDF.js 5.x split its image decoders (`openjpeg.wasm`, `jbig2.wasm`), color profiles (`qcms_bg.wasm`, ICC), CJK character maps, and the standard 14 base fonts into separate buckets. `getDocument()` requires URLs to fetch them on demand, but lector wasn't passing any.

The most visible symptom: any scanned PDF from the Internet Archive (Scribe), government archives, or any other JPX/JBIG2-heavy source renders as a white screen. The console logs are easy to miss because they're tagged `Warning:` rather than `Error:`:

```
Warning: JpxImage#instantiateWasm: UnknownErrorException:
  Ensure that the `wasmUrl` API parameter is provided.
Warning: JpxImage#getJsModule: TypeError:
  Failed to resolve module specifier 'nullopenjpeg_nowasm_fallback.js'
Warning: Unable to decode image "img_p0_1":
  "JpxError: OpenJPEG failed to initialize".
```

…and then every page comes out blank because every image failed to decode.

## What changed

- `packages/lector/src/lib/pdfjs.ts`: new `getDefaultPdfJsAssetUrls(version)` helper. Builds versioned jsDelivr URLs (`https://cdn.jsdelivr.net/npm/pdfjs-dist@<version>/{wasm,cmaps,standard_fonts,iccs}/`).
- `packages/lector/src/hooks/document/document.ts`: reads `version` off the loaded pdfjs module and threads it through `buildDocumentInitParams` so the four URLs get sensible defaults.

The defaults sit *below* `documentOptions` in the spread order, so anyone who wants to self-host (CSP, offline, latency) can override:

```tsx
<Root
  documentOptions={{
    wasmUrl: new URL('pdfjs-dist/wasm/', import.meta.url).href,
    cMapUrl: new URL('pdfjs-dist/cmaps/', import.meta.url).href,
    standardFontDataUrl: new URL('pdfjs-dist/standard_fonts/', import.meta.url).href,
    iccUrl: new URL('pdfjs-dist/iccs/', import.meta.url).href,
  }}
  ...
/>
```

Pinning to the loaded `pdfjs-dist` version (rather than a hard-coded version string) means version drift between the consumer's installed `pdfjs-dist` and the CDN can't happen.

## Test plan

Reproduced and verified against a 724-page Internet Archive scan (`englishlegalsyst0000wils_r8m9` — 40 MB, JPX color image + JBIG2 soft mask + GlyphLessFont OCR layer per page) using the `examples/basic` app:

- [x] Before: every page renders as a blank white canvas; console shows `JpxError: OpenJPEG failed to initialize` for every image
- [x] After: cover renders in full color, content pages render with sharp text on color background (the JBIG2-mask compositing trick), text layer is selectable
- [x] LCP 116 ms, per-page render after a scroll-jump 400–560 ms (worker-bound on JPX+JBIG2 decode now using WASM instead of failing)
- [x] Scrolling stays smooth (~8 ms/frame)
- [x] Existing PDFs (no JPX/JBIG2) unaffected — `documentOptions` overrides still take precedence

## Notes / follow-ups

- jsDelivr was chosen over unpkg because of permissive CORS, higher uptime, and range-request support.
- Production apps with strict CSP should override these defaults to self-hosted URLs (the `import.meta.url` snippet above works in Vite, webpack 5, Next.js, etc.).
- The `Warning:` (vs `Error:`) log level in pdf.js was a big part of why this slipped — might be worth a separate console-noise audit, but out of scope here.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix JPEG2000 and JBIG2 PDF rendering by defaulting wasm, cMap, font, and ICC URLs
> - Adds `getDefaultPdfJsAssetUrls(version)` in [`pdfjs.ts`](https://github.com/anaralabs/lector/pull/113/files#diff-26d8c47d71141bf3f9ece281f5ba72e8e6a4ed078ad14fd627ef7946840dae99) that returns jsDelivr CDN URLs for wasm, CMaps, standard fonts, and ICC profiles based on the pdf.js version.
> - Updates `buildDocumentInitParams` in [`document.ts`](https://github.com/anaralabs/lector/pull/113/files#diff-76ae8d556756568456ebb2cf14621df2c1af3e72c69e1c9093ec3384e2a15c9b) to accept a version string and merge these defaults into `DocumentInitParameters`, also setting `cMapPacked: true`.
> - Callers that omit these fields will now have them populated automatically; explicit overrides still take precedence.
> - Behavioral Change: `cMapPacked` is now set to `true` by default for all document loads that do not explicitly override it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 53ec55e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->