### PR TITLE
fix(viewport): account for scroll-container padding in pinch-zoom math

### DIFF
--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 40034,
+    "size": 40073,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/src/hooks/viewport/useViewportContainer.tsx
+++ b/packages/lector/src/hooks/viewport/useViewportContainer.tsx
@@ -247,14 +247,22 @@ export const useViewportContainer = ({
 					const containerRect = currentContainer.getBoundingClientRect();
 					const currentZoom = transformations.current.zoom;
 
+					// containerRect is the border box, but the inner element
+					// sits in the padding box. Bake padding into containerPosition
+					// so the pinch math doesn't drop scrollTop by paddingTop on
+					// the first frame when the scroll container has padding.
+					const containerStyle = getComputedStyle(currentContainer);
+					const paddingTop = parseFloat(containerStyle.paddingTop) || 0;
+					const paddingLeft = parseFloat(containerStyle.paddingLeft) || 0;
+
 					const contentPosition: [number, number] = [
 						origin[0] - elementRect.left,
 						origin[1] - elementRect.top,
 					];
 
 					const containerPosition: [number, number] = [
-						origin[0] - containerRect.left,
-						origin[1] - containerRect.top,
+						origin[0] - containerRect.left - paddingLeft,
+						origin[1] - containerRect.top - paddingTop,
 					];
 
 					originRef.current = [


### PR DESCRIPTION
## Summary

Pinch-zoom on a `<Pages>` whose className includes padding (e.g. the README's `<Pages className="p-4">`) shifts the document by `paddingTop` pixels downward and `paddingLeft` pixels leftward the moment the gesture starts, whenever the user is not at the very top-left of the doc.

The `onPinch` handler measured the touch origin relative to the container's **border box** (`containerRect.top/left`), but the inner wrapper/element sits inside the container's **padding box**, so the scroll math was off by `paddingTop` / `paddingLeft`. At realMs ≈ 1 (first non-`first` pinch frame, before any visible scale change), the formula

```
newTranslateY = contentPosition * realMs − containerPosition
```

resolves to `scrollTop_old − paddingTop`, which the assignment `containerRef.current.scrollTop = translateY` then writes back — visibly dropping the scroll position. At `scrollTop = 0` the new value clamps to 0 and the bug is invisible, which is probably why it had been silent.

Bake `paddingTop` / `paddingLeft` into `containerPosition` at gesture start (inside `firstMemo`, so the `getComputedStyle` read fires once per pinch, not per frame).

Closes #122.

## Why this matters

The README's [Basic Usage](https://github.com/anaralabs/lector#basic-usage) snippet uses `<Pages className="p-4">`, so the default copy-paste path is affected.

## Test plan

- [x] `pnpm build` (lector package) — clean
- [x] `pnpm lint` — clean
- [x] Manual repro in a downstream app using `<Pages className="p-4">`: scroll past page 1, start a pinch — pre-patch the doc jumps ~16px down; post-patch it stays put while scaling around the touch point.
- [ ] No regression at `scrollTop = 0` (was clamped to 0 before; now stays 0).
- [ ] No regression for `<Pages>` with no padding (paddingTop/Left = 0 → identical math).

(Happy to add a regression test alongside this if the maintainers can point me at the preferred way to drive `useGesture` in vitest — there are no existing tests for the viewport hook so this would be net-new infra.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pinch-zoom math in `useViewportContainer` to account for scroll-container padding
> Reads `paddingTop` and `paddingLeft` from the container's computed style during pinch handling and subtracts them from the `containerPosition` delta. Previously, the calculation used the border box origin, causing misalignment when the scroll container had padding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0d39a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- leo:summary-start -->
> [!NOTE]
> ### Account for scroll-container padding in `useViewportContainer` pinch zoom math
>
> - Adjusts pinch-zoom origin math in [useViewportContainer.tsx](https://github.com/anaralabs/lector/pull/123/files#diff-47bea89be68e90ad3ef7badd691780cc40a106c963d7f52ca97daaf7369d9b53) to subtract the scroll container’s `paddingTop`/`paddingLeft`, aligning calculations with the inner element’s padding box instead of the container border box.
> - Updates [size.json](https://github.com/anaralabs/lector/pull/123/files#diff-28235c98c8b5e73c2dc0aa8e562bd937c78db717e5894a3964024e97cd01ce42) for the client bundle size `40034→40073`.
> - Behavioral change: Pinch-zooming inside a padded `<Pages>` container no longer shifts the document by the container padding when the gesture starts.
>
> <sup>[Leo](https://anara.com) summarized `3dc0859`</sup>
<!-- leo:summary-end -->