### PR TITLE
chore(security): add dependabot 7-day cooldown policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependency update policy.
+#
+# 7-day minimum release age: Dependabot will not propose any dependency
+# update (security fix or version bump) to a release younger than 7 days.
+# This is a supply-chain guard — a freshly published version may be
+# compromised and not yet flagged, so we deliberately wait out the window
+# rather than installing brand-new releases. Alerts whose only fix is a
+# <7-day-old version are effectively held until the fix has aged in.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Adds a `.github/dependabot.yml` enforcing a **7-day minimum release age**: Dependabot will not propose any security fix or version bump to a release younger than 7 days.

Supply-chain guard — a freshly published version may be compromised and not yet flagged, so we wait out the window rather than installing brand-new releases. Alerts whose only fix is a <7-day-old version are held until the fix has aged in.

Covers `npm` and `github-actions`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Apply 7-day Dependabot cooldown for `npm` and `github-actions`
>
> - Adds [dependabot.yml](https://github.com/anaralabs/lector/pull/132/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28) with weekly Dependabot update checks for root `npm` dependencies and `github-actions`.
> - Sets `cooldown.default-days: 7` for both ecosystems so Dependabot waits for releases to age before proposing updates; caps open npm update PRs at 10.
> - Behavioral change: Dependabot will no longer open npm or GitHub Actions update PRs for releases newer than 7 days.
> - Risk: Security remediation PRs are delayed when the only available fixed version is less than 7 days old.
>
> <sup>[Leo](https://anara.com) summarized `35a431d`</sup>
<!-- leo:summary-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Dependabot weekly update schedule with 7-day cooldown policy
> Adds [dependabot.yml](.github/dependabot.yml) to configure weekly dependency updates for npm and GitHub Actions. A 7-day minimum release age (`cooldown default-days: 7`) is enforced before Dependabot proposes updates. npm updates are capped at 10 open PRs at a time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35a431d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->