### PR TITLE
feat(annotations): scope useAnnotations store per-tree

### DIFF
--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 38222,
+    "size": 40034,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/src/hooks/useAnnotations.ts
+++ b/packages/lector/src/hooks/useAnnotations.ts
@@ -1,4 +1,7 @@
-import { create } from "zustand";
+import React from "react";
+import { createStore, type StoreApi, useStore } from "zustand";
+
+import { createZustandContext } from "../lib/zustand";
 
 export interface HighlightRect {
 	height: number;
@@ -30,28 +33,59 @@ interface AnnotationState {
 	setAnnotations: (annotations: Annotation[]) => void;
 }
 
-export const useAnnotations = create<AnnotationState>((set) => ({
-	annotations: [],
-	addAnnotation: (annotation) =>
-		set((state) => ({
-			annotations: [...state.annotations, annotation],
-		})),
-	updateAnnotation: (id, updates) =>
-		set((state) => ({
-			annotations: state.annotations.map((annotation) =>
-				annotation.id === id
-					? {
-							...annotation,
-							...updates,
-						}
-					: annotation,
-			),
-		})),
-	deleteAnnotation: (id) =>
-		set((state) => ({
-			annotations: state.annotations.filter(
-				(annotation) => annotation.id !== id,
-			),
-		})),
-	setAnnotations: (annotations) => set({ annotations }),
-}));
+type AnnotationStoreApi = StoreApi<AnnotationState>;
+
+const createAnnotationStore = (): AnnotationStoreApi =>
+	createStore<AnnotationState>((set) => ({
+		annotations: [],
+		addAnnotation: (annotation) =>
+			set((state) => ({
+				annotations: [...state.annotations, annotation],
+			})),
+		updateAnnotation: (id, updates) =>
+			set((state) => ({
+				annotations: state.annotations.map((annotation) =>
+					annotation.id === id
+						? {
+								...annotation,
+								...updates,
+							}
+						: annotation,
+				),
+			})),
+		deleteAnnotation: (id) =>
+			set((state) => ({
+				annotations: state.annotations.filter(
+					(annotation) => annotation.id !== id,
+				),
+			})),
+		setAnnotations: (annotations) => set({ annotations }),
+	}));
+
+const AnnotationsStore = createZustandContext<void, AnnotationStoreApi>(() =>
+	createAnnotationStore(),
+);
+
+// Lazy module-level fallback: preserves pre-context behavior for any
+// consumer that hasn't wrapped their tree in AnnotationsStoreProvider.
+let fallbackStore: AnnotationStoreApi | null = null;
+const getFallbackStore = (): AnnotationStoreApi => {
+	if (!fallbackStore) fallbackStore = createAnnotationStore();
+	return fallbackStore;
+};
+
+export const AnnotationsStoreProvider = ({
+	children,
+}: {
+	children?: React.ReactNode;
+}) =>
+	React.createElement(
+		AnnotationsStore.Provider,
+		{ initialValue: undefined as never },
+		children,
+	);
+
+export const useAnnotations = (): AnnotationState => {
+	const ctx = AnnotationsStore.useContext();
+	return useStore(ctx ?? getFallbackStore());
+};

--- a/packages/lector/src/index.ts
+++ b/packages/lector/src/index.ts
@@ -31,7 +31,10 @@ export {
 } from "./hooks/search/useSearch";
 export { calculateHighlightRects } from "./hooks/search/useSearchPosition";
 export type { Annotation } from "./hooks/useAnnotations";
-export { useAnnotations } from "./hooks/useAnnotations";
+export {
+	AnnotationsStoreProvider,
+	useAnnotations,
+} from "./hooks/useAnnotations";
 export { usePageRendered } from "./hooks/usePageRendered";
 export {
 	LinkService,


### PR DESCRIPTION
## Summary

- `useAnnotations` becomes context-scoped via `createZustandContext` — one annotation store per `<AnnotationsStoreProvider>` rather than one global singleton shared across every `<Root>` in the app
- New export: `AnnotationsStoreProvider` — consumers wrap a common ancestor (above both the `<Root>` and any sidebar that reads/writes annotations) so the PDF viewer and its companion UI share one store
- Module-level fallback is retained, so any consumer that hasn't wrapped its tree keeps the prior global behavior — non-breaking

## Why

A consumer (Anara) noticed annotation state bleeding across tabs: a yellow highlight in tab A would appear in tab B's PDF, and the "annotations don't render until I add one" symptom was the same root cause — the global store gets clobbered when another tab calls `setAnnotations`, then rehydrates on the next mutation/refetch. With the store scoped per-tree, both symptoms go away.

`PDFStore` already uses `createZustandContext`. This brings `useAnnotations` in line with that pattern.

## Test plan

- [ ] `pnpm build` — passes (size limit: 40034 / 150000 bytes, ~1.8KB increase from the new Provider + context plumbing)
- [ ] Consumer (Anara) verified per-tab isolation with a Playwright spec that opens two PDFs in dockview tabs, highlights in tab A, switches to tab B → zero highlight elements; switches back → highlight survives
- [ ] Unwrapped consumers (existing examples, docs) keep working via the module-level fallback store

## Bumps to

Minor — first new export, no breaking API change. Should publish as `3.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope `useAnnotations` store per-tree with `AnnotationsStoreProvider`
> - Extracts the global Zustand store into a `createAnnotationStore` factory and wires it to a React context via `createZustandContext`.
> - Adds `AnnotationsStoreProvider` so consumers can mount an independent annotations store for a subtree; `useAnnotations` binds to the nearest provider when present.
> - Falls back to a shared module-level store when no provider is in the tree, preserving existing behavior.
> - `AnnotationsStoreProvider` is now exported from the package's public API in [index.ts](https://github.com/anaralabs/lector/pull/118/files#diff-64db155208fba8ae87e8e8db80f814e8d384f7a807cbae5a7205ecb62df1ad30).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df44f68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->