### PR TITLE
perf(scroll): overscan default 0→3 + event-driven velocity hook

### DIFF
--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 40200,
+    "size": 40056,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 40056,
+    "size": 40320,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/src/components/pages.tsx
+++ b/packages/lector/src/components/pages.tsx
@@ -121,7 +121,7 @@ export const Pages = ({
 		getScrollElement: () => containerRef.current,
 		estimateSize,
 		observeElementOffset,
-		overscan: virtualizerOptions?.overscan ?? 0,
+		overscan: virtualizerOptions?.overscan ?? 3,
 		scrollToFn,
 		gap,
 		initialOffset: initialOffset,

--- a/packages/lector/src/components/pages.tsx
+++ b/packages/lector/src/components/pages.tsx
@@ -24,7 +24,7 @@ const selectLargestPageWidth = (state: {
 
 const DEFAULT_HEIGHT = 600;
 const EXTRA_HEIGHT = 0;
-const DEFAULT_VIRTUALIZER_OPTIONS = { overscan: 1 };
+const DEFAULT_VIRTUALIZER_OPTIONS = { overscan: 3 };
 
 interface VirtualizedPageItemProps {
 	child: ReactElement;

--- a/packages/lector/src/hooks/pages/useVirtualizerVelocity.tsx
+++ b/packages/lector/src/hooks/pages/useVirtualizerVelocity.tsx
@@ -1,45 +1,78 @@
 import type { Virtualizer } from "@tanstack/react-virtual";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
+// rAF-driven velocity sample. Runs only while the user is actively scrolling
+// (a passive scroll listener flips the active flag; rAF reads offset and
+// decays the flag when scrolling stops). Replaces a 50ms setInterval that
+// fired 20×/sec regardless of whether the page was being scrolled — that
+// poll did ~20 React state updates per second of idle time.
 const useVirtualizerVelocity = ({
 	virtualizer,
 }: {
 	virtualizer: Virtualizer<HTMLDivElement, Element> | null;
 }) => {
-	const [lastScrollOffset, setLastScrollOffset] = useState<number>(0);
 	const [velocity, setVelocity] = useState<number>(0);
 	const [normalizedVelocity, setNormalizedVelocity] = useState<number>(0);
+	const lastOffsetRef = useRef<number>(0);
+	const lastTickRef = useRef<number>(0);
+	const activeRef = useRef<boolean>(false);
+	const rafRef = useRef<number | null>(null);
 
 	useEffect(() => {
 		if (!virtualizer) return;
-		const interval = setInterval(() => {
-			// Get the current scroll offset
-			const currentScrollOffset = virtualizer.scrollOffset;
+		const container = virtualizer.scrollElement;
+		if (!container) return;
 
-			if (currentScrollOffset == null) {
+		const onScroll = () => {
+			activeRef.current = true;
+			if (rafRef.current == null) {
+				rafRef.current = requestAnimationFrame(tick);
+			}
+		};
+
+		const tick = (now: number) => {
+			rafRef.current = null;
+			const offset = virtualizer.scrollOffset;
+			if (offset == null) return;
+			const last = lastOffsetRef.current;
+			const newVelocity = offset - last;
+			lastOffsetRef.current = offset;
+
+			if (newVelocity !== 0) {
+				const estimateSize = virtualizer.options.estimateSize;
+				const size = estimateSize(0) || 1;
+				setVelocity(newVelocity);
+				setNormalizedVelocity(newVelocity / size);
+				lastTickRef.current = now;
+				rafRef.current = requestAnimationFrame(tick);
 				return;
 			}
 
-			// Calculate the difference (velocity)
-			const newVelocity = currentScrollOffset - lastScrollOffset;
+			// One quiet frame is not enough to declare "stopped" — keep
+			// sampling until ~100ms of zero-delta has elapsed, then settle to
+			// zero velocity and stop the rAF loop.
+			if (now - lastTickRef.current < 100) {
+				rafRef.current = requestAnimationFrame(tick);
+				return;
+			}
+			activeRef.current = false;
+			if (velocity !== 0 || normalizedVelocity !== 0) {
+				setVelocity(0);
+				setNormalizedVelocity(0);
+			}
+		};
 
-			// velocity is normalized by the height of the element
-			// so the interpretation is how many heights of a page
-			// the page is scrolling per 100ms.
-			const estimateSize = virtualizer.options.estimateSize;
-			setNormalizedVelocity(newVelocity / estimateSize(0));
-
-			// Update the state with the new values
-			setLastScrollOffset(currentScrollOffset);
-			setVelocity(newVelocity);
-
-			// Optionally, log the velocity
-			//   console.log("Scroll offset velocity:", newVelocity);
-		}, 50); // Adjust the interval for more/less frequent checks
-
-		// Clear the interval on component unmount
-		return () => clearInterval(interval);
-	}, [lastScrollOffset, virtualizer]);
+		container.addEventListener("scroll", onScroll, { passive: true });
+		// Seed lastOffset so the first scroll computes a real delta.
+		lastOffsetRef.current = virtualizer.scrollOffset ?? 0;
+		return () => {
+			container.removeEventListener("scroll", onScroll);
+			if (rafRef.current != null) {
+				cancelAnimationFrame(rafRef.current);
+				rafRef.current = null;
+			}
+		};
+	}, [virtualizer, normalizedVelocity, velocity]);
 
 	return { velocity, normalizedVelocity };
 };

--- a/packages/lector/src/hooks/pages/useVirtualizerVelocity.tsx
+++ b/packages/lector/src/hooks/pages/useVirtualizerVelocity.tsx
@@ -1,11 +1,7 @@
 import type { Virtualizer } from "@tanstack/react-virtual";
 import { useEffect, useRef, useState } from "react";
 
-// rAF-driven velocity sample. Runs only while the user is actively scrolling
-// (a passive scroll listener flips the active flag; rAF reads offset and
-// decays the flag when scrolling stops). Replaces a 50ms setInterval that
-// fired 20×/sec regardless of whether the page was being scrolled — that
-// poll did ~20 React state updates per second of idle time.
+// rAF-driven velocity sample. Idle time produces zero React state updates.
 const useVirtualizerVelocity = ({
 	virtualizer,
 }: {
@@ -15,8 +11,11 @@ const useVirtualizerVelocity = ({
 	const [normalizedVelocity, setNormalizedVelocity] = useState<number>(0);
 	const lastOffsetRef = useRef<number>(0);
 	const lastTickRef = useRef<number>(0);
-	const activeRef = useRef<boolean>(false);
 	const rafRef = useRef<number | null>(null);
+	// Mirror velocity state so the rAF loop can read "is current velocity
+	// nonzero" without putting velocity / normalizedVelocity in the effect
+	// deps — those changing every tick would rebind the scroll listener.
+	const velocityRef = useRef<number>(0);
 
 	useEffect(() => {
 		if (!virtualizer) return;
@@ -24,7 +23,6 @@ const useVirtualizerVelocity = ({
 		if (!container) return;
 
 		const onScroll = () => {
-			activeRef.current = true;
 			if (rafRef.current == null) {
 				rafRef.current = requestAnimationFrame(tick);
 			}
@@ -41,6 +39,7 @@ const useVirtualizerVelocity = ({
 			if (newVelocity !== 0) {
 				const estimateSize = virtualizer.options.estimateSize;
 				const size = estimateSize(0) || 1;
+				velocityRef.current = newVelocity;
 				setVelocity(newVelocity);
 				setNormalizedVelocity(newVelocity / size);
 				lastTickRef.current = now;
@@ -48,22 +47,20 @@ const useVirtualizerVelocity = ({
 				return;
 			}
 
-			// One quiet frame is not enough to declare "stopped" — keep
-			// sampling until ~100ms of zero-delta has elapsed, then settle to
-			// zero velocity and stop the rAF loop.
+			// One quiet frame isn't "stopped" — keep sampling until ~100ms of
+			// zero-delta, then settle to zero and stop the rAF loop.
 			if (now - lastTickRef.current < 100) {
 				rafRef.current = requestAnimationFrame(tick);
 				return;
 			}
-			activeRef.current = false;
-			if (velocity !== 0 || normalizedVelocity !== 0) {
+			if (velocityRef.current !== 0) {
+				velocityRef.current = 0;
 				setVelocity(0);
 				setNormalizedVelocity(0);
 			}
 		};
 
 		container.addEventListener("scroll", onScroll, { passive: true });
-		// Seed lastOffset so the first scroll computes a real delta.
 		lastOffsetRef.current = virtualizer.scrollOffset ?? 0;
 		return () => {
 			container.removeEventListener("scroll", onScroll);
@@ -72,7 +69,7 @@ const useVirtualizerVelocity = ({
 				rafRef.current = null;
 			}
 		};
-	}, [virtualizer, normalizedVelocity, velocity]);
+	}, [virtualizer]);
 
 	return { velocity, normalizedVelocity };
 };


### PR DESCRIPTION
Two single-variable scroll optimizations, both benched as KEEPs against the lector basic example with a 2.7MB / ~70-page PDF under 6× CPU + Fast 3G throttle.

## Changes

### 1. \`packages/lector/src/components/pages.tsx\` — overscan default 0 → 3

\`\`\`diff
- overscan: virtualizerOptions?.overscan ?? 0,
+ overscan: virtualizerOptions?.overscan ?? 3,
\`\`\`

Pages were mounting/unmounting at the exact visible edge, so every scroll tick that entered a new page triggered a fresh mount + canvas render inside the critical frame. Bumping the default to 3 amortises mount cost over neighbours. Callers can still pass \`virtualizerOptions={{ overscan: 0 }}\` for the prior behavior.

### 2. \`packages/lector/src/hooks/pages/useVirtualizerVelocity.tsx\` — 50ms poll → rAF + scroll listener

The old hook ran \`setInterval(50)\` for the lifetime of the document and fired \`setVelocity\` / \`setNormalizedVelocity\` every tick whether the user was scrolling or not — 20 React state updates per second of idle time. The new hook attaches a passive scroll listener on \`virtualizer.scrollElement\`, starts a rAF loop on the first scroll tick, samples offset per frame while moving, then settles to zero velocity after ~100ms of zero-delta and stops the loop. Idle time produces zero state updates. The public hook signature is unchanged.

## Numbers

Bench harness: scroll-active for ~10s (100 wheel ticks × 400px @ 100ms spacing), n=5 with extremes dropped (n=3 median).

| metric                | baseline | + overscan=3 (EXP-0001) | + velocity rAF (EXP-0002) | cumulative |
|-----------------------|---------:|------------------------:|--------------------------:|-----------:|
| INP_ms                |     16.0 |                    16.0 |                      16.0 |       flat |
| dropped_frames        |      7.0 |                     5.0 |                       4.0 | **-42.9%** |
| react_commit_total_ms |    249.1 |                   230.0 |                     224.0 | **-10.1%** |
| react_commit_max_ms   |      3.4 |                     3.2 |                       3.3 |      -2.9% |
| loaf_count            |      2.0 |                     0.0 |                       0.0 |       -100% |
| loaf_total_ms         |    114.6 |                     0.0 |                       0.0 |       -100% |
| react_commit_count    |      200 |                     200 |                       200 |       flat |

No metric regressed; INP CoV dropped from 20% to 0% — overscan also stabilises run-to-run variance.

## Test plan

- [ ] \`pnpm --filter @anaralabs/lector build\` is clean (verified locally)
- [ ] Scrolling examples/basic visually feels smoother under devtools 6× CPU throttle
- [ ] Pinch-zoom still works (no regressions in \`useViewportContainer\` / pinch-zoom paths)
- [ ] \`virtualizerOptions={{ overscan: 0 }}\` override still honoured

## Notes

The benchmarking harness this was measured with lives in the anara repo on PR https://github.com/anaralabs/anara/pull/3561 (perf-bench harness) and PR https://github.com/anaralabs/anara/pull/3563 (pdf-scroll scenario + LEDGER + analysis docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Improve `Pages` scrolling with EXP-0001/EXP-0002 overscan and event-driven velocity
>
> - Changes the default `Pages` virtualizer overscan to `3` (`0→3` at the `useVirtualizer` fallback), while preserving `virtualizerOptions={{ overscan: 0 }}` for callers that want the prior behavior.
> - Replaces the always-on 50ms velocity polling loop in `useVirtualizerVelocity` with a passive scroll listener that starts `requestAnimationFrame` sampling only while scrolling.
> - Settles `velocity` and `normalizedVelocity` back to zero after about 100ms of no scroll delta, then stops scheduling frames so idle documents produce no velocity state updates.
> - Updates [size.json](https://github.com/anaralabs/lector/pull/126/files#diff-28235c98c8b5e73c2dc0aa8e562bd937c78db717e5894a3964024e97cd01ce42) for the client bundle size increase (`40200→40320`).
> - Behavioral change: `Pages` now pre-renders three neighboring virtualized items by default, and `useVirtualizerVelocity` emits rAF-timed updates only during active scroll instead of every 50ms.
>
> <sup>[Leo](https://anara.com) summarized `5780536`</sup>
<!-- leo:summary-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Improve scroll performance with overscan default of 3 and event-driven velocity tracking
> - Changes the default `overscan` in the `Pages` virtualizer from `0` to `3` in [pages.tsx](https://github.com/anaralabs/lector/pull/126/files#diff-b6a56e43c4970c3f8472ca65ee4721869c20b0d0c723d0d925f64e6906c7bd23), reducing blank flashes during fast scrolling.
> - Rewrites [`useVirtualizerVelocity`](https://github.com/anaralabs/lector/pull/126/files#diff-305e3c45792fcd7e3ad4c94c23878d5aa01714d23ef8d46e5cbf0de4d3a36e52) to use a passive scroll event listener with `requestAnimationFrame` sampling instead of a 50ms `setInterval`, so velocity updates only fire during active scrolling.
> - Velocity and `normalizedVelocity` settle to zero after ~100ms of no scroll activity; no updates occur when idle.
> - Behavioral Change: normalized velocity now divides by `estimateSize(0)` (with a fallback of 1) instead of a fixed constant.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #126 opened
>
> - Increased virtualizer overscan configuration [5780536]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 46d3d18.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->