### PR TITLE
fix(selection): widen layerForRect center-point tolerance to 4px

### DIFF
--- a/packages/lector/src/hooks/useSelectionDimensions.tsx
+++ b/packages/lector/src/hooks/useSelectionDimensions.tsx
@@ -1,6 +1,7 @@
 import { type HighlightRect, PDFStore } from "../internal";
 
 const MERGE_THRESHOLD = 2; // Reduced threshold for more precise merging
+const LAYER_ATTRIBUTION_TOLERANCE_PX = 4;
 
 type CollapsibleSelection = {
 	highlights: HighlightRect[];
@@ -99,12 +100,13 @@ const mapSelectionRectsToLayers = (range: Range): MappedSelectionRect[] => {
 	const layerForRect = (rect: DOMRect): HTMLElement | null => {
 		const cx = rect.left + rect.width / 2;
 		const cy = rect.top + rect.height / 2;
+		const T = LAYER_ATTRIBUTION_TOLERANCE_PX;
 		const geomMatch = textLayerEntries.find(
 			({ rect: lr }) =>
-				cx >= lr.left - 1 &&
-				cx <= lr.right + 1 &&
-				cy >= lr.top - 1 &&
-				cy <= lr.bottom + 1,
+				cx >= lr.left - T &&
+				cx <= lr.right + T &&
+				cy >= lr.top - T &&
+				cy <= lr.bottom + T,
 		);
 		if (geomMatch) return geomMatch.el;
 


### PR DESCRIPTION
## Summary

Follow-up to #124. Same root-cause family: pdf.js geometric quirks (transform-matrix-positioned spans + CSS \`width: round(down, ...)\` on the text layer) cause selection rect coordinates to land a few px off the layer's bounding box. #124 fixed the case where the layer-overshoot caused the post-attribution \`fitsInLayer\` filter to drop wide rects. This PR fixes the adjacent case in \`layerForRect\` itself, where the same rounding can put a rect's center 2–3px outside the layer bbox — the ±1px geomMatch then fails and we fall through to the \`elementFromPoint\` fallback, which returns null for off-viewport pages and drops the rect silently.

Bumping tolerance to ±4px keeps attribution robust against the same rounding noise while staying well under the typical line height (~16–18px), so the center still can't accidentally cross into a sibling text layer.

## Test plan

- [ ] Manual smoke: select multi-line text including content near the page-edge on a PDF with wide-column layout; click Highlight; all selected lines persist (same scenario as #124, with no new regressions on the easy cases).
- [ ] Regression: narrow body-text highlight still works.
- [ ] Regression: multi-page selection still produces per-line rects, no full-page rectangles.

## Why this PR exists

The previous run of #124's CI created the \`v3.12.1\` tag without npm publish completing, so semantic-release on subsequent runs saw "0 commits since last release" and exited. Tag deleted; this PR carries a real fix that will let semantic-release cut + publish 3.12.1 cleanly on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Loosen `layerForRect` text-layer attribution tolerance
>
> - Adds `LAYER_ATTRIBUTION_TOLERANCE_PX` in [useSelectionDimensions.tsx](https://github.com/anaralabs/lector/pull/125/files#diff-5f46e567f62fe62edb5da6a7060299971dddeb955f5f301437e50a99482ff764) and uses it when matching a selection rect’s center point to a text layer.
> - Widens the geometric match tolerance from `1→4` px so slightly out-of-bounds PDF text selection rects can still be attributed to their layer before falling back to `elementFromPoint`.
> - Behavioral change: PDF highlights near text-layer edges are less likely to drop selected rects when pdf.js rounding places their center a few pixels outside the layer bounds.
>
> <sup>[Leo](https://anara.com) summarized `1ad582b`</sup>
<!-- leo:summary-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Widen `layerForRect` center-point tolerance from 1px to 4px for text layer attribution
> The containment check in `mapSelectionRectsToLayers` used a ±1px margin when matching selection rect center-points to `.textLayer` bounds, causing misattribution for rects near layer edges. The margin is now sourced from a `LAYER_ATTRIBUTION_TOLERANCE_PX` constant set to 4px in [useSelectionDimensions.tsx](https://github.com/anaralabs/lector/pull/125/files#diff-5f46e567f62fe62edb5da6a7060299971dddeb955f5f301437e50a99482ff764).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ad582b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->