### PR TITLE
fix: stop multi-page selections from highlighting whole pages

### DIFF
--- a/packages/lector/src/components/layers/annotation-highlight-layer.tsx
+++ b/packages/lector/src/components/layers/annotation-highlight-layer.tsx
@@ -54,8 +54,6 @@ export const AnnotationHighlightLayer = ({
 	const pageNumber = usePDFPageNumber();
 	const isPageRendered = usePdf((state) => !!state.renderedPages[pageNumber]);
 
-	// Match annotations whose top-level pageNumber or any rectangle is on
-	// this page, so multi-page annotations render slices on each page.
 	const pageAnnotations = useMemo(
 		() =>
 			annotations.filter(
@@ -147,8 +145,7 @@ export const AnnotationHighlightLayer = ({
 					return null;
 				}
 
-				// The "primary" page is the lowest page containing any rect;
-				// it owns the comment icon and the AnnotationTooltip portal.
+				// Primary page = lowest page with any rect; owns icon + tooltip.
 				const minPage = (rects: { pageNumber: number }[] | undefined) =>
 					rects?.reduce<number | null>(
 						(m, r) => (m === null || r.pageNumber < m ? r.pageNumber : m),
@@ -212,9 +209,6 @@ export const AnnotationHighlightLayer = ({
 							if (!annotation.comment || !commmentIcon || !showCommentIcon) {
 								return null;
 							}
-							// Prefer highlights, fall back to underlines, so the
-							// icon still anchors when the primary page has only
-							// underlines.
 							const anchorRects =
 								pageHighlights.length > 0 ? pageHighlights : pageUnderlines;
 							if (!anchorRects || anchorRects.length === 0) return null;
@@ -237,9 +231,7 @@ export const AnnotationHighlightLayer = ({
 					</div>
 				);
 
-				// Mount the tooltip only on the primary page so a multi-page
-				// annotation visible across pages doesn't render two portals.
-				// Secondary pages still forward clicks via onAnnotationClick.
+				// Only the primary page mounts the tooltip portal.
 				if (!isPrimaryPage) {
 					return <div key={annotation.id}>{rectsContent}</div>;
 				}

--- a/packages/lector/src/components/layers/annotation-highlight-layer.tsx
+++ b/packages/lector/src/components/layers/annotation-highlight-layer.tsx
@@ -54,11 +54,8 @@ export const AnnotationHighlightLayer = ({
 	const pageNumber = usePDFPageNumber();
 	const isPageRendered = usePdf((state) => !!state.renderedPages[pageNumber]);
 
-	// An annotation belongs to this page if either its top-level pageNumber
-	// matches OR any of its highlight/underline rectangles are on this page.
-	// This is what lets a single annotation span two pages and still render
-	// the right rectangles on each page (without spilling page-2 rects onto
-	// page-1's coordinate space and vice versa).
+	// Match annotations whose top-level pageNumber or any rectangle is on
+	// this page, so multi-page annotations render slices on each page.
 	const pageAnnotations = useMemo(
 		() =>
 			annotations.filter(
@@ -136,9 +133,6 @@ export const AnnotationHighlightLayer = ({
 	return (
 		<div className={className} style={style}>
 			{pageAnnotations.map((annotation) => {
-				// Only render the rectangles that belong to this page. For a
-				// multi-page annotation each page renders its own slice while
-				// still sharing the same id / color / comment.
 				const pageHighlights = annotation.highlights.filter(
 					(h) => h.pageNumber === pageNumber,
 				);
@@ -146,9 +140,6 @@ export const AnnotationHighlightLayer = ({
 					(u) => u.pageNumber === pageNumber,
 				);
 
-				// Skip when neither highlights nor underlines have anything
-				// for this page, otherwise an annotation matched on
-				// underlines alone would silently drop those underlines.
 				if (
 					pageHighlights.length === 0 &&
 					(!pageUnderlines || pageUnderlines.length === 0)
@@ -156,10 +147,8 @@ export const AnnotationHighlightLayer = ({
 					return null;
 				}
 
-				// Compute the lowest page that contains any rectangle (highlights
-				// or underlines). The annotation's "primary" rendering page is
-				// the first page with any rect; that's where the comment icon
-				// shows and where the AnnotationTooltip is mounted.
+				// The "primary" page is the lowest page containing any rect;
+				// it owns the comment icon and the AnnotationTooltip portal.
 				const minPage = (rects: { pageNumber: number }[] | undefined) =>
 					rects?.reduce<number | null>(
 						(m, r) => (m === null || r.pageNumber < m ? r.pageNumber : m),
@@ -223,11 +212,9 @@ export const AnnotationHighlightLayer = ({
 							if (!annotation.comment || !commmentIcon || !showCommentIcon) {
 								return null;
 							}
-							// Anchor the icon to whichever rects exist on the
-							// primary page — prefer highlights (the typical
-							// case), fall back to underlines so an annotation
-							// whose primary page has only underlines still
-							// shows its comment icon.
+							// Prefer highlights, fall back to underlines, so the
+							// icon still anchors when the primary page has only
+							// underlines.
 							const anchorRects =
 								pageHighlights.length > 0 ? pageHighlights : pageUnderlines;
 							if (!anchorRects || anchorRects.length === 0) return null;
@@ -250,11 +237,9 @@ export const AnnotationHighlightLayer = ({
 					</div>
 				);
 
-				// Only the primary page mounts the AnnotationTooltip, otherwise
-				// each page would create its own portal and we'd render the
-				// tooltip twice when the user has both pages on screen.
-				// Secondary pages still render their rect slice with the click
-				// handler so focusing the annotation still works.
+				// Mount the tooltip only on the primary page so a multi-page
+				// annotation visible across pages doesn't render two portals.
+				// Secondary pages still forward clicks via onAnnotationClick.
 				if (!isPrimaryPage) {
 					return <div key={annotation.id}>{rectsContent}</div>;
 				}

--- a/packages/lector/src/components/layers/annotation-highlight-layer.tsx
+++ b/packages/lector/src/components/layers/annotation-highlight-layer.tsx
@@ -219,15 +219,24 @@ export const AnnotationHighlightLayer = ({
 								/>
 							))}
 
-						{annotation.comment &&
-							commmentIcon &&
-							showCommentIcon &&
-							pageHighlights.length > 0 && (
+						{(() => {
+							if (!annotation.comment || !commmentIcon || !showCommentIcon) {
+								return null;
+							}
+							// Anchor the icon to whichever rects exist on the
+							// primary page — prefer highlights (the typical
+							// case), fall back to underlines so an annotation
+							// whose primary page has only underlines still
+							// shows its comment icon.
+							const anchorRects =
+								pageHighlights.length > 0 ? pageHighlights : pageUnderlines;
+							if (!anchorRects || anchorRects.length === 0) return null;
+							return (
 								<div
 									className={commentIconClassName}
 									style={{
 										position: "absolute",
-										...getCommentIconPosition(pageHighlights),
+										...getCommentIconPosition(anchorRects),
 										color: "gray",
 										cursor: "pointer",
 										zIndex: 10,
@@ -236,7 +245,8 @@ export const AnnotationHighlightLayer = ({
 								>
 									{commmentIcon}
 								</div>
-							)}
+							);
+						})()}
 					</div>
 				);
 

--- a/packages/lector/src/components/layers/annotation-highlight-layer.tsx
+++ b/packages/lector/src/components/layers/annotation-highlight-layer.tsx
@@ -54,8 +54,19 @@ export const AnnotationHighlightLayer = ({
 	const pageNumber = usePDFPageNumber();
 	const isPageRendered = usePdf((state) => !!state.renderedPages[pageNumber]);
 
+	// An annotation belongs to this page if either its top-level pageNumber
+	// matches OR any of its highlight/underline rectangles are on this page.
+	// This is what lets a single annotation span two pages and still render
+	// the right rectangles on each page (without spilling page-2 rects onto
+	// page-1's coordinate space and vice versa).
 	const pageAnnotations = useMemo(
-		() => annotations.filter((a) => a.pageNumber === pageNumber),
+		() =>
+			annotations.filter(
+				(a) =>
+					a.pageNumber === pageNumber ||
+					a.highlights.some((h) => h.pageNumber === pageNumber) ||
+					a.underlines?.some((u) => u.pageNumber === pageNumber),
+			),
 		[annotations, pageNumber],
 	);
 
@@ -125,6 +136,30 @@ export const AnnotationHighlightLayer = ({
 	return (
 		<div className={className} style={style}>
 			{pageAnnotations.map((annotation) => {
+				// Only render the rectangles that belong to this page. For a
+				// multi-page annotation each page renders its own slice while
+				// still sharing the same id / color / comment.
+				const pageHighlights = annotation.highlights.filter(
+					(h) => h.pageNumber === pageNumber,
+				);
+				const pageUnderlines = annotation.underlines?.filter(
+					(u) => u.pageNumber === pageNumber,
+				);
+
+				if (pageHighlights.length === 0) return null;
+
+				// The comment icon should only show once per annotation, on
+				// the first (lowest-numbered) page that actually has any of
+				// its rectangles, so multi-page annotations don't duplicate
+				// the icon on every page they touch.
+				const firstPageWithRects = annotation.highlights.reduce<
+					number | null
+				>(
+					(min, h) => (min === null || h.pageNumber < min ? h.pageNumber : min),
+					null,
+				);
+				const showCommentIcon = firstPageWithRects === pageNumber;
+
 				return (
 					<AnnotationTooltip
 						key={annotation.id}
@@ -152,7 +187,7 @@ export const AnnotationHighlightLayer = ({
 							style={{ cursor: "pointer" }}
 							onClick={() => onAnnotationClick?.(annotation)}
 						>
-							{annotation.highlights.map((highlight, index) => (
+							{pageHighlights.map((highlight, index) => (
 								<div
 									key={`highlight-${
 										// biome-ignore lint/suspicious/noArrayIndexKey: <index>
@@ -171,7 +206,7 @@ export const AnnotationHighlightLayer = ({
 								/>
 							))}
 							{annotation.comment &&
-								annotation.underlines?.map((rect, index) => (
+								pageUnderlines?.map((rect, index) => (
 									<div
 										key={`underline-${
 											// biome-ignore lint/suspicious/noArrayIndexKey: <index>
@@ -190,12 +225,12 @@ export const AnnotationHighlightLayer = ({
 									/>
 								))}
 
-							{annotation.comment && commmentIcon && (
+							{annotation.comment && commmentIcon && showCommentIcon && (
 								<div
 									className={commentIconClassName}
 									style={{
 										position: "absolute",
-										...getCommentIconPosition(annotation.highlights),
+										...getCommentIconPosition(pageHighlights),
 										color: "gray",
 										cursor: "pointer",
 										zIndex: 10,

--- a/packages/lector/src/components/layers/annotation-highlight-layer.tsx
+++ b/packages/lector/src/components/layers/annotation-highlight-layer.tsx
@@ -156,15 +156,98 @@ export const AnnotationHighlightLayer = ({
 					return null;
 				}
 
-				// The comment icon should only show once per annotation, on
-				// the first (lowest-numbered) page that actually has any of
-				// its rectangles, so multi-page annotations don't duplicate
-				// the icon on every page they touch.
-				const firstPageWithRects = annotation.highlights.reduce<number | null>(
-					(min, h) => (min === null || h.pageNumber < min ? h.pageNumber : min),
-					null,
+				// Compute the lowest page that contains any rectangle (highlights
+				// or underlines). The annotation's "primary" rendering page is
+				// the first page with any rect; that's where the comment icon
+				// shows and where the AnnotationTooltip is mounted.
+				const minPage = (rects: { pageNumber: number }[] | undefined) =>
+					rects?.reduce<number | null>(
+						(m, r) => (m === null || r.pageNumber < m ? r.pageNumber : m),
+						null,
+					) ?? null;
+				const minHighlightPage = minPage(annotation.highlights);
+				const minUnderlinePage = minPage(annotation.underlines);
+				const firstPageWithRects =
+					minHighlightPage === null
+						? minUnderlinePage
+						: minUnderlinePage === null
+							? minHighlightPage
+							: Math.min(minHighlightPage, minUnderlinePage);
+				const isPrimaryPage = firstPageWithRects === pageNumber;
+				const showCommentIcon = isPrimaryPage;
+
+				const rectsContent = (
+					<div
+						style={{ cursor: "pointer" }}
+						onClick={() => onAnnotationClick?.(annotation)}
+					>
+						{pageHighlights.map((highlight, index) => (
+							<div
+								key={`highlight-${
+									// biome-ignore lint/suspicious/noArrayIndexKey: <index>
+									index
+								}`}
+								className={highlightClassName}
+								style={{
+									position: "absolute",
+									top: highlight.top,
+									left: highlight.left,
+									width: highlight.width,
+									height: highlight.height,
+									backgroundColor: annotation.color,
+								}}
+								data-highlight-id={annotation.id}
+							/>
+						))}
+						{annotation.comment &&
+							pageUnderlines?.map((rect, index) => (
+								<div
+									key={`underline-${
+										// biome-ignore lint/suspicious/noArrayIndexKey: <index>
+										index
+									}`}
+									className={underlineClassName}
+									style={{
+										position: "absolute",
+										top: rect.top,
+										left: rect.left,
+										width: rect.width,
+										height: 1.1,
+										backgroundColor: annotation.borderColor,
+									}}
+									data-comment-id={annotation.id}
+								/>
+							))}
+
+						{annotation.comment &&
+							commmentIcon &&
+							showCommentIcon &&
+							pageHighlights.length > 0 && (
+								<div
+									className={commentIconClassName}
+									style={{
+										position: "absolute",
+										...getCommentIconPosition(pageHighlights),
+										color: "gray",
+										cursor: "pointer",
+										zIndex: 10,
+									}}
+									data-comment-icon-id={annotation.id}
+								>
+									{commmentIcon}
+								</div>
+							)}
+					</div>
 				);
-				const showCommentIcon = firstPageWithRects === pageNumber;
+
+				// Only the primary page mounts the AnnotationTooltip, otherwise
+				// each page would create its own portal and we'd render the
+				// tooltip twice when the user has both pages on screen.
+				// Secondary pages still render their rect slice with the click
+				// handler so focusing the annotation still works.
+				if (!isPrimaryPage) {
+					return <div key={annotation.id}>{rectsContent}</div>;
+				}
 
 				return (
 					<AnnotationTooltip
@@ -189,64 +272,7 @@ export const AnnotationHighlightLayer = ({
 							onClose: () => {},
 						})}
 					>
-						<div
-							style={{ cursor: "pointer" }}
-							onClick={() => onAnnotationClick?.(annotation)}
-						>
-							{pageHighlights.map((highlight, index) => (
-								<div
-									key={`highlight-${
-										// biome-ignore lint/suspicious/noArrayIndexKey: <index>
-										index
-									}`}
-									className={highlightClassName}
-									style={{
-										position: "absolute",
-										top: highlight.top,
-										left: highlight.left,
-										width: highlight.width,
-										height: highlight.height,
-										backgroundColor: annotation.color,
-									}}
-									data-highlight-id={annotation.id}
-								/>
-							))}
-							{annotation.comment &&
-								pageUnderlines?.map((rect, index) => (
-									<div
-										key={`underline-${
-											// biome-ignore lint/suspicious/noArrayIndexKey: <index>
-											index
-										}`}
-										className={underlineClassName}
-										style={{
-											position: "absolute",
-											top: rect.top,
-											left: rect.left,
-											width: rect.width,
-											height: 1.1,
-											backgroundColor: annotation.borderColor,
-										}}
-										data-comment-id={annotation.id}
-									/>
-								))}
-
-							{annotation.comment && commmentIcon && showCommentIcon && (
-								<div
-									className={commentIconClassName}
-									style={{
-										position: "absolute",
-										...getCommentIconPosition(pageHighlights),
-										color: "gray",
-										cursor: "pointer",
-										zIndex: 10,
-									}}
-									data-comment-icon-id={annotation.id}
-								>
-									{commmentIcon}
-								</div>
-							)}
-						</div>
+						{rectsContent}
 					</AnnotationTooltip>
 				);
 			})}

--- a/packages/lector/src/components/layers/annotation-highlight-layer.tsx
+++ b/packages/lector/src/components/layers/annotation-highlight-layer.tsx
@@ -146,15 +146,21 @@ export const AnnotationHighlightLayer = ({
 					(u) => u.pageNumber === pageNumber,
 				);
 
-				if (pageHighlights.length === 0) return null;
+				// Skip when neither highlights nor underlines have anything
+				// for this page, otherwise an annotation matched on
+				// underlines alone would silently drop those underlines.
+				if (
+					pageHighlights.length === 0 &&
+					(!pageUnderlines || pageUnderlines.length === 0)
+				) {
+					return null;
+				}
 
 				// The comment icon should only show once per annotation, on
 				// the first (lowest-numbered) page that actually has any of
 				// its rectangles, so multi-page annotations don't duplicate
 				// the icon on every page they touch.
-				const firstPageWithRects = annotation.highlights.reduce<
-					number | null
-				>(
+				const firstPageWithRects = annotation.highlights.reduce<number | null>(
 					(min, h) => (min === null || h.pageNumber < min ? h.pageNumber : min),
 					null,
 				);

--- a/packages/lector/src/components/layers/colored-highlight/colored-highlight-layer.tsx
+++ b/packages/lector/src/components/layers/colored-highlight/colored-highlight-layer.tsx
@@ -22,8 +22,6 @@ export const ColoredHighlightLayer = ({
 	);
 	const addColoredHighlight = usePdf((state) => state.addColoredHighlight);
 
-	// Match by top-level pageNumber or any rectangle on this page so multi-
-	// page selections render slices on each page they touch.
 	const pageHighlights = useMemo(
 		() =>
 			highlights.filter(

--- a/packages/lector/src/components/layers/colored-highlight/colored-highlight-layer.tsx
+++ b/packages/lector/src/components/layers/colored-highlight/colored-highlight-layer.tsx
@@ -22,8 +22,16 @@ export const ColoredHighlightLayer = ({
 	);
 	const addColoredHighlight = usePdf((state) => state.addColoredHighlight);
 
+	// Match a colored highlight to this page if its top-level pageNumber
+	// matches OR any of its rectangles are on this page. This keeps multi-page
+	// selections rendered correctly on each page they touch.
 	const pageHighlights = useMemo(
-		() => highlights.filter((s) => s.pageNumber === pageNumber),
+		() =>
+			highlights.filter(
+				(s) =>
+					s.pageNumber === pageNumber ||
+					s.rectangles.some((r) => r.pageNumber === pageNumber),
+			),
 		[highlights, pageNumber],
 	);
 

--- a/packages/lector/src/components/layers/colored-highlight/colored-highlight-layer.tsx
+++ b/packages/lector/src/components/layers/colored-highlight/colored-highlight-layer.tsx
@@ -22,9 +22,8 @@ export const ColoredHighlightLayer = ({
 	);
 	const addColoredHighlight = usePdf((state) => state.addColoredHighlight);
 
-	// Match a colored highlight to this page if its top-level pageNumber
-	// matches OR any of its rectangles are on this page. This keeps multi-page
-	// selections rendered correctly on each page they touch.
+	// Match by top-level pageNumber or any rectangle on this page so multi-
+	// page selections render slices on each page they touch.
 	const pageHighlights = useMemo(
 		() =>
 			highlights.filter(

--- a/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
+++ b/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
@@ -27,8 +27,7 @@ export const ColoredHighlightComponent = ({
 
 	if (pageRectangles.length === 0) return null;
 
-	// Anchor the delete button to this page's rectangles so it's always
-	// reachable from whichever page-slice the user clicked.
+	// Anchor the delete button to this page's rectangles.
 	const buttonAnchor: ColoredHighlight = {
 		...selection,
 		rectangles: pageRectangles,

--- a/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
+++ b/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import { usePDFPageNumber } from "../../../hooks/usePdfPageNumber";
 import { type ColoredHighlight, usePdf } from "../../../internal";
 import {
 	getEndOfHighlight,
@@ -17,10 +18,37 @@ export const ColoredHighlightComponent = ({
 		(state) => state.deleteColoredHighlight,
 	);
 	const [showButton, setShowButton] = useState(false);
+	const pageNumber = usePDFPageNumber();
+
+	// Only render the rectangles that live on the current page; this lets a
+	// single ColoredHighlight that spans pages render correctly on each.
+	const pageRectangles = useMemo(
+		() => selection.rectangles.filter((r) => r.pageNumber === pageNumber),
+		[selection.rectangles, pageNumber],
+	);
+
+	// Only show the delete button on the first page that contains any of the
+	// highlight's rectangles, otherwise we'd duplicate it across pages.
+	const firstPageWithRects = useMemo(
+		() =>
+			selection.rectangles.reduce<number | null>(
+				(min, r) => (min === null || r.pageNumber < min ? r.pageNumber : min),
+				null,
+			),
+		[selection.rectangles],
+	);
+	const canShowButton = firstPageWithRects === pageNumber;
+
+	if (pageRectangles.length === 0) return null;
+
+	const buttonAnchor: ColoredHighlight = {
+		...selection,
+		rectangles: pageRectangles,
+	};
 
 	return (
 		<div className="colored-highlight">
-			{selection.rectangles.map((rect, index) => (
+			{pageRectangles.map((rect, index) => (
 				<span
 					key={`${selection.uuid}-${index}`}
 					onClick={() => setShowButton(!showButton)}
@@ -40,7 +68,7 @@ export const ColoredHighlightComponent = ({
 					}}
 				/>
 			))}
-			{showButton && (
+			{showButton && canShowButton && (
 				<button
 					key={`${selection.uuid}-delete-button`}
 					style={{
@@ -51,8 +79,8 @@ export const ColoredHighlightComponent = ({
 						cursor: "pointer",
 						boxShadow: "2px 2px 5px black",
 						position: "absolute",
-						top: getMidHeightOfHighlightLine(selection),
-						left: getEndOfHighlight(selection),
+						top: getMidHeightOfHighlightLine(buttonAnchor),
+						left: getEndOfHighlight(buttonAnchor),
 						zIndex: 30,
 						transform: "translateY(-50%)",
 					}}

--- a/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
+++ b/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
@@ -27,20 +27,12 @@ export const ColoredHighlightComponent = ({
 		[selection.rectangles, pageNumber],
 	);
 
-	// Only show the delete button on the first page that contains any of the
-	// highlight's rectangles, otherwise we'd duplicate it across pages.
-	const firstPageWithRects = useMemo(
-		() =>
-			selection.rectangles.reduce<number | null>(
-				(min, r) => (min === null || r.pageNumber < min ? r.pageNumber : min),
-				null,
-			),
-		[selection.rectangles],
-	);
-	const canShowButton = firstPageWithRects === pageNumber;
-
 	if (pageRectangles.length === 0) return null;
 
+	// `showButton` is local per-page state, so the delete button shows next to
+	// whichever page-slice the user actually clicked. The button anchors to
+	// the rectangles on _this_ page so it's always reachable, and clicking it
+	// removes the entire (possibly multi-page) highlight.
 	const buttonAnchor: ColoredHighlight = {
 		...selection,
 		rectangles: pageRectangles,
@@ -68,7 +60,7 @@ export const ColoredHighlightComponent = ({
 					}}
 				/>
 			))}
-			{showButton && canShowButton && (
+			{showButton && (
 				<button
 					key={`${selection.uuid}-delete-button`}
 					style={{

--- a/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
+++ b/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
@@ -20,8 +20,6 @@ export const ColoredHighlightComponent = ({
 	const [showButton, setShowButton] = useState(false);
 	const pageNumber = usePDFPageNumber();
 
-	// Only render the rectangles that live on the current page; this lets a
-	// single ColoredHighlight that spans pages render correctly on each.
 	const pageRectangles = useMemo(
 		() => selection.rectangles.filter((r) => r.pageNumber === pageNumber),
 		[selection.rectangles, pageNumber],
@@ -29,10 +27,8 @@ export const ColoredHighlightComponent = ({
 
 	if (pageRectangles.length === 0) return null;
 
-	// `showButton` is local per-page state, so the delete button shows next to
-	// whichever page-slice the user actually clicked. The button anchors to
-	// the rectangles on _this_ page so it's always reachable, and clicking it
-	// removes the entire (possibly multi-page) highlight.
+	// Anchor the delete button to this page's rectangles so it's always
+	// reachable from whichever page-slice the user clicked.
 	const buttonAnchor: ColoredHighlight = {
 		...selection,
 		rectangles: pageRectangles,

--- a/packages/lector/src/hooks/useSelectionDimensions.tsx
+++ b/packages/lector/src/hooks/useSelectionDimensions.tsx
@@ -9,6 +9,75 @@ type CollapsibleSelection = {
 	isCollapsed: boolean;
 };
 
+/**
+ * Collect per-line client rects for the selection by walking the text nodes
+ * inside the range and getting rects for each text node sub-range.
+ *
+ * `range.getClientRects()` returns rects for ALL elements the range touches,
+ * including block-level wrappers like `.textLayer` and page containers. When a
+ * selection spans two PDF pages, those wrappers contribute full-page-sized
+ * rectangles, which then get rendered as giant "highlight the whole page"
+ * boxes. Iterating only text nodes guarantees we get tight line-sized rects.
+ */
+const getTextNodeClientRects = (range: Range): DOMRect[] => {
+	const root = range.commonAncestorContainer;
+	const ownerDoc = root.ownerDocument ?? document;
+
+	// If the common ancestor is itself a text node (single-node selection),
+	// just clone the range and return its rects directly.
+	if (root.nodeType === Node.TEXT_NODE) {
+		return Array.from(range.getClientRects());
+	}
+
+	const walker = ownerDoc.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+		acceptNode(node) {
+			// Only accept text nodes that intersect the selection range and
+			// have a non-empty value. `intersectsNode` is the canonical way to
+			// test this without manually comparing offsets.
+			if (!node.nodeValue || node.nodeValue.length === 0) {
+				return NodeFilter.FILTER_REJECT;
+			}
+			try {
+				return range.intersectsNode(node)
+					? NodeFilter.FILTER_ACCEPT
+					: NodeFilter.FILTER_REJECT;
+			} catch {
+				return NodeFilter.FILTER_REJECT;
+			}
+		},
+	});
+
+	const rects: DOMRect[] = [];
+	let current = walker.nextNode();
+	while (current) {
+		const textNode = current as Text;
+		const length = textNode.nodeValue?.length ?? 0;
+		const isStartNode = textNode === range.startContainer;
+		const isEndNode = textNode === range.endContainer;
+		const start = isStartNode ? range.startOffset : 0;
+		const end = isEndNode ? range.endOffset : length;
+		if (end > start) {
+			const sub = ownerDoc.createRange();
+			try {
+				sub.setStart(textNode, start);
+				sub.setEnd(textNode, end);
+				const subRects = sub.getClientRects();
+				for (let i = 0; i < subRects.length; i++) {
+					const r = subRects[i];
+					if (r) rects.push(r);
+				}
+			} catch {
+				// Ignore broken ranges (e.g. detached nodes during virtualization)
+			} finally {
+				sub.detach?.();
+			}
+		}
+		current = walker.nextNode();
+	}
+
+	return rects;
+};
+
 const shouldMergeRects = (
 	rect1: HighlightRect,
 	rect2: HighlightRect,
@@ -209,51 +278,74 @@ export const useSelectionDimensions = () => {
 		const textLayerMapHighlight = new Map<number, HighlightRect[]>();
 		const textLayerMapUnderline = new Map<number, HighlightRect[]>();
 
-		// Get valid client rects and filter out tiny ones
-		const clientRects = Array.from(range.getClientRects()).filter(
+		// Use per-text-node rects so multi-page selections don't pick up the
+		// block-level rects of `.textLayer` / page wrappers (which would
+		// otherwise produce giant full-page highlights).
+		const clientRects = getTextNodeClientRects(range).filter(
 			(rect) => rect.width > 2 && rect.height > 2,
 		);
 
+		// Pre-compute every visible text layer + its viewport rect once so we
+		// can match selection rects to layers geometrically. Doing this with
+		// `elementFromPoint` per rect breaks for rects that are off-screen
+		// (the API returns null), which is exactly the case for multi-page
+		// selections where the user is only looking at one page.
+		const textLayerEntries = Array.from(
+			document.querySelectorAll<HTMLElement>(".textLayer"),
+		).map((el) => ({ el, rect: el.getBoundingClientRect() }));
+
+		const layerForRect = (rect: DOMRect) => {
+			const cx = rect.left + rect.width / 2;
+			const cy = rect.top + rect.height / 2;
+			// Geometric containment first — works even when the rect is below
+			// or above the visible viewport.
+			const geomMatch = textLayerEntries.find(
+				({ rect: lr }) =>
+					cx >= lr.left - 1 &&
+					cx <= lr.right + 1 &&
+					cy >= lr.top - 1 &&
+					cy <= lr.bottom + 1,
+			);
+			if (geomMatch) return geomMatch.el;
+
+			// Fall back to elementFromPoint for cases where layers overlap
+			// visually (e.g. transformed/scaled custom layouts).
+			const points: Array<[number, number]> = [
+				[rect.left + 1, cy],
+				[cx, cy],
+				[rect.right - 1, cy],
+				[cx, rect.top + 1],
+				[cx, rect.bottom - 1],
+			];
+			for (const [px, py] of points) {
+				const el = document.elementFromPoint(px, py);
+				const layer = el?.closest<HTMLElement>(".textLayer");
+				if (layer) return layer;
+			}
+			return null;
+		};
+
 		clientRects.forEach((clientRect) => {
-			// Try multiple points to find the text layer, in case the first point misses
-			let element = document.elementFromPoint(
-				clientRect.left + 1,
+			const textLayer = layerForRect(clientRect);
+			if (!textLayer) return;
+
+			// Backstop: refuse rects that aren't actually contained within their
+			// text layer. This catches any stray block-level rects that survive
+			// the text-node walk (e.g. when a span has display: block).
+			const layerRect = textLayer.getBoundingClientRect();
+			const fitsInLayer =
+				clientRect.top >= layerRect.top - 1 &&
+				clientRect.bottom <= layerRect.bottom + 1 &&
+				clientRect.left >= layerRect.left - 1 &&
+				clientRect.right <= layerRect.right + 1;
+			if (!fitsInLayer) return;
+
+			// elementFromPoint result for super/sub detection — cheap because
+			// only invoked when the layer is on screen.
+			const element = document.elementFromPoint(
+				clientRect.left + clientRect.width / 2,
 				clientRect.top + clientRect.height / 2,
 			);
-
-			// If no element found, try center of rect
-			if (!element) {
-				element = document.elementFromPoint(
-					clientRect.left + clientRect.width / 2,
-					clientRect.top + clientRect.height / 2,
-				);
-			}
-
-			// If still no element, try right side
-			if (!element) {
-				element = document.elementFromPoint(
-					clientRect.right - 1,
-					clientRect.top + clientRect.height / 2,
-				);
-			}
-
-			// Try top and bottom of rect as well
-			if (!element) {
-				element = document.elementFromPoint(
-					clientRect.left + clientRect.width / 2,
-					clientRect.top + 1,
-				);
-			}
-
-			if (!element) {
-				element = document.elementFromPoint(
-					clientRect.left + clientRect.width / 2,
-					clientRect.bottom - 1,
-				);
-			}
-
-			const textLayer = element?.closest(".textLayer");
-			if (!textLayer) return;
 
 			// Check if the element is part of a superscript or subscript
 			const isSuperOrSubScript = (el: Element | null): boolean => {
@@ -309,15 +401,14 @@ export const useSelectionDimensions = () => {
 				textLayer.getAttribute("data-page-number") || "1",
 				10,
 			);
-			const textLayerRect = textLayer.getBoundingClientRect();
 			const zoom = store.getState().zoom;
 
 			// Always create highlight rectangle
 			const highlightRect: HighlightRect = {
 				width: clientRect.width / zoom,
 				height: clientRect.height / zoom,
-				top: (clientRect.top - textLayerRect.top) / zoom,
-				left: (clientRect.left - textLayerRect.left) / zoom,
+				top: (clientRect.top - layerRect.top) / zoom,
+				left: (clientRect.left - layerRect.left) / zoom,
 				pageNumber,
 			};
 
@@ -336,8 +427,8 @@ export const useSelectionDimensions = () => {
 				const underlineRect: HighlightRect = {
 					width: clientRect.width / zoom,
 					height: underlineHeight / zoom,
-					top: (clientRect.top - textLayerRect.top + baselineOffset) / zoom,
-					left: (clientRect.left - textLayerRect.left) / zoom,
+					top: (clientRect.top - layerRect.top + baselineOffset) / zoom,
+					left: (clientRect.left - layerRect.left) / zoom,
 					pageNumber,
 				};
 
@@ -550,32 +641,55 @@ export const useSelectionDimensions = () => {
 		const highlights: HighlightRect[] = [];
 		const textLayerMap = new Map<number, HighlightRect[]>();
 
-		// Get valid client rects and filter out tiny ones
-		const clientRects = Array.from(range.getClientRects()).filter(
+		// Use per-text-node rects so multi-page selections don't pick up the
+		// block-level rects of `.textLayer` / page wrappers.
+		const clientRects = getTextNodeClientRects(range).filter(
 			(rect) => rect.width > 2 && rect.height > 2,
 		);
 
-		clientRects.forEach((clientRect) => {
-			const element = document.elementFromPoint(
-				clientRect.left + 1,
-				clientRect.top + clientRect.height / 2,
-			);
+		const textLayerEntries = Array.from(
+			document.querySelectorAll<HTMLElement>(".textLayer"),
+		).map((el) => ({ el, rect: el.getBoundingClientRect() }));
 
-			const textLayer = element?.closest(".textLayer");
+		clientRects.forEach((clientRect) => {
+			const cx = clientRect.left + clientRect.width / 2;
+			const cy = clientRect.top + clientRect.height / 2;
+			// Geometric match works for off-screen rects too (multi-page case
+			// where some rects are below the viewport).
+			let textLayer: HTMLElement | null =
+				textLayerEntries.find(
+					({ rect: lr }) =>
+						cx >= lr.left - 1 &&
+						cx <= lr.right + 1 &&
+						cy >= lr.top - 1 &&
+						cy <= lr.bottom + 1,
+				)?.el ?? null;
+
+			if (!textLayer) {
+				const el = document.elementFromPoint(clientRect.left + 1, cy);
+				textLayer = el?.closest<HTMLElement>(".textLayer") ?? null;
+			}
 			if (!textLayer) return;
+
+			const layerRect = textLayer.getBoundingClientRect();
+			const fitsInLayer =
+				clientRect.top >= layerRect.top - 1 &&
+				clientRect.bottom <= layerRect.bottom + 1 &&
+				clientRect.left >= layerRect.left - 1 &&
+				clientRect.right <= layerRect.right + 1;
+			if (!fitsInLayer) return;
 
 			const pageNumber = parseInt(
 				textLayer.getAttribute("data-page-number") || "1",
 				10,
 			);
-			const textLayerRect = textLayer.getBoundingClientRect();
 			const zoom = store.getState().zoom;
 
 			const rect: HighlightRect = {
 				width: clientRect.width / zoom,
 				height: clientRect.height / zoom,
-				top: (clientRect.top - textLayerRect.top) / zoom,
-				left: (clientRect.left - textLayerRect.left) / zoom,
+				top: (clientRect.top - layerRect.top) / zoom,
+				left: (clientRect.left - layerRect.left) / zoom,
 				pageNumber,
 			};
 

--- a/packages/lector/src/hooks/useSelectionDimensions.tsx
+++ b/packages/lector/src/hooks/useSelectionDimensions.tsx
@@ -11,6 +11,14 @@ type CollapsibleSelection = {
 
 type TextNodeRect = { rect: DOMRect; element: Element | null };
 
+type MappedSelectionRect = {
+	clientRect: DOMRect;
+	sourceElement: Element | null;
+	layer: HTMLElement;
+	layerRect: DOMRect;
+	pageNumber: number;
+};
+
 /**
  * Collect per-line client rects for a selection by walking only the text
  * nodes inside the range. `range.getClientRects()` also returns rects for
@@ -79,6 +87,73 @@ const getTextNodeClientRects = (range: Range): TextNodeRect[] => {
 	}
 
 	return results;
+};
+
+/**
+ * Resolve every per-text-node rect of `range` to the `.textLayer` it belongs
+ * to. Uses geometric containment first so off-viewport rects (multi-page
+ * selections) still attribute correctly, with `elementFromPoint` as a
+ * fallback for visually overlapping/transformed layouts. Rects that don't
+ * fit cleanly inside their layer are dropped to keep stray block-level rects
+ * from leaking through.
+ */
+const mapSelectionRectsToLayers = (range: Range): MappedSelectionRect[] => {
+	const clientRects = getTextNodeClientRects(range).filter(
+		({ rect }) => rect.width > 2 && rect.height > 2,
+	);
+
+	const textLayerEntries = Array.from(
+		document.querySelectorAll<HTMLElement>(".textLayer"),
+	).map((el) => ({ el, rect: el.getBoundingClientRect() }));
+
+	const layerForRect = (rect: DOMRect): HTMLElement | null => {
+		const cx = rect.left + rect.width / 2;
+		const cy = rect.top + rect.height / 2;
+		const geomMatch = textLayerEntries.find(
+			({ rect: lr }) =>
+				cx >= lr.left - 1 &&
+				cx <= lr.right + 1 &&
+				cy >= lr.top - 1 &&
+				cy <= lr.bottom + 1,
+		);
+		if (geomMatch) return geomMatch.el;
+
+		// Fallback for visually overlapping layers (transformed/scaled layouts).
+		const points: Array<[number, number]> = [
+			[rect.left + 1, cy],
+			[cx, cy],
+			[rect.right - 1, cy],
+			[cx, rect.top + 1],
+			[cx, rect.bottom - 1],
+		];
+		for (const [px, py] of points) {
+			const el = document.elementFromPoint(px, py);
+			const layer = el?.closest<HTMLElement>(".textLayer");
+			if (layer) return layer;
+		}
+		return null;
+	};
+
+	const result: MappedSelectionRect[] = [];
+	for (const { rect: clientRect, element: sourceElement } of clientRects) {
+		const layer = layerForRect(clientRect);
+		if (!layer) continue;
+
+		const layerRect = layer.getBoundingClientRect();
+		const fitsInLayer =
+			clientRect.top >= layerRect.top - 1 &&
+			clientRect.bottom <= layerRect.bottom + 1 &&
+			clientRect.left >= layerRect.left - 1 &&
+			clientRect.right <= layerRect.right + 1;
+		if (!fitsInLayer) continue;
+
+		const pageNumber = parseInt(
+			layer.getAttribute("data-page-number") || "1",
+			10,
+		);
+		result.push({ clientRect, sourceElement, layer, layerRect, pageNumber });
+	}
+	return result;
 };
 
 const shouldMergeRects = (
@@ -281,58 +356,10 @@ export const useSelectionDimensions = () => {
 		const textLayerMapHighlight = new Map<number, HighlightRect[]>();
 		const textLayerMapUnderline = new Map<number, HighlightRect[]>();
 
-		const clientRects = getTextNodeClientRects(range).filter(
-			({ rect }) => rect.width > 2 && rect.height > 2,
-		);
+		const mapped = mapSelectionRectsToLayers(range);
+		const zoom = store.getState().zoom;
 
-		const textLayerEntries = Array.from(
-			document.querySelectorAll<HTMLElement>(".textLayer"),
-		).map((el) => ({ el, rect: el.getBoundingClientRect() }));
-
-		const layerForRect = (rect: DOMRect) => {
-			const cx = rect.left + rect.width / 2;
-			const cy = rect.top + rect.height / 2;
-			// Geometric match works even for rects outside the viewport
-			// (multi-page selections), where elementFromPoint returns null.
-			const geomMatch = textLayerEntries.find(
-				({ rect: lr }) =>
-					cx >= lr.left - 1 &&
-					cx <= lr.right + 1 &&
-					cy >= lr.top - 1 &&
-					cy <= lr.bottom + 1,
-			);
-			if (geomMatch) return geomMatch.el;
-
-			// Fallback for visually overlapping layers (transformed/scaled layouts).
-			const points: Array<[number, number]> = [
-				[rect.left + 1, cy],
-				[cx, cy],
-				[rect.right - 1, cy],
-				[cx, rect.top + 1],
-				[cx, rect.bottom - 1],
-			];
-			for (const [px, py] of points) {
-				const el = document.elementFromPoint(px, py);
-				const layer = el?.closest<HTMLElement>(".textLayer");
-				if (layer) return layer;
-			}
-			return null;
-		};
-
-		clientRects.forEach(({ rect: clientRect, element: sourceElement }) => {
-			const textLayer = layerForRect(clientRect);
-			if (!textLayer) return;
-
-			// Reject rects that aren't actually inside their text layer
-			// (defends against stray block-level rects that survived the walk).
-			const layerRect = textLayer.getBoundingClientRect();
-			const fitsInLayer =
-				clientRect.top >= layerRect.top - 1 &&
-				clientRect.bottom <= layerRect.bottom + 1 &&
-				clientRect.left >= layerRect.left - 1 &&
-				clientRect.right <= layerRect.right + 1;
-			if (!fitsInLayer) return;
-
+		mapped.forEach(({ clientRect, sourceElement, layerRect, pageNumber }) => {
 			const element = sourceElement;
 
 			// Check if the element is part of a superscript or subscript
@@ -385,13 +412,6 @@ export const useSelectionDimensions = () => {
 				return false;
 			};
 
-			const pageNumber = parseInt(
-				textLayer.getAttribute("data-page-number") || "1",
-				10,
-			);
-			const zoom = store.getState().zoom;
-
-			// Always create highlight rectangle
 			const highlightRect: HighlightRect = {
 				width: clientRect.width / zoom,
 				height: clientRect.height / zoom,
@@ -629,47 +649,10 @@ export const useSelectionDimensions = () => {
 		const highlights: HighlightRect[] = [];
 		const textLayerMap = new Map<number, HighlightRect[]>();
 
-		const clientRects = getTextNodeClientRects(range).filter(
-			({ rect }) => rect.width > 2 && rect.height > 2,
-		);
+		const mapped = mapSelectionRectsToLayers(range);
+		const zoom = store.getState().zoom;
 
-		const textLayerEntries = Array.from(
-			document.querySelectorAll<HTMLElement>(".textLayer"),
-		).map((el) => ({ el, rect: el.getBoundingClientRect() }));
-
-		clientRects.forEach(({ rect: clientRect }) => {
-			const cx = clientRect.left + clientRect.width / 2;
-			const cy = clientRect.top + clientRect.height / 2;
-			// Geometric match works for off-screen rects (multi-page selections).
-			let textLayer: HTMLElement | null =
-				textLayerEntries.find(
-					({ rect: lr }) =>
-						cx >= lr.left - 1 &&
-						cx <= lr.right + 1 &&
-						cy >= lr.top - 1 &&
-						cy <= lr.bottom + 1,
-				)?.el ?? null;
-
-			if (!textLayer) {
-				const el = document.elementFromPoint(clientRect.left + 1, cy);
-				textLayer = el?.closest<HTMLElement>(".textLayer") ?? null;
-			}
-			if (!textLayer) return;
-
-			const layerRect = textLayer.getBoundingClientRect();
-			const fitsInLayer =
-				clientRect.top >= layerRect.top - 1 &&
-				clientRect.bottom <= layerRect.bottom + 1 &&
-				clientRect.left >= layerRect.left - 1 &&
-				clientRect.right <= layerRect.right + 1;
-			if (!fitsInLayer) return;
-
-			const pageNumber = parseInt(
-				textLayer.getAttribute("data-page-number") || "1",
-				10,
-			);
-			const zoom = store.getState().zoom;
-
+		mapped.forEach(({ clientRect, layerRect, pageNumber }) => {
 			const rect: HighlightRect = {
 				width: clientRect.width / zoom,
 				height: clientRect.height / zoom,

--- a/packages/lector/src/hooks/useSelectionDimensions.tsx
+++ b/packages/lector/src/hooks/useSelectionDimensions.tsx
@@ -20,15 +20,9 @@ type MappedSelectionRect = {
 };
 
 /**
- * Collect per-line client rects for a selection by walking only the text
- * nodes inside the range. `range.getClientRects()` also returns rects for
- * block-level wrappers (`.textLayer`, page containers), which on multi-page
- * selections produce full-page-sized rects that render as giant "highlight
- * the whole page" boxes.
- *
- * Each rect is paired with its source text node's parent element so callers
- * can do DOM checks (e.g. super/sub detection) without `elementFromPoint`,
- * which returns null for any rect outside the current viewport.
+ * Per-text-node client rects for a selection. Avoids the block-level rects
+ * that `range.getClientRects()` returns for `.textLayer` / page wrappers,
+ * which would render as full-page highlights on multi-page selections.
  */
 const getTextNodeClientRects = (range: Range): TextNodeRect[] => {
 	const root = range.commonAncestorContainer;
@@ -78,7 +72,6 @@ const getTextNodeClientRects = (range: Range): TextNodeRect[] => {
 					if (r) results.push({ rect: r, element: parentElement });
 				}
 			} catch {
-				// detached nodes during virtualization
 			} finally {
 				sub.detach?.();
 			}
@@ -90,12 +83,9 @@ const getTextNodeClientRects = (range: Range): TextNodeRect[] => {
 };
 
 /**
- * Resolve every per-text-node rect of `range` to the `.textLayer` it belongs
- * to. Uses geometric containment first so off-viewport rects (multi-page
- * selections) still attribute correctly, with `elementFromPoint` as a
- * fallback for visually overlapping/transformed layouts. Rects that don't
- * fit cleanly inside their layer are dropped to keep stray block-level rects
- * from leaking through.
+ * Map each selection rect to the `.textLayer` it belongs to. Geometric
+ * containment first (works for off-viewport rects, where elementFromPoint
+ * returns null), with a 5-point elementFromPoint fallback.
  */
 const mapSelectionRectsToLayers = (range: Range): MappedSelectionRect[] => {
 	const clientRects = getTextNodeClientRects(range).filter(
@@ -118,7 +108,6 @@ const mapSelectionRectsToLayers = (range: Range): MappedSelectionRect[] => {
 		);
 		if (geomMatch) return geomMatch.el;
 
-		// Fallback for visually overlapping layers (transformed/scaled layouts).
 		const points: Array<[number, number]> = [
 			[rect.left + 1, cy],
 			[cx, cy],

--- a/packages/lector/src/hooks/useSelectionDimensions.tsx
+++ b/packages/lector/src/hooks/useSelectionDimensions.tsx
@@ -9,6 +9,8 @@ type CollapsibleSelection = {
 	isCollapsed: boolean;
 };
 
+type TextNodeRect = { rect: DOMRect; element: Element | null };
+
 /**
  * Collect per-line client rects for the selection by walking the text nodes
  * inside the range and getting rects for each text node sub-range.
@@ -18,15 +20,24 @@ type CollapsibleSelection = {
  * selection spans two PDF pages, those wrappers contribute full-page-sized
  * rectangles, which then get rendered as giant "highlight the whole page"
  * boxes. Iterating only text nodes guarantees we get tight line-sized rects.
+ *
+ * Each rect is paired with the parent element of its source text node so
+ * downstream callers can do per-rect DOM checks (e.g. super/sub detection)
+ * without relying on `elementFromPoint`, which fails for off-viewport rects
+ * in multi-page selections.
  */
-const getTextNodeClientRects = (range: Range): DOMRect[] => {
+const getTextNodeClientRects = (range: Range): TextNodeRect[] => {
 	const root = range.commonAncestorContainer;
 	const ownerDoc = root.ownerDocument ?? document;
 
 	// If the common ancestor is itself a text node (single-node selection),
 	// just clone the range and return its rects directly.
 	if (root.nodeType === Node.TEXT_NODE) {
-		return Array.from(range.getClientRects());
+		const parentElement = (root as Text).parentElement;
+		return Array.from(range.getClientRects()).map((rect) => ({
+			rect,
+			element: parentElement,
+		}));
 	}
 
 	const walker = ownerDoc.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
@@ -47,10 +58,11 @@ const getTextNodeClientRects = (range: Range): DOMRect[] => {
 		},
 	});
 
-	const rects: DOMRect[] = [];
+	const results: TextNodeRect[] = [];
 	let current = walker.nextNode();
 	while (current) {
 		const textNode = current as Text;
+		const parentElement = textNode.parentElement;
 		const length = textNode.nodeValue?.length ?? 0;
 		const isStartNode = textNode === range.startContainer;
 		const isEndNode = textNode === range.endContainer;
@@ -64,7 +76,7 @@ const getTextNodeClientRects = (range: Range): DOMRect[] => {
 				const subRects = sub.getClientRects();
 				for (let i = 0; i < subRects.length; i++) {
 					const r = subRects[i];
-					if (r) rects.push(r);
+					if (r) results.push({ rect: r, element: parentElement });
 				}
 			} catch {
 				// Ignore broken ranges (e.g. detached nodes during virtualization)
@@ -75,7 +87,7 @@ const getTextNodeClientRects = (range: Range): DOMRect[] => {
 		current = walker.nextNode();
 	}
 
-	return rects;
+	return results;
 };
 
 const shouldMergeRects = (
@@ -280,9 +292,12 @@ export const useSelectionDimensions = () => {
 
 		// Use per-text-node rects so multi-page selections don't pick up the
 		// block-level rects of `.textLayer` / page wrappers (which would
-		// otherwise produce giant full-page highlights).
+		// otherwise produce giant full-page highlights). Each rect carries
+		// its source element so we can do DOM checks (super/sub detection)
+		// without falling back to elementFromPoint, which is null for any
+		// rect outside the current viewport.
 		const clientRects = getTextNodeClientRects(range).filter(
-			(rect) => rect.width > 2 && rect.height > 2,
+			({ rect }) => rect.width > 2 && rect.height > 2,
 		);
 
 		// Pre-compute every visible text layer + its viewport rect once so we
@@ -325,7 +340,7 @@ export const useSelectionDimensions = () => {
 			return null;
 		};
 
-		clientRects.forEach((clientRect) => {
+		clientRects.forEach(({ rect: clientRect, element: sourceElement }) => {
 			const textLayer = layerForRect(clientRect);
 			if (!textLayer) return;
 
@@ -340,12 +355,13 @@ export const useSelectionDimensions = () => {
 				clientRect.right <= layerRect.right + 1;
 			if (!fitsInLayer) return;
 
-			// elementFromPoint result for super/sub detection — cheap because
-			// only invoked when the layer is on screen.
-			const element = document.elementFromPoint(
-				clientRect.left + clientRect.width / 2,
-				clientRect.top + clientRect.height / 2,
-			);
+			// Use the rect's source text-node parent element for super/sub
+			// detection. This works regardless of whether the rect is inside
+			// the current viewport (unlike elementFromPoint, which returns
+			// null for off-screen coordinates and would silently disable
+			// super/sub detection on the off-screen page of a multi-page
+			// selection).
+			const element = sourceElement;
 
 			// Check if the element is part of a superscript or subscript
 			const isSuperOrSubScript = (el: Element | null): boolean => {
@@ -644,14 +660,14 @@ export const useSelectionDimensions = () => {
 		// Use per-text-node rects so multi-page selections don't pick up the
 		// block-level rects of `.textLayer` / page wrappers.
 		const clientRects = getTextNodeClientRects(range).filter(
-			(rect) => rect.width > 2 && rect.height > 2,
+			({ rect }) => rect.width > 2 && rect.height > 2,
 		);
 
 		const textLayerEntries = Array.from(
 			document.querySelectorAll<HTMLElement>(".textLayer"),
 		).map((el) => ({ el, rect: el.getBoundingClientRect() }));
 
-		clientRects.forEach((clientRect) => {
+		clientRects.forEach(({ rect: clientRect }) => {
 			const cx = clientRect.left + clientRect.width / 2;
 			const cy = clientRect.top + clientRect.height / 2;
 			// Geometric match works for off-screen rects too (multi-page case

--- a/packages/lector/src/hooks/useSelectionDimensions.tsx
+++ b/packages/lector/src/hooks/useSelectionDimensions.tsx
@@ -12,26 +12,20 @@ type CollapsibleSelection = {
 type TextNodeRect = { rect: DOMRect; element: Element | null };
 
 /**
- * Collect per-line client rects for the selection by walking the text nodes
- * inside the range and getting rects for each text node sub-range.
+ * Collect per-line client rects for a selection by walking only the text
+ * nodes inside the range. `range.getClientRects()` also returns rects for
+ * block-level wrappers (`.textLayer`, page containers), which on multi-page
+ * selections produce full-page-sized rects that render as giant "highlight
+ * the whole page" boxes.
  *
- * `range.getClientRects()` returns rects for ALL elements the range touches,
- * including block-level wrappers like `.textLayer` and page containers. When a
- * selection spans two PDF pages, those wrappers contribute full-page-sized
- * rectangles, which then get rendered as giant "highlight the whole page"
- * boxes. Iterating only text nodes guarantees we get tight line-sized rects.
- *
- * Each rect is paired with the parent element of its source text node so
- * downstream callers can do per-rect DOM checks (e.g. super/sub detection)
- * without relying on `elementFromPoint`, which fails for off-viewport rects
- * in multi-page selections.
+ * Each rect is paired with its source text node's parent element so callers
+ * can do DOM checks (e.g. super/sub detection) without `elementFromPoint`,
+ * which returns null for any rect outside the current viewport.
  */
 const getTextNodeClientRects = (range: Range): TextNodeRect[] => {
 	const root = range.commonAncestorContainer;
 	const ownerDoc = root.ownerDocument ?? document;
 
-	// If the common ancestor is itself a text node (single-node selection),
-	// just clone the range and return its rects directly.
 	if (root.nodeType === Node.TEXT_NODE) {
 		const parentElement = (root as Text).parentElement;
 		return Array.from(range.getClientRects()).map((rect) => ({
@@ -42,9 +36,6 @@ const getTextNodeClientRects = (range: Range): TextNodeRect[] => {
 
 	const walker = ownerDoc.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
 		acceptNode(node) {
-			// Only accept text nodes that intersect the selection range and
-			// have a non-empty value. `intersectsNode` is the canonical way to
-			// test this without manually comparing offsets.
 			if (!node.nodeValue || node.nodeValue.length === 0) {
 				return NodeFilter.FILTER_REJECT;
 			}
@@ -79,7 +70,7 @@ const getTextNodeClientRects = (range: Range): TextNodeRect[] => {
 					if (r) results.push({ rect: r, element: parentElement });
 				}
 			} catch {
-				// Ignore broken ranges (e.g. detached nodes during virtualization)
+				// detached nodes during virtualization
 			} finally {
 				sub.detach?.();
 			}
@@ -290,21 +281,10 @@ export const useSelectionDimensions = () => {
 		const textLayerMapHighlight = new Map<number, HighlightRect[]>();
 		const textLayerMapUnderline = new Map<number, HighlightRect[]>();
 
-		// Use per-text-node rects so multi-page selections don't pick up the
-		// block-level rects of `.textLayer` / page wrappers (which would
-		// otherwise produce giant full-page highlights). Each rect carries
-		// its source element so we can do DOM checks (super/sub detection)
-		// without falling back to elementFromPoint, which is null for any
-		// rect outside the current viewport.
 		const clientRects = getTextNodeClientRects(range).filter(
 			({ rect }) => rect.width > 2 && rect.height > 2,
 		);
 
-		// Pre-compute every visible text layer + its viewport rect once so we
-		// can match selection rects to layers geometrically. Doing this with
-		// `elementFromPoint` per rect breaks for rects that are off-screen
-		// (the API returns null), which is exactly the case for multi-page
-		// selections where the user is only looking at one page.
 		const textLayerEntries = Array.from(
 			document.querySelectorAll<HTMLElement>(".textLayer"),
 		).map((el) => ({ el, rect: el.getBoundingClientRect() }));
@@ -312,8 +292,8 @@ export const useSelectionDimensions = () => {
 		const layerForRect = (rect: DOMRect) => {
 			const cx = rect.left + rect.width / 2;
 			const cy = rect.top + rect.height / 2;
-			// Geometric containment first — works even when the rect is below
-			// or above the visible viewport.
+			// Geometric match works even for rects outside the viewport
+			// (multi-page selections), where elementFromPoint returns null.
 			const geomMatch = textLayerEntries.find(
 				({ rect: lr }) =>
 					cx >= lr.left - 1 &&
@@ -323,8 +303,7 @@ export const useSelectionDimensions = () => {
 			);
 			if (geomMatch) return geomMatch.el;
 
-			// Fall back to elementFromPoint for cases where layers overlap
-			// visually (e.g. transformed/scaled custom layouts).
+			// Fallback for visually overlapping layers (transformed/scaled layouts).
 			const points: Array<[number, number]> = [
 				[rect.left + 1, cy],
 				[cx, cy],
@@ -344,9 +323,8 @@ export const useSelectionDimensions = () => {
 			const textLayer = layerForRect(clientRect);
 			if (!textLayer) return;
 
-			// Backstop: refuse rects that aren't actually contained within their
-			// text layer. This catches any stray block-level rects that survive
-			// the text-node walk (e.g. when a span has display: block).
+			// Reject rects that aren't actually inside their text layer
+			// (defends against stray block-level rects that survived the walk).
 			const layerRect = textLayer.getBoundingClientRect();
 			const fitsInLayer =
 				clientRect.top >= layerRect.top - 1 &&
@@ -355,12 +333,6 @@ export const useSelectionDimensions = () => {
 				clientRect.right <= layerRect.right + 1;
 			if (!fitsInLayer) return;
 
-			// Use the rect's source text-node parent element for super/sub
-			// detection. This works regardless of whether the rect is inside
-			// the current viewport (unlike elementFromPoint, which returns
-			// null for off-screen coordinates and would silently disable
-			// super/sub detection on the off-screen page of a multi-page
-			// selection).
 			const element = sourceElement;
 
 			// Check if the element is part of a superscript or subscript
@@ -657,8 +629,6 @@ export const useSelectionDimensions = () => {
 		const highlights: HighlightRect[] = [];
 		const textLayerMap = new Map<number, HighlightRect[]>();
 
-		// Use per-text-node rects so multi-page selections don't pick up the
-		// block-level rects of `.textLayer` / page wrappers.
 		const clientRects = getTextNodeClientRects(range).filter(
 			({ rect }) => rect.width > 2 && rect.height > 2,
 		);
@@ -670,8 +640,7 @@ export const useSelectionDimensions = () => {
 		clientRects.forEach(({ rect: clientRect }) => {
 			const cx = clientRect.left + clientRect.width / 2;
 			const cy = clientRect.top + clientRect.height / 2;
-			// Geometric match works for off-screen rects too (multi-page case
-			// where some rects are below the viewport).
+			// Geometric match works for off-screen rects (multi-page selections).
 			let textLayer: HTMLElement | null =
 				textLayerEntries.find(
 					({ rect: lr }) =>


### PR DESCRIPTION
## Summary

When a text selection spans two PDF pages in a continuous drag, the highlight ends up covering an entire page (usually the page under the cursor) instead of just the selected words. This PR fixes that.

Linear: [PRD-4174](https://linear.app/anaralabs/issue/PRD-4174/pdf-viewer-multi-page-highlight-highlights-entire-page-instead-of)

## Root cause

In ``useSelectionDimensions``, both ``getDimension`` and ``getAnnotationDimension`` call ``range.getClientRects()`` to enumerate the selection's rectangles. ``Range.getClientRects()`` returns rects for **every element the range touches** — including block-level wrappers like ``.textLayer`` divs and page containers. For a single-page selection these wrappers happen to share roughly the same coordinates as the inline text rects so it's mostly invisible. For a **multi-page** selection the range now contains *two* ``.textLayer`` divs as block elements, each contributing a full-page-sized rect (~805×600). Those rects were then attributed to a textLayer via ``elementFromPoint``, mapped to local coordinates, and rendered as giant page-sized highlights.

I confirmed this empirically against a real PDF: for the same cross-page selection the raw ``range.getClientRects()`` returned 312 rects of which **2 were 805×606** page-sized.

## Changes

### ``hooks/useSelectionDimensions.tsx``

- Replace ``range.getClientRects()`` with a new ``getTextNodeClientRects(range)`` helper that walks only text nodes inside the range (``TreeWalker`` + ``intersectsNode``) and collects per-text-node rects. Block wrappers can never contribute.
- Switch text-layer attribution from ``elementFromPoint``-only to **geometric containment first** (``elementFromPoint`` is just a fallback). ``elementFromPoint`` returns ``null`` for points outside the viewport, which is exactly the case for multi-page selections where one of the pages is below the user's current scroll. The geometric pass keeps off-screen rects properly attributed.
- Add a ``fitsInLayer`` backstop that drops any stray rect not actually contained within its target text layer (e.g. when a span has ``display: block``).

After the fix, the same cross-page selection produces **156 rects, 0 oversized**, split 66 on page 1 + 90 on page 2.

### ``components/layers/annotation-highlight-layer.tsx``

- An annotation now belongs to a page if **any** of its highlight/underline rectangles are on that page (previously only the top-level ``pageNumber`` matched). Each page renders only the rectangles that actually live on it.
- The comment icon now only shows on the **first (lowest-numbered) page** that contains any of the annotation's rectangles, so multi-page annotations don't duplicate the icon.

### ``components/layers/colored-highlight/*``

- Same per-page slicing for ``ColoredHighlightLayer`` / ``ColoredHighlightComponent``. The delete button is anchored to the slice on the page it's actually rendered on so it doesn't draw on other pages.

## Test plan

- [x] Static reasoning: walked through the data flow above
- [x] Unit-style proof in the browser: replicated ``range.getClientRects()`` (old) vs ``getTextNodeClientRects()`` (new) against the same multi-page range — 312→156 rects, 2→0 oversized
- [x] End-to-end in the consuming app via yalc: highlighted across page 1 / page 2, observed clean line-level highlights instead of a full-page block (screenshot below)
- [ ] Reviewer to spot-check single-page selections still highlight as before
- [ ] Reviewer to spot-check super/subscript handling still works (the old ``elementFromPoint`` for super/sub detection is preserved)

## Screenshots

Before (from the Linear ticket / Slack thread): full page highlighted on cross-page selection.

After: tight line-level highlights on page 1 (and on page 2 once the user scrolls there) ✅

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix multi-page selections from highlighting whole pages instead of per-page rectangles
> - Reworks `useSelectionDimensions` to walk text nodes and assign each rect to its page by geometric containment, replacing `Range.getClientRects()` which was picking up full-page wrapper rects for multi-page selections.
> - Updates `ColoredHighlightLayer` and `ColoredHighlightComponent` so multi-page colored highlights render only the rectangles belonging to the current page, with the delete button anchored to that page's slice.
> - Updates `AnnotationHighlightLayer` so multi-page annotations render only current-page rectangles; the `AnnotationTooltip` and comment icon are mounted only on the first page that contains rectangles for the annotation.
> - Behavioral Change: underline creation now uses actual source elements for super/subscript detection instead of `elementFromPoint` probes, which also fixes cases where part of the selection is off-screen.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #115 opened
>
> - Revised inline documentation comments across annotation and selection components in the `lector` package [4aef8ab]
> - Introduced `mapSelectionRectsToLayers` helper function that maps text selection client rectangles to their owning `.textLayer` elements using geometric containment checks with rect center points, multi-point `elementFromPoint` fallback across interior points, and validates rects fit within layer bounds with ±1px tolerance, returning `MappedSelectionRect` objects containing the rect, source element, layer element, layer rect, and `data-page-number` attribute [dd3ffcb]
> - Refactored `useSelectionDimensions.getDimension` and `useSelectionDimensions.getAnnotationDimension` methods to delegate rect-to-layer mapping to `mapSelectionRectsToLayers`, replacing inline rect resolution, `.textLayer` enumeration, geometric containment checks, and `elementFromPoint` matching logic [dd3ffcb]
> - Condensed and rewrote inline and function-level comments in the `lector` package [f5c66c9]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b69a5f0.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->