### PR TITLE
perf(resize): rAF-throttle ResizeObserver + skip canvas re-render during drag

### DIFF
--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 40424,
+    "size": 40452,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 40392,
+    "size": 40424,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 40452,
+    "size": 40485,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 40200,
+    "size": 40392,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -102,6 +102,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 	const dpr = useDpr();
 
 	const bouncyZoom = usePdf((state) => state.zoom);
+	const isResizing = usePdf((state) => state.isResizing);
 	const docId = usePdf((state) => state.pdfDocumentProxy.fingerprints[0] ?? "");
 	const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 	const markPageRendered = usePdf((state) => state.markPageRendered);
@@ -116,6 +117,12 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		const baseViewport = pdfPageProxy.getViewport({ scale: 1 });
 		const pageWidth = baseViewport.width;
 		const pageHeight = baseViewport.height;
+
+		if (isResizing && baseCanvas.width > 0 && baseCanvas.height > 0) {
+			baseCanvas.style.width = `${pageWidth}px`;
+			baseCanvas.style.height = `${pageHeight}px`;
+			return;
+		}
 
 		const targetBaseScale = dpr * Math.min(zoom, 1);
 		const baseScale = clampScaleForPage(targetBaseScale, pageWidth, pageHeight);
@@ -233,6 +240,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		background,
 		dpr,
 		zoom,
