### PR TITLE
perf(annotation-layer): stop rebuilding annotations on every re-render

### DIFF
--- a/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
+++ b/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
@@ -35,9 +35,21 @@ const defaultAnnotationLayerParams = {
 } satisfies Required<AnnotationLayerParams>;
 
 export const useAnnotationLayer = (params: AnnotationLayerParams) => {
+	// `params` is a fresh object on every render (the AnnotationLayer component
+	// passes an object literal, and `jumpOptions` defaults to a literal too), so
+	// depending on `params` made this memo — and the render effect below that
+	// rebuilds the annotation DOM + re-parses annotations — re-run on EVERY
+	// re-render. Depend on the primitive leaves so it only changes on real input
+	// changes (and so real option changes still re-render, unlike a ref), while
+	// keeping the original `{ ...defaults, ...params }` merge semantics.
 	const mergedParams = useMemo(() => {
 		return { ...defaultAnnotationLayerParams, ...params };
-	}, [params]);
+	}, [
+		params.renderForms,
+		params.externalLinksEnabled,
+		params.jumpOptions?.behavior,
+		params.jumpOptions?.align,
+	]);
 	const annotationLayerRef = useRef<HTMLDivElement>(null);
 	const annotationLayerObjectRef = useRef<unknown>(null);
 	const linkService = usePDFLinkService();


### PR DESCRIPTION
## Problem

`useAnnotationLayer` memoizes `mergedParams` on `[params]`:

```ts
const mergedParams = useMemo(() => ({ ...defaultAnnotationLayerParams, ...params }), [params]);
```

…but `params` is a **fresh object on every render** — the `AnnotationLayer` component passes a new `{ renderForms, externalLinksEnabled, jumpOptions }` literal each render, and `jumpOptions` even *defaults* to an object literal. So `mergedParams` is never referentially stable, which makes the render effect (deps include `mergedParams`):

```ts
useEffect(() => {
  container.replaceChildren();
  // …
  const annotations = await pdfPageProxy.getAnnotations();
  await annotationLayer.render({ …, annotations });
}, [pdfPageProxy, pdfDocumentProxy, mergedParams, linkService]);
```

…re-run on **every re-render**, not just when the page changes. Each run wipes the annotation DOM (`replaceChildren()`) and calls `pdfPageProxy.getAnnotations()` (a round-trip to the pdf.js worker).

In a virtualized viewer where the host app re-renders the page subtree frequently during scroll, this turns every cheap re-render into a full annotation rebuild. On a link-annotation-heavy PDF (e.g. a journal article with ~100 reference/DOI links) it became the **dominant scroll cost** in a downstream app: ~**56 annotation-layer rebuilds/sec**, and the pdf.js worker's `getAnnotationsData` ran for **~8.5s of CPU during a 5s scroll** (plus heavy GC from the churn).

## Fix

Depend on the **primitive leaf values** instead of the unstable `params` object, so `mergedParams` only changes on a real input change and the effect runs once per page:

```ts
}, [
  params.renderForms,
  params.externalLinksEnabled,
  params.jumpOptions?.behavior,
  params.jumpOptions?.align,
]);
```

This is robust regardless of how a consumer passes the props (explicit stable object, inline literal, or the component default).

## Impact (measured in a downstream app, real PDF, fast scroll)

| | before | after |
|---|---|---|
| annotation-layer rebuilds / 4s | 227 | **36** |
| `getAnnotationsData` worker self-time | ~8.5s (top cost) | **out of the top costs** |
| scroll p95 frame time | 50ms | **25ms** |

No behavior change — annotations/links render identically (verified: link anchors with correct hrefs still present); the effect simply stops doing redundant work on re-renders where nothing relevant changed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- leo:summary-start -->
> [!NOTE]
> ### Stop redundant `useAnnotationLayer` annotation rebuilds
>
> - Memoizes `mergedParams` from the primitive annotation option values instead of the fresh `params` object, so the annotation render effect only reruns when the relevant inputs actually change.
> - Keeps the existing default-merge semantics while avoiding redundant DOM replacement and `pdfPageProxy.getAnnotations()` calls on unrelated re-renders.
> - Downstream measurement from the author: annotation-layer rebuilds during a 4s scroll dropped `227→36`, and `getAnnotationsData` fell out of the top worker costs.
>
> <sup>[Leo](https://anara.com) summarized `27636d7`</sup>
<!-- leo:summary-end -->