### PR TITLE
fix(root): omit HTMLDivElement onError from Root prop intersection

### DIFF
--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -25,7 +25,7 @@ export const Root = forwardRef(
 			zoomOptions,
 			documentOptions,
 			...props
-		}: HTMLProps<HTMLDivElement> &
+		}: Omit<HTMLProps<HTMLDivElement>, "onError"> &
 			usePDFDocumentParams & {
 				loader?: ReactNode;
 			},


### PR DESCRIPTION
## Summary

`<Root>` extended `HTMLProps<HTMLDivElement>` directly, which already includes `onError: ReactEventHandler<HTMLDivElement>`. Combined with the new `usePDFDocumentParams.onError` from #116, TypeScript intersected the two and produced a type no callback can satisfy. Consumers of `onError` had to cast.

This drops `onError` from the HTMLProps half so the lector callback wins. The runtime spread of remaining `...props` onto `Primitive.div` continues to forward all other DOM handlers — the only thing removed is the HTML-element error handler, which has no realistic use here (pdf.js load errors are surfaced via the new callback, not via DOM).

## Test plan

- [ ] `<Root onError={({ error, phase, source }) => ...}>` typechecks without a cast.
- [ ] Other DOM handlers (`onClick`, `onMouseEnter`, etc.) still pass through the prop spread.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Omit `onError` from `HTMLDivElement` props in `Root` component to fix type conflict
> The `Root` component in [root.tsx](https://github.com/anaralabs/lector/pull/117/files#diff-d9723dd7c868885ce3529c0089de347a7ea349cd8ed1b3d9fb36b3aa7032a9a3) accepts both `HTMLProps<HTMLDivElement>` and `usePDFDocumentParams`, but both define `onError` with incompatible signatures. This fix uses `Omit<HTMLProps<HTMLDivElement>, "onError">` so the component's own `onError` from `usePDFDocumentParams` takes precedence without a TypeScript conflict.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a063b06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->