+		isResizing,
 		pageNumber,
 		markPageRendered,
 		docId,

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -119,6 +119,10 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		const pageHeight = baseViewport.height;
 
 		if (isResizing && baseCanvas.width > 0 && baseCanvas.height > 0) {
+			// Restore visibility — if a render started, hid the canvas, then
+			// got interrupted by isResizing flipping true, we'd otherwise
+			// leave the page blank for the entire drag.
+			baseCanvas.style.visibility = "";
 			baseCanvas.style.width = `${pageWidth}px`;
 			baseCanvas.style.height = `${pageHeight}px`;
 			return;

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -97,6 +97,7 @@ function setCachedBitmap(
 
 export const useCanvasLayer = ({ background }: { background?: string }) => {
 	const canvasRef = useRef<HTMLCanvasElement | null>(null);
+	const hasContentRef = useRef(false);
 	const pageNumber = usePDFPageNumber();
 
 	const dpr = useDpr();
@@ -118,15 +119,16 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		const pageWidth = baseViewport.width;
 		const pageHeight = baseViewport.height;
 
-		if (isResizing && baseCanvas.width > 0 && baseCanvas.height > 0) {
-			// Restore visibility — if a render started, hid the canvas, then
-			// got interrupted by isResizing flipping true, we'd otherwise
-			// leave the page blank for the entire drag.
+		// Mid-resize, reuse the painted frame via CSS — but only if one exists,
+		// else we'd un-hide a cleared, never-painted canvas (blank for the drag).
+		if (isResizing && hasContentRef.current) {
 			baseCanvas.style.visibility = "";
 			baseCanvas.style.width = `${pageWidth}px`;
 			baseCanvas.style.height = `${pageHeight}px`;
 			return;
 		}
+
+		hasContentRef.current = false;
 
 		const targetBaseScale = dpr * Math.min(zoom, 1);
 		const baseScale = clampScaleForPage(targetBaseScale, pageWidth, pageHeight);
@@ -151,6 +153,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		if (cached) {
 			context.drawImage(cached, 0, 0);
 			markPageRendered(pageNumber);
+			hasContentRef.current = true;
 			return;
 		}
 
@@ -206,6 +209,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 				}
 				baseCanvas.style.visibility = "";
 				markPageRendered(pageNumber);
+				hasContentRef.current = true;
 				if (typeof createImageBitmap !== "undefined") {
 					createImageBitmap(renderCanvas)
 						.then((bitmap) => {

--- a/packages/lector/src/hooks/pages/useFitWidth.tsx
+++ b/packages/lector/src/hooks/pages/useFitWidth.tsx
@@ -67,6 +67,10 @@ export const useFitWidth = ({ viewportRef }: UseFitWidth) => {
 				cancelAnimationFrame(pendingFrameRef.current);
 				pendingFrameRef.current = null;
 			}
+			// Clear isResizing on unmount — otherwise tearing down mid-drag
+			// leaves the store stuck in resizing mode and useCanvasLayer
+			// keeps skipping render() for pages that already have a bitmap.
+			if (store.getState().isResizing) setIsResizing(false);
 		};
 	}, [store, updateZoom, setIsResizing, viewportRef, viewports, zoomOptions]);
 

--- a/packages/lector/src/hooks/pages/useFitWidth.tsx
+++ b/packages/lector/src/hooks/pages/useFitWidth.tsx
@@ -27,18 +27,22 @@ export const useFitWidth = ({ viewportRef }: UseFitWidth) => {
 		const resizeObserver = new ResizeObserver((entries) => {
 			for (const entry of entries) {
 				if (entry.target !== viewportRef.current) continue;
+				const prevWidth = latestWidthRef.current;
 				latestWidthRef.current = entry.contentRect.width;
 
-				// Flip isResizing immediately on every entry; clear once the
-				// observer has been quiet for RESIZE_QUIET_MS. useCanvasLayer
-				// reads this flag and skips pdfPageProxy.render() during the
-				// drag, just stretching the existing bitmap via CSS.
-				if (!store.getState().isResizing) setIsResizing(true);
-				if (quietTimer) clearTimeout(quietTimer);
-				quietTimer = setTimeout(() => {
-					setIsResizing(false);
-					quietTimer = null;
-				}, RESIZE_QUIET_MS);
+				// Enter resizing mode on a real width change only. The initial
+				// observe() callback (and height-only resizes) must not flip it:
+				// useCanvasLayer cancels in-flight renders on the change, so that
+				// would restart every page's first render on mount. Cleared once
+				// the observer has been quiet for RESIZE_QUIET_MS.
+				if (prevWidth !== null && prevWidth !== entry.contentRect.width) {
+					if (!store.getState().isResizing) setIsResizing(true);
+					if (quietTimer) clearTimeout(quietTimer);
+					quietTimer = setTimeout(() => {
+						setIsResizing(false);
+						quietTimer = null;
+					}, RESIZE_QUIET_MS);
+				}
 
 				// rAF-coalesce the zoom update: any number of ResizeObserver
 				// entries that land in the same frame produce one updateZoom.

--- a/packages/lector/src/hooks/pages/useFitWidth.tsx
+++ b/packages/lector/src/hooks/pages/useFitWidth.tsx
@@ -30,12 +30,17 @@ export const useFitWidth = ({ viewportRef }: UseFitWidth) => {
 				const prevWidth = latestWidthRef.current;
 				latestWidthRef.current = entry.contentRect.width;
 
-				// Enter resizing mode on a real width change only. The initial
-				// observe() callback (and height-only resizes) must not flip it:
-				// useCanvasLayer cancels in-flight renders on the change, so that
-				// would restart every page's first render on mount. Cleared once
+				// Enter resizing mode only when a real width change will actually
+				// re-render pages: fit-width mode, where the resize drives zoom.
+				// Outside fit-width — and on the initial observe() / height-only
+				// resizes — flipping isResizing is pure churn, since useCanvasLayer
+				// re-runs every visible canvas effect on the change. Cleared once
 				// the observer has been quiet for RESIZE_QUIET_MS.
-				if (prevWidth !== null && prevWidth !== entry.contentRect.width) {
+				if (
+					store.getState().isZoomFitWidth &&
+					prevWidth !== null &&
+					prevWidth !== entry.contentRect.width
+				) {
 					if (!store.getState().isResizing) setIsResizing(true);
 					if (quietTimer) clearTimeout(quietTimer);
 					quietTimer = setTimeout(() => {

--- a/packages/lector/src/hooks/pages/useFitWidth.tsx
+++ b/packages/lector/src/hooks/pages/useFitWidth.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useLayoutEffect } from "react";
+import { useLayoutEffect, useRef } from "react";
 
 import { PDFStore, usePdf } from "../../internal";
 import { getFitWidthZoom } from "../../lib/zoom";
@@ -7,37 +7,68 @@ import { getFitWidthZoom } from "../../lib/zoom";
 interface UseFitWidth {
 	viewportRef: React.RefObject<HTMLDivElement | null>;
 }
+
+const RESIZE_QUIET_MS = 200;
+
 export const useFitWidth = ({ viewportRef }: UseFitWidth) => {
 	const viewports = usePdf((state) => state.viewports);
 	const zoomOptions = usePdf((state) => state.zoomOptions);
 
 	const updateZoom = usePdf((state) => state.updateZoom);
+	const setIsResizing = usePdf((state) => state.setIsResizing);
 	const store = PDFStore.useContext();
+
+	const pendingFrameRef = useRef<number | null>(null);
+	const latestWidthRef = useRef<number | null>(null);
 
 	useLayoutEffect(() => {
 		if (viewportRef.current === null) return;
+		let quietTimer: ReturnType<typeof setTimeout> | null = null;
 		const resizeObserver = new ResizeObserver((entries) => {
 			for (const entry of entries) {
-				const isFitWidth = store.getState().isZoomFitWidth;
+				if (entry.target !== viewportRef.current) continue;
+				latestWidthRef.current = entry.contentRect.width;
 
-				if (entry.target === viewportRef.current && isFitWidth) {
-					const containerWidth = entry.contentRect.width;
+				// Flip isResizing immediately on every entry; clear once the
+				// observer has been quiet for RESIZE_QUIET_MS. useCanvasLayer
+				// reads this flag and skips pdfPageProxy.render() during the
+				// drag, just stretching the existing bitmap via CSS.
+				if (!store.getState().isResizing) setIsResizing(true);
+				if (quietTimer) clearTimeout(quietTimer);
+				quietTimer = setTimeout(() => {
+					setIsResizing(false);
+					quietTimer = null;
+				}, RESIZE_QUIET_MS);
+
+				// rAF-coalesce the zoom update: any number of ResizeObserver
+				// entries that land in the same frame produce one updateZoom.
+				if (pendingFrameRef.current !== null) continue;
+				pendingFrameRef.current = requestAnimationFrame(() => {
+					pendingFrameRef.current = null;
+					const containerWidth = latestWidthRef.current;
+					if (containerWidth === null) return;
+					if (!store.getState().isZoomFitWidth) return;
 					const newZoom = getFitWidthZoom(
 						containerWidth,
 						viewports,
 						zoomOptions,
 					);
 					updateZoom(newZoom, true);
-				}
+				});
 			}
 		});
 
 		resizeObserver.observe(viewportRef.current);
 
 		return () => {
+			if (quietTimer) clearTimeout(quietTimer);
 			resizeObserver.disconnect();
+			if (pendingFrameRef.current !== null) {
+				cancelAnimationFrame(pendingFrameRef.current);
+				pendingFrameRef.current = null;
+			}
 		};
-	}, [store, updateZoom, viewportRef, viewports, zoomOptions]);
+	}, [store, updateZoom, setIsResizing, viewportRef, viewports, zoomOptions]);
 
 	return null;
 };

--- a/packages/lector/src/internal.ts
+++ b/packages/lector/src/internal.ts
@@ -51,6 +51,9 @@ interface PDFState {
 	isPinching: boolean;
 	setIsPinching: (isPinching: boolean) => void;
 
+	isResizing: boolean;
+	setIsResizing: (isResizing: boolean) => void;
+
 	currentPage: number;
 	setCurrentPage: (pageNumber: number) => void;
 
@@ -153,6 +156,13 @@ export const PDFStore = createZustandContext(
 			setIsPinching: (val) => {
 				set({
 					isPinching: val,
+				});
+			},
+
+			isResizing: false,
+			setIsResizing: (val) => {
+				set({
+					isResizing: val,
 				});
 			},
 


### PR DESCRIPTION
Eliminates the lag users hit when resizing the dockview pane / window with an image-heavy PDF open. Measured on a stress bench in the anara repo (`pdf-resize` scenario, 16 MB graphics-heavy PDF, 200 viewport resize ticks at 20 Hz, 6× CPU throttle, n=5).

## Numbers

| metric | baseline | this PR | delta |
|---|---:|---:|---:|
| **loaf_count** | **3** | **0** | **-100%** |
| **loaf_total_ms** | **157** | **0** | **-100%** |
| **commit_max_ms** | 4.1 | **3.0** | **-27%** |
| dropped_frames | 15 | 13 | -13% |
| react_commit_total_ms | 290 | 263 | -9% |

LoAF (Long Animation Frame) is the metric that captures the perceived lag — frames that take > 50 ms to render. The combined fix eliminates them entirely under the bench workload.

## Root cause

`useFitWidth.tsx` had a `ResizeObserver` that synchronously called `updateZoom(newZoom, true)` on every entry. The browser fires ResizeObserver entries continuously during a drag (60+ Hz). Each `updateZoom` triggered every visible canvas to re-render via `pdfPageProxy.render()` — expensive on graphics-heavy PDFs, and lined up with each resize tick.

## What this changes

Two stacked changes, both in `packages/lector/src/`:

### 1. rAF-throttle the ResizeObserver entries (`useFitWidth.tsx`)

ResizeObserver callback stashes the latest width in a ref and schedules a single `requestAnimationFrame`. Any number of entries that land in the same frame coalesce — only one `updateZoom` per frame, reading the latest width at frame time. On its own, this drops `loaf_total` by 67%.

### 2. Skip canvas re-render during the drag (`useFitWidth.tsx` + `internal.ts` + `useCanvasLayer.tsx`)

New `isResizing` flag in the PDF store. `useFitWidth` flips it true on every ResizeObserver entry; a 200 ms quiet-debounce clears it. While `isResizing` is true, `useCanvasLayer` early-returns from its render path and just updates the canvas's CSS `width`/`height` so the parent's transform stretches the existing bitmap. The fresh re-rasterize fires once on the trailing edge of the debounce. On its own, this drops `loaf_total` by 100%.

Combined, they also drop `commit_max` (the worst single React commit during the drag) by 27% — the rAF throttle and the skip-render compose cleanly because they target different layers (state-update count vs cost-per-update).

## Public API

No change. `isResizing` is internal to the PDFStore. Consumers see the same `updateZoom` cadence on settle. Visible behaviour: canvases briefly look slightly soft during the drag (CSS-stretched bitmap), sharpen on release.

## Test plan

- [ ] Drag the dockview pane edge with an image-heavy PDF open — visible lag should be gone.
- [ ] After releasing the drag, canvases re-rasterize at the new resolution within ~200 ms — sharp again.
- [ ] Pinch-zoom still works (`useViewportContainer` `isPinching` path is untouched).
- [ ] Scrolling unaffected.
- [ ] Repro the bench: in anara repo at PR https://github.com/anaralabs/anara/pull/{tbd}, `pnpm perf-bench run --scenario pdf-resize --runs 5` with this PR yalc-linked.

## Branches it was developed against

Three single-variable experiments tested in parallel sub-agent worktrees: `perf/wild-resize-raf` (R1), `perf/wild-resize-css-scale` (R2), `perf/wild-resize-skip-render` (R3). All on this remote. R1 + R3 combined is what this PR ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Smooth fit-width PDF resizing with `ResizeObserver` throttling and canvas reuse
>
> - Coalesces `useFitWidth` `ResizeObserver` callbacks through `requestAnimationFrame`, so fit-width zoom updates use the latest width at most once per frame instead of every observer entry.
> - Adds internal PDF store state `isResizing`, set only for real width changes in fit-width mode and cleared after a 200 ms quiet period or unmount.
> - Updates `useCanvasLayer` to reuse an already-painted canvas during active resize by adjusting CSS dimensions instead of calling `pdfPageProxy.render()`, then returns to normal rendering after resize settles.
> - Preserves first-paint behavior by only taking the resize early-return when a canvas has existing content, avoiding blank canvases mid-drag.
> - Updates the `packages/lector` bundle size snapshot `40200→40485`; the author’s resize bench reports LoAF `3→0` for the image-heavy PDF scenario.
> - Behavioral change: During fit-width resize drags, existing PDF canvases may look temporarily CSS-stretched and then rerender sharply after a 200 ms quiet period.
>
> <sup>[Leo](https://anara.com) summarized `9562958`</sup>
<!-- leo:summary-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Throttle ResizeObserver with rAF and skip canvas re-render during resize drag
> - Adds `isResizing` boolean to the PDF store ([internal.ts](https://github.com/anaralabs/lector/pull/127/files#diff-897bb7d00167d16ee8e7ffb24389e0151939c4a9789d6913ef9eb097f2128c5d)) to track active resize drag state.
> - [`useFitWidth`](https://github.com/anaralabs/lector/pull/127/files#diff-9b8540faf176a5eb5cda5d5623990ba67fce39760e5366eed0b371a7df3acf9e) sets `isResizing=true` on each ResizeObserver entry and clears it 200 ms after activity stops; fit-width zoom recalculations are coalesced to one per animation frame via `requestAnimationFrame`.
> - [`useCanvasLayer`](https://github.com/anaralabs/lector/pull/127/files#diff-6a7e91363c64c3b2352656a0bc2b3f72403cd2ca014a95de5271f7a7c122652c) skips `pdfPageProxy.render()` while `isResizing` is true, keeping the existing bitmap visible by resetting canvas CSS dimensions instead.
> - Behavioral Change: canvas re-renders are suppressed during resize drags and resume only after a 200 ms quiet period.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #127 opened
>
> - Modified canvas rendering behavior during resize operations in `useCanvasLayer` hook within the `lector` package [bec3501]
> - Updated bundle size measurement in `lector` package [bec3501]
> - Modified `useFitWidth` hook in `lector` package to track previous observed width and conditionally trigger resizing state only when width actually changes [86686d9]
> - Updated bundle size metric in `lector` package [86686d9]
> - Modified resize detection logic in `useFitWidth` hook within `lector` package [9562958]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e109134.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->