### PR TITLE
perf: stop PDF scroll from forcing document style-recalc

### DIFF
--- a/packages/lector/src/components/pages.tsx
+++ b/packages/lector/src/components/pages.tsx
@@ -161,7 +161,10 @@ export const Pages = ({
 
 	useVisiblePage({
 		items,
-		scrollOffset: virtualizer.scrollOffset ?? 0,
+		// Pass through nullish (pre-measure) rather than coercing to 0, so the
+		// hook doesn't publish a top-of-document page before the real offset
+		// (incl. a restored/deep-linked one) arrives.
+		scrollOffset: virtualizer.scrollOffset ?? null,
 	});
 
 	useFitWidth({ viewportRef: containerRef });

--- a/packages/lector/src/components/pages.tsx
+++ b/packages/lector/src/components/pages.tsx
@@ -161,6 +161,7 @@ export const Pages = ({
 
 	useVisiblePage({
 		items,
+		scrollOffset: virtualizer.scrollOffset ?? 0,
 	});
 
 	useFitWidth({ viewportRef: containerRef });

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -161,7 +161,13 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		buffer.width = baseCanvas.width;
 		buffer.height = baseCanvas.height;
 		const bufferCtx = buffer.getContext("2d");
-		if (!bufferCtx) return;
+		if (!bufferCtx) {
+			// Restore visibility — we hid the canvas above for the rerender, and
+			// without a buffer context there's nothing to draw, so otherwise the
+			// page would stay blank.
+			baseCanvas.style.visibility = "";
+			return;
+		}
 
 		const renderingTask = pdfPageProxy.render({
 			canvas: buffer,
@@ -181,6 +187,11 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 					releaseBuffer();
 					return;
 				}
+				// Clear before blitting: drawImage composites source-over, so on a
+				// page with transparent regions (or a transparent background) any
+				// pixels already on the canvas would show through. The render task
+				// resolves async, so don't rely on the clear at effect start.
+				context.clearRect(0, 0, baseCanvas.width, baseCanvas.height);
 				context.drawImage(buffer, 0, 0);
 				baseCanvas.style.visibility = "";
 				markPageRendered(pageNumber);

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -151,20 +151,41 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		let cancelled = false;
 		const viewport = pdfPageProxy.getViewport({ scale: baseScale });
 
+		// Render into a detached buffer, never the in-DOM canvas: pdf.js calls
+		// ctx.font / measureText during rendering, and those force a full
+		// document style-recalc when run on an attached canvas — pathological
+		// under large stylesheets (Tailwind v4's @property custom props), to the
+		// tune of ~6ms per call. Off-DOM the same ops are free; we blit the
+		// finished frame onto the visible canvas in one drawImage.
+		const buffer = document.createElement("canvas");
+		buffer.width = baseCanvas.width;
+		buffer.height = baseCanvas.height;
+		const bufferCtx = buffer.getContext("2d");
+		if (!bufferCtx) return;
+
 		const renderingTask = pdfPageProxy.render({
-			canvas: baseCanvas,
-			canvasContext: context,
+			canvas: buffer,
+			canvasContext: bufferCtx,
 			viewport,
 			background,
 		});
 
+		const releaseBuffer = () => {
+			buffer.width = 0;
+			buffer.height = 0;
+		};
+
 		renderingTask.promise
 			.then(() => {
-				if (cancelled) return;
+				if (cancelled) {
+					releaseBuffer();
+					return;
+				}
+				context.drawImage(buffer, 0, 0);
 				baseCanvas.style.visibility = "";
 				markPageRendered(pageNumber);
 				if (typeof createImageBitmap !== "undefined") {
-					createImageBitmap(baseCanvas)
+					createImageBitmap(buffer)
 						.then((bitmap) => {
 							if (cancelled) {
 								bitmap.close();
@@ -178,10 +199,14 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 								bitmap,
 							);
 						})
-						.catch(() => {});
+						.catch(() => {})
+						.finally(releaseBuffer);
+				} else {
+					releaseBuffer();
 				}
 			})
 			.catch((error) => {
+				releaseBuffer();
 				if (cancelled) return;
 				if (error?.name === "RenderingCancelledException") return;
 				baseCanvas.style.visibility = "";

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -156,22 +156,20 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		// document style-recalc when run on an attached canvas — pathological
 		// under large stylesheets (Tailwind v4's @property custom props), to the
 		// tune of ~6ms per call. Off-DOM the same ops are free; we blit the
-		// finished frame onto the visible canvas in one drawImage.
+		// finished frame onto the visible canvas in one drawImage. If a second
+		// 2D context can't be allocated (canvas memory pressure), fall back to
+		// rendering directly into the visible canvas so the page still renders.
 		const buffer = document.createElement("canvas");
 		buffer.width = baseCanvas.width;
 		buffer.height = baseCanvas.height;
 		const bufferCtx = buffer.getContext("2d");
-		if (!bufferCtx) {
-			// Restore visibility — we hid the canvas above for the rerender, and
-			// without a buffer context there's nothing to draw, so otherwise the
-			// page would stay blank.
-			baseCanvas.style.visibility = "";
-			return;
-		}
+		const useBuffer = bufferCtx !== null;
+		const renderCanvas = useBuffer ? buffer : baseCanvas;
+		const renderCtx = bufferCtx ?? context;
 
 		const renderingTask = pdfPageProxy.render({
-			canvas: buffer,
-			canvasContext: bufferCtx,
+			canvas: renderCanvas,
+			canvasContext: renderCtx,
 			viewport,
 			background,
 		});
@@ -187,16 +185,18 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 					releaseBuffer();
 					return;
 				}
-				// Clear before blitting: drawImage composites source-over, so on a
-				// page with transparent regions (or a transparent background) any
-				// pixels already on the canvas would show through. The render task
-				// resolves async, so don't rely on the clear at effect start.
-				context.clearRect(0, 0, baseCanvas.width, baseCanvas.height);
-				context.drawImage(buffer, 0, 0);
+				if (useBuffer) {
+					// Clear before blitting: drawImage composites source-over, so on
+					// a page with transparent regions (or a transparent background)
+					// any pixels already on the canvas would show through. The render
+					// task resolves async, so don't rely on the clear at effect start.
+					context.clearRect(0, 0, baseCanvas.width, baseCanvas.height);
+					context.drawImage(buffer, 0, 0);
+				}
 				baseCanvas.style.visibility = "";
 				markPageRendered(pageNumber);
 				if (typeof createImageBitmap !== "undefined") {
-					createImageBitmap(buffer)
+					createImageBitmap(renderCanvas)
 						.then((bitmap) => {
 							if (cancelled) {
 								bitmap.close();

--- a/packages/lector/src/hooks/pages/useVisiblePage.tsx
+++ b/packages/lector/src/hooks/pages/useVisiblePage.tsx
@@ -34,13 +34,16 @@ export const useVisiblePage = ({
 	const [viewportHeight, setViewportHeight] = useState(0);
 	useEffect(() => {
 		if (!scrollElement) return;
-		// Measure once on attach regardless; only wire up the observer where the
-		// API exists (older embedded browsers / jsdom consumer tests lack it).
-		setViewportHeight(scrollElement.clientHeight);
-		if (typeof ResizeObserver === "undefined") return;
-		const observer = new ResizeObserver(() => {
-			setViewportHeight(scrollElement.clientHeight);
-		});
+		const measure = () => setViewportHeight(scrollElement.clientHeight);
+		measure();
+		// Prefer ResizeObserver (catches container resizes, not just window
+		// ones); fall back to window `resize` where it's unavailable (older
+		// embedded browsers / jsdom consumer tests) so the height still updates.
+		if (typeof ResizeObserver === "undefined") {
+			window.addEventListener("resize", measure);
+			return () => window.removeEventListener("resize", measure);
+		}
+		const observer = new ResizeObserver(measure);
 		observer.observe(scrollElement);
 		return () => observer.disconnect();
 	}, [scrollElement]);

--- a/packages/lector/src/hooks/pages/useVisiblePage.tsx
+++ b/packages/lector/src/hooks/pages/useVisiblePage.tsx
@@ -47,9 +47,11 @@ export const useVisiblePage = ({
 			if (virtualItems.length === 0) return 0;
 
 			// Derive everything from cached/virtualizer values — no DOM layout
-			// reads, so this never forces a reflow during scroll.
-			const scrollTop = scrollOffset / zoomLevel;
-			const viewportCenter = scrollTop + viewportHeight / zoomLevel / 2;
+			// reads, so this never forces a reflow during scroll. `scrollOffset`
+			// is already zoom-normalized by the virtualizer (useObserveElement
+			// divides scrollTop by zoom), and item start/size live in that same
+			// unzoomed space — so only the raw viewport height needs dividing.
+			const viewportCenter = scrollOffset + viewportHeight / zoomLevel / 2;
 
 			// Find the page whose center is closest to viewport center
 			let closestIndex = 0;

--- a/packages/lector/src/hooks/pages/useVisiblePage.tsx
+++ b/packages/lector/src/hooks/pages/useVisiblePage.tsx
@@ -82,6 +82,19 @@ export const useVisiblePage = ({
 	);
 
 	useEffect(() => {
+		// Self-heal a stale 0 height: if the element now has a real height but
+		// our cached value is still 0 (e.g. mounted hidden in a tab/accordion in
+		// an environment without ResizeObserver, then shown without a window
+		// resize), pick it up here. Gated on `=== 0`, so steady-state scrolling
+		// never reads layout — no reflow on the hot path.
+		if (viewportHeight === 0 && scrollElement) {
+			const h = scrollElement.clientHeight;
+			if (h > 0) {
+				setViewportHeight(h);
+				return;
+			}
+		}
+
 		// Wait for a real viewport height before publishing — at height 0 the
 		// center collapses to the viewport top, which can briefly report the
 		// wrong page on mount or a restored/deep-linked scroll position.
@@ -107,6 +120,7 @@ export const useVisiblePage = ({
 		setCurrentPage,
 		viewportHeight,
 		scrollOffset,
+		scrollElement,
 	]);
 
 	return null;

--- a/packages/lector/src/hooks/pages/useVisiblePage.tsx
+++ b/packages/lector/src/hooks/pages/useVisiblePage.tsx
@@ -15,7 +15,10 @@ interface UseVisiblePageProps {
 	scrollOffset: number;
 }
 
-export const useVisiblePage = ({ items, scrollOffset }: UseVisiblePageProps) => {
+export const useVisiblePage = ({
+	items,
+	scrollOffset,
+}: UseVisiblePageProps) => {
 	const zoomLevel = usePdf((state) => state.zoom);
 	const isPinching = usePdf((state) => state.isPinching);
 	const setCurrentPage = usePdf((state) => state.setCurrentPage);

--- a/packages/lector/src/hooks/pages/useVisiblePage.tsx
+++ b/packages/lector/src/hooks/pages/useVisiblePage.tsx
@@ -1,5 +1,5 @@
 import type { VirtualItem } from "@tanstack/react-virtual";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { usePdf } from "../../internal";
 
@@ -26,14 +26,17 @@ export const useVisiblePage = ({
 
 	const lastPageRef = useRef(0);
 
-	// Cache the viewport height — it only changes on resize, so reading
-	// `clientHeight` on every scroll would force a layout reflow each frame.
-	const viewportHeightRef = useRef(0);
+	// Track viewport height in state — it only changes on resize (and when the
+	// scroll element first attaches), never on scroll, so the per-scroll path
+	// stays free of `clientHeight` reads (which would force a reflow each
+	// frame), while a resize still re-runs page detection below (it feeds
+	// `calculateVisiblePageIndex`'s deps).
+	const [viewportHeight, setViewportHeight] = useState(0);
 	useEffect(() => {
 		if (!scrollElement) return;
-		viewportHeightRef.current = scrollElement.clientHeight;
+		setViewportHeight(scrollElement.clientHeight);
 		const observer = new ResizeObserver(() => {
-			viewportHeightRef.current = scrollElement.clientHeight;
+			setViewportHeight(scrollElement.clientHeight);
 		});
 		observer.observe(scrollElement);
 		return () => observer.disconnect();
@@ -46,8 +49,7 @@ export const useVisiblePage = ({
 			// Derive everything from cached/virtualizer values — no DOM layout
 			// reads, so this never forces a reflow during scroll.
 			const scrollTop = scrollOffset / zoomLevel;
-			const viewportHeight = viewportHeightRef.current / zoomLevel;
-			const viewportCenter = scrollTop + viewportHeight / 2;
+			const viewportCenter = scrollTop + viewportHeight / zoomLevel / 2;
 
 			// Find the page whose center is closest to viewport center
 			let closestIndex = 0;
@@ -66,7 +68,7 @@ export const useVisiblePage = ({
 
 			return closestIndex;
 		},
-		[scrollOffset, zoomLevel],
+		[scrollOffset, zoomLevel, viewportHeight],
 	);
 
 	useEffect(() => {

--- a/packages/lector/src/hooks/pages/useVisiblePage.tsx
+++ b/packages/lector/src/hooks/pages/useVisiblePage.tsx
@@ -11,8 +11,10 @@ interface UseVisiblePageProps {
 	 * forces a synchronous reflow on every frame, which is pathologically
 	 * expensive under large stylesheets (e.g. Tailwind v4's registered
 	 * @property custom properties amplify forced style-recalc ~8x).
+	 * Null before the virtualizer has measured its offset — page detection is
+	 * skipped until then so we never publish a stale top-of-document page.
 	 */
-	scrollOffset: number;
+	scrollOffset: number | null;
 }
 
 export const useVisiblePage = ({
@@ -50,7 +52,7 @@ export const useVisiblePage = ({
 
 	const calculateVisiblePageIndex = useCallback(
 		(virtualItems: VirtualItem[]) => {
-			if (virtualItems.length === 0) return 0;
+			if (virtualItems.length === 0 || scrollOffset == null) return 0;
 
 			// Derive everything from cached/virtualizer values — no DOM layout
 			// reads, so this never forces a reflow during scroll. `scrollOffset`
@@ -83,7 +85,12 @@ export const useVisiblePage = ({
 		// Wait for a real viewport height before publishing — at height 0 the
 		// center collapses to the viewport top, which can briefly report the
 		// wrong page on mount or a restored/deep-linked scroll position.
-		if (!isPinching && items.length > 0 && viewportHeight > 0) {
+		if (
+			!isPinching &&
+			items.length > 0 &&
+			viewportHeight > 0 &&
+			scrollOffset != null
+		) {
 			const mostVisibleIndex = calculateVisiblePageIndex(items);
 			const page = mostVisibleIndex + 1;
 
@@ -99,6 +106,7 @@ export const useVisiblePage = ({
 		calculateVisiblePageIndex,
 		setCurrentPage,
 		viewportHeight,
+		scrollOffset,
 	]);
 
 	return null;

--- a/packages/lector/src/hooks/pages/useVisiblePage.tsx
+++ b/packages/lector/src/hooks/pages/useVisiblePage.tsx
@@ -34,7 +34,10 @@ export const useVisiblePage = ({
 	const [viewportHeight, setViewportHeight] = useState(0);
 	useEffect(() => {
 		if (!scrollElement) return;
+		// Measure once on attach regardless; only wire up the observer where the
+		// API exists (older embedded browsers / jsdom consumer tests lack it).
 		setViewportHeight(scrollElement.clientHeight);
+		if (typeof ResizeObserver === "undefined") return;
 		const observer = new ResizeObserver(() => {
 			setViewportHeight(scrollElement.clientHeight);
 		});
@@ -74,7 +77,10 @@ export const useVisiblePage = ({
 	);
 
 	useEffect(() => {
-		if (!isPinching && items.length > 0) {
+		// Wait for a real viewport height before publishing — at height 0 the
+		// center collapses to the viewport top, which can briefly report the
+		// wrong page on mount or a restored/deep-linked scroll position.
+		if (!isPinching && items.length > 0 && viewportHeight > 0) {
 			const mostVisibleIndex = calculateVisiblePageIndex(items);
 			const page = mostVisibleIndex + 1;
 
@@ -84,7 +90,13 @@ export const useVisiblePage = ({
 				setCurrentPage?.(page);
 			}
 		}
-	}, [items, isPinching, calculateVisiblePageIndex, setCurrentPage]);
+	}, [
+		items,
+		isPinching,
+		calculateVisiblePageIndex,
+		setCurrentPage,
+		viewportHeight,
+	]);
 
 	return null;
 };

--- a/packages/lector/src/hooks/pages/useVisiblePage.tsx
+++ b/packages/lector/src/hooks/pages/useVisiblePage.tsx
@@ -5,9 +5,17 @@ import { usePdf } from "../../internal";
 
 interface UseVisiblePageProps {
 	items: VirtualItem[];
+	/**
+	 * The virtualizer's tracked scroll offset (px). Passed in so we never read
+	 * `scrollElement.scrollTop` here — reading layout in this per-scroll effect
+	 * forces a synchronous reflow on every frame, which is pathologically
+	 * expensive under large stylesheets (e.g. Tailwind v4's registered
+	 * @property custom properties amplify forced style-recalc ~8x).
+	 */
+	scrollOffset: number;
 }
 
-export const useVisiblePage = ({ items }: UseVisiblePageProps) => {
+export const useVisiblePage = ({ items, scrollOffset }: UseVisiblePageProps) => {
 	const zoomLevel = usePdf((state) => state.zoom);
 	const isPinching = usePdf((state) => state.isPinching);
 	const setCurrentPage = usePdf((state) => state.setCurrentPage);
@@ -15,12 +23,27 @@ export const useVisiblePage = ({ items }: UseVisiblePageProps) => {
 
 	const lastPageRef = useRef(0);
 
+	// Cache the viewport height — it only changes on resize, so reading
+	// `clientHeight` on every scroll would force a layout reflow each frame.
+	const viewportHeightRef = useRef(0);
+	useEffect(() => {
+		if (!scrollElement) return;
+		viewportHeightRef.current = scrollElement.clientHeight;
+		const observer = new ResizeObserver(() => {
+			viewportHeightRef.current = scrollElement.clientHeight;
+		});
+		observer.observe(scrollElement);
+		return () => observer.disconnect();
+	}, [scrollElement]);
+
 	const calculateVisiblePageIndex = useCallback(
 		(virtualItems: VirtualItem[]) => {
-			if (!scrollElement || virtualItems.length === 0) return 0;
+			if (virtualItems.length === 0) return 0;
 
-			const scrollTop = scrollElement.scrollTop / zoomLevel;
-			const viewportHeight = scrollElement.clientHeight / zoomLevel;
+			// Derive everything from cached/virtualizer values — no DOM layout
+			// reads, so this never forces a reflow during scroll.
+			const scrollTop = scrollOffset / zoomLevel;
+			const viewportHeight = viewportHeightRef.current / zoomLevel;
 			const viewportCenter = scrollTop + viewportHeight / 2;
 
 			// Find the page whose center is closest to viewport center
@@ -40,7 +63,7 @@ export const useVisiblePage = ({ items }: UseVisiblePageProps) => {
 
 			return closestIndex;
 		},
-		[scrollElement, zoomLevel],
+		[scrollOffset, zoomLevel],
 	);
 
 	useEffect(() => {


### PR DESCRIPTION
## Why

Consumers on large stylesheets — notably **Tailwind v4**, which registers 80+ `@property` custom properties — pay a heavy penalty whenever the document's style is invalidated during scroll: any forced style-recalc on the page becomes ~8x more expensive. Two spots in the viewer were triggering exactly that on every scroll, which made PDF scrolling visibly laggy and the page canvas slow to appear.

Measured on a real app (Chromium, fast flick scroll over a 70k-px doc):

| pdfjs cost during a cold scroll | before | after |
|---|---|---|
| `resetCtxToDefault` | ~1,294ms | gone |
| `setFont` | ~697ms | gone |

## Changes

**1. `useCanvasLayer` — render the base page into a detached buffer, then blit.**
pdf.js calls `ctx.font` / `measureText` thousands of times while rendering a page. On an **in-DOM** canvas each of those calls forces a full-document style recalc — ~6ms *each* under a large stylesheet (vs ~0 detached). A cold page render was spending ~2s in `resetCtxToDefault` + `setFont` alone. We now render into an off-DOM `<canvas>` buffer and `drawImage` the finished frame onto the visible canvas (a raster op, recalc-free even when style is dirty). This mirrors what the detail-canvas layer already does.

Isolated proof on the live page (3000 `font`/`measureText` ops):

| canvas | clean DOM | style-dirty DOM |
|---|---|---|
| detached | 6ms | 3ms |
| in-DOM | 10ms | **19,930ms** |

**2. `useVisiblePage` — derive the visible page from the virtualizer's tracked offset, not DOM reads.**
It was reading `scrollElement.scrollTop` / `clientHeight` on every scroll to find the centered page — each read forcing a synchronous reflow per frame. Now it takes the virtualizer's `scrollOffset` as a prop and caches viewport height via a `ResizeObserver`, so the per-scroll path does no layout reads.

## Notes
- No API changes. `Pages` passes `virtualizer.scrollOffset` into `useVisiblePage`.
- Behavior is identical on browsers without the heavy `@property` cost; this only removes forced-recalc work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Stop `Pages` PDF scroll from forcing document style recalculation
>
> - `useCanvasLayer` now renders PDF pages into a detached buffer canvas, then clears and blits the finished frame onto the visible canvas, avoiding pdf.js `ctx.font`/`measureText` work on an in-DOM canvas; it falls back to direct rendering if a buffer context cannot be allocated.
> - `useVisiblePage` now computes the centered page from the virtualizer’s `scrollOffset` plus cached viewport height instead of reading `scrollTop`/`clientHeight` during scroll, with `ResizeObserver`, window `resize`, and zero-height recovery paths keeping the height fresh.
> - `Pages` passes `virtualizer.scrollOffset ?? null` into `useVisiblePage`, so visible-page detection waits for the virtualizer’s measured offset rather than briefly publishing a top-of-document page.
> - Behavioral change: Visible-page publication now waits until both `scrollOffset` is measured and viewport height is nonzero, avoiding transient wrong-page reporting on mount or restored/deep-linked scroll positions.
>
> <sup>[Leo](https://anara.com) summarized `29f89b2`</sup>
<!-- leo:summary-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stop PDF scroll from triggering layout recalc in `useVisiblePage` and `useCanvasLayer`
> - [`useVisiblePage`](https://github.com/anaralabs/lector/pull/128/files#diff-a71ea864d253b976e6da4041f54680ae5f944b702dd3246f6af2a21c2620e661) now accepts `scrollOffset` from the virtualizer instead of reading `scrollElement.scrollTop`, eliminating forced layout reads on every scroll event. A `ResizeObserver` (with a `window` resize fallback) tracks viewport height without per-scroll layout reads.
> - [`Pages`](https://github.com/anaralabs/lector/pull/128/files#diff-b6a56e43c4970c3f8472ca65ee4721869c20b0d0c723d0d925f64e6906c7bd23) forwards `virtualizer.scrollOffset` (or `null` pre-measure) to `useVisiblePage`, so page detection is deferred until an actual offset is available.
> - [`useCanvasLayer`](https://github.com/anaralabs/lector/pull/128/files#diff-70155b846da3b1555196236046ff87bb7239a3d21ac61cc89af97f5e648816a4) renders PDF pages into a detached off-DOM canvas buffer, then blits the result to the visible canvas with `drawImage`, falling back to direct rendering if a second 2D context cannot be created.
> - Behavioral Change: the visible page is no longer updated until both a non-null scroll offset and a non-zero viewport height are available, which may delay initial page reporting in some environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29f89b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->