### PR TITLE
feat(document): expose onError callback for load failures

### DIFF
--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -19,6 +19,7 @@ export const Root = forwardRef(
 			source,
 			loader,
 			onDocumentLoad,
+			onError,
 			isZoomFitWidth,
 			zoom,
 			zoomOptions,
@@ -33,6 +34,7 @@ export const Root = forwardRef(
 		const { initialState } = usePDFDocumentContext({
 			source,
 			onDocumentLoad,
+			onError,
 			isZoomFitWidth,
 			zoom,
 			zoomOptions,

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -26,10 +26,13 @@ export interface usePDFDocumentParams {
 		source: Source;
 	}) => void;
 	/**
-	 * Called when the document fails to load. Two failure modes:
+	 * Called when the document fails to load. Three failure modes:
 	 *  - `phase: "pdfjs-load"` — the PDF.js worker / runtime itself failed to load.
 	 *  - `phase: "document-load"` — `getDocument()` rejected (network error,
-	 *    parse error, password required, etc).
+	 *    parse error, password required, etc). `onDocumentLoad` has NOT fired.
+	 *  - `phase: "viewport-generation"` — the document loaded successfully and
+	 *    `onDocumentLoad` already fired, but resolving page proxies / viewports
+	 *    afterwards failed (e.g. corrupted page, transient pdf.js error).
 	 * The callback fires in addition to the existing console.error, so existing
 	 * consumers see no behavior change.
 	 */
@@ -39,7 +42,7 @@ export interface usePDFDocumentParams {
 		source,
 	}: {
 		error: unknown;
-		phase: "pdfjs-load" | "document-load";
+		phase: "pdfjs-load" | "document-load" | "viewport-generation";
 		source: Source;
 	}) => void;
 	initialRotation?: number;
@@ -199,7 +202,7 @@ export const usePDFDocumentContext = ({
 					};
 
 					return loadingTask.promise
-						.then((proxy) => {
+						.then(async (proxy) => {
 							if (isDisposed || loadingTask?.destroyed) {
 								return;
 							}
@@ -207,7 +210,20 @@ export const usePDFDocumentContext = ({
 							onDocumentLoad?.({ proxy, source });
 							setProgress(1);
 
-							return generateViewports(proxy);
+							try {
+								await generateViewports(proxy);
+							} catch (error) {
+								if (isDisposed || loadingTask?.destroyed) {
+									return;
+								}
+
+								console.error("Error generating PDF viewports", error);
+								onErrorRef.current?.({
+									error,
+									phase: "viewport-generation",
+									source,
+								});
+							}
 						})
 						.catch((error) => {
 							if (isDisposed || loadingTask?.destroyed) {

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -25,6 +25,23 @@ export interface usePDFDocumentParams {
 		proxy: PDFDocumentProxy;
 		source: Source;
 	}) => void;
+	/**
+	 * Called when the document fails to load. Two failure modes:
+	 *  - `phase: "pdfjs-load"` — the PDF.js worker / runtime itself failed to load.
+	 *  - `phase: "document-load"` — `getDocument()` rejected (network error,
+	 *    parse error, password required, etc).
+	 * The callback fires in addition to the existing console.error, so existing
+	 * consumers see no behavior change.
+	 */
+	onError?: ({
+		error,
+		phase,
+		source,
+	}: {
+		error: unknown;
+		phase: "pdfjs-load" | "document-load";
+		source: Source;
+	}) => void;
 	initialRotation?: number;
 	isZoomFitWidth?: boolean;
 	zoom?: number;
@@ -95,6 +112,7 @@ function buildDocumentInitParams(
 
 export const usePDFDocumentContext = ({
 	onDocumentLoad,
+	onError,
 	source,
 	initialRotation = 0,
 	isZoomFitWidth,
@@ -112,6 +130,11 @@ export const usePDFDocumentContext = ({
 	// when consumers pass an inline object).
 	const documentOptionsRef = useRef(documentOptions);
 	documentOptionsRef.current = documentOptions;
+
+	// Same reasoning as documentOptionsRef: keep the effect stable while
+	// always invoking the latest callback.
+	const onErrorRef = useRef(onError);
+	onErrorRef.current = onError;
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <onDocumnetLoad,zoomOptions>
 	useEffect(() => {
@@ -192,6 +215,11 @@ export const usePDFDocumentContext = ({
 							}
 
 							console.error("Error loading PDF document", error);
+							onErrorRef.current?.({
+								error,
+								phase: "document-load",
+								source,
+							});
 						});
 				})
 				.catch((error) => {
@@ -200,6 +228,11 @@ export const usePDFDocumentContext = ({
 					}
 
 					console.error("Error loading PDF.js", error);
+					onErrorRef.current?.({
+						error,
+						phase: "pdfjs-load",
+						source,
+					});
 				});
 
 			return () => {


### PR DESCRIPTION
## Summary

- Add an `onError` prop to `usePDFDocumentContext` and `<Root>` so consumers can react to PDF load failures (network errors, parse errors, password prompts, pdf.js runtime load failures).
- Today both failure paths only `console.error` and leave the viewer stuck on `loader` indefinitely — consumers can't tell loading apart from failure.
- Backwards compatible: existing `console.error` calls are preserved; consumers that don't pass `onError` see no behavior change.

## API

```ts
onError?: ({ error, phase, source }: {
  error: unknown;
  phase: "pdfjs-load" | "document-load";
  source: Source;
}) => void;
```

- `phase: "pdfjs-load"` — pdf.js worker / runtime itself failed to load.
- `phase: "document-load"` — `getDocument()` rejected.

## Motivation

In the Anara app we see a long tail of users (esp. RU/CIS where CloudFront has no PoP) where the PDF binary fails to fetch from the CDN. The metadata API succeeds, AI chat works, but the viewer shows an infinite spinner with no way to surface the failure. With `onError` we can render a "Failed to load — Retry" UI and capture telemetry to quantify the issue.

## Test plan

- [ ] Existing consumers that don't pass `onError` continue to render the loader / load successfully.
- [ ] Consumers that pass `onError` receive a callback when `getDocument()` rejects.
- [ ] Consumers that pass `onError` receive a callback when pdf.js fails to load.
- [ ] No double-fire after unmount (`isDisposed` / `loadingTask.destroyed` checks still gate the catch).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `onError` callback to the `Root` component for PDF load failures
> Adds an optional `onError` prop to the `Root` component in [root.tsx](https://github.com/anaralabs/lector/pull/116/files#diff-402a8e83dc1150d82f61a239319f615e89b3b2c467ef6ebb69c39046e7d14bde), which is forwarded to `usePDFDocumentContext` in [document.ts](https://github.com/anaralabs/lector/pull/116/files#diff-76ae8d556756568456ebb2cf14621df2c1af3e72c69e1c9093ec3384e2a15c9b). The callback is invoked with `{ error, phase, source }` when either PDF.js fails to load (`phase: "pdfjs-load"`) or `getDocument()` rejects (`phase: "document-load"`). An internal ref holds the latest callback to avoid adding it as an effect dependency.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #116 opened
>
> - Extended error handling in `usePDFDocumentContext` hook within `lector` package to catch viewport generation failures separately [caededc]
> - Extended `usePDFDocumentParams` interface in `lector` package to support viewport generation error reporting [caededc]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6610a2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->