### PR TITLE
fix(selection): drop fitsInLayer backstop that silently dropped wide rects

### DIFF
--- a/packages/lector/src/hooks/useSelectionDimensions.tsx
+++ b/packages/lector/src/hooks/useSelectionDimensions.tsx
@@ -129,13 +129,6 @@ const mapSelectionRectsToLayers = (range: Range): MappedSelectionRect[] => {
 		if (!layer) continue;
 
 		const layerRect = layer.getBoundingClientRect();
-		const fitsInLayer =
-			clientRect.top >= layerRect.top - 1 &&
-			clientRect.bottom <= layerRect.bottom + 1 &&
-			clientRect.left >= layerRect.left - 1 &&
-			clientRect.right <= layerRect.right + 1;
-		if (!fitsInLayer) continue;
-
 		const pageNumber = parseInt(
 			layer.getAttribute("data-page-number") || "1",
 			10,


### PR DESCRIPTION
## Summary

`mapSelectionRectsToLayers` (added in #115) has a `fitsInLayer` check that requires every selection rect to fall within ±1px of its owning text layer's bounding box. pdf.js positions text spans via `transform` matrices on `font-size: 1px` elements, while `.textLayer` width is set to `round(down, var(--total-scale-factor) * basePageWidthPx, ...)`. On wide content (figure captions, full-width tables, footnotes spanning the page) the spans routinely render 25–30px past the truncated layer width, so every wide rect fails the ±1px backstop and gets dropped.

When all selected rects are wide, `mapped.length === 0`, `getAnnotationDimension()` returns empty `highlights`/`underlines`, and downstream `handleCreateHighlight` early-returns with no annotation saved — the user sees a multi-line selection and clicks Highlight, but nothing persists.

Reported by Anara users; reproducible 100% on PDFs with wide figure captions (npj Parkinson's paper, page 2, figure-2 caption — totalRects: 7, droppedFits: 7, mapped: 0).

## Why this is safe

`layerForRect` already attributes each rect to its owning layer via center-point geometric match plus a 5-point `elementFromPoint` fallback. `getTextNodeClientRects` walks text nodes individually rather than calling `range.getClientRects()` on the whole range, so the block-level-rect bug that #115 was originally fixing (whole-page highlights on multi-page selections) can no longer reach this code path. The `fitsInLayer` backstop was redundant for that case and actively wrong for wide-span rects.

## Test plan

- [ ] Manual: select multi-line text including a figure caption on a PDF with wide content (npj Parkinson's PD paper, page 2 works); click Highlight; highlight persists across all selected lines.
- [ ] Regression: multi-page selection (drag from page N into page N+1) still produces per-line highlights, no full-page rectangles.
- [ ] Regression: narrow body-text selections still highlight correctly.

## Followups

Anara-side bump from `^3.12.0` → `^3.12.1` after this lands, plus an e2e regression covering the wide-caption case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Stop dropping wide selection rects in `mapSelectionRectsToLayers`
>
> - Removes the `fitsInLayer` bounds backstop in [useSelectionDimensions.tsx](https://github.com/anaralabs/lector/pull/124/files#diff-5f46e567f62fe62edb5da6a7060299971dddeb955f5f301437e50a99482ff764), so selection rects that are associated with a text layer are no longer discarded just because they extend more than 1px outside that layer’s bounding box.
> - Behavioral change: Wide or overflowed PDF text selections can now produce highlight/underline dimensions instead of being silently dropped.
>
> <sup>[Leo](https://anara.com) summarized `e651852`</sup>
<!-- leo:summary-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `mapSelectionRectsToLayers` to include wide rects that exceed layer bounds
> Removes the `fitsInLayer` bounding-rect check in [useSelectionDimensions.tsx](https://github.com/anaralabs/lector/pull/124/files#diff-5f46e567f62fe62edb5da6a7060299971dddeb955f5f301437e50a99482ff764) that silently dropped selection rects not fully contained within their layer. The function now unconditionally processes any rect that `layerForRect` assigns to a layer. Behavioral Change: `mapSelectionRectsToLayers` may now return more `MappedSelectionRect` entries than before, particularly for wide or edge-spanning selections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e651852.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->