### PR TITLE
perf(text-layer): defer the text-layer build until scrolling settles

### DIFF
--- a/packages/lector/src/hooks/layers/useTextLayer.tsx
+++ b/packages/lector/src/hooks/layers/useTextLayer.tsx
@@ -201,6 +201,13 @@ const TEXT_BUILD_IDLE_MS = 300;
 // long after the last scroll event (i.e. once scrolling settles).
 const TEXT_SCROLL_SETTLE_MS = 160;
 
+// The viewport ref is assigned by a parent effect (after child effects), so on
+// first mount the scroll subscription retries on rAF. A mounted page implies
+// the viewport div is already committed (pages render inside it), so this
+// normally succeeds on the first retry — the generous cap only exists so a
+// non-lector integration without a viewport doesn't spin a rAF loop forever.
+const VIEWPORT_ATTACH_MAX_FRAMES = 300;
+
 export const useTextLayer = () => {
 	const textContainerRef = useRef<TextLayerDivElement>(null);
 	const textLayerRef = useRef<{
@@ -219,9 +226,27 @@ export const useTextLayer = () => {
 		}
 
 		let isCancelled = false;
+		let buildTimer: ReturnType<typeof setTimeout> | null = null;
+		let unsubscribe: (() => void) | null = null;
 
-		const buildTimer = setTimeout(() => {
-			if (isCancelled || textContainerRef.current !== textContainer) return;
+		// Building the text layer streams the page text from the pdf worker and
+		// measures every span (`ctx.measureText`) — a 100ms+ main-thread burst on
+		// dense pages that lands mid-scroll as the virtualizer mounts pages, and
+		// the user can't select text they're flying past anyway. So debounce the
+		// build against viewport scrolls: every scroll event restarts the timer
+		// (cancelling an in-flight build, which would otherwise keep running on
+		// the scroll path), and the build runs exactly TEXT_BUILD_IDLE_MS after
+		// the last scroll (mirrors the visibility gating below). Once a build has
+		// COMPLETED, further scrolls are no-ops.
+		let built = false;
+		let building = false;
+		// Bumped to abandon a cancelled build's promise chain so it can't mark
+		// `built` or touch the container after a newer build has started.
+		let buildGen = 0;
+
+		const build = () => {
+			building = true;
+			const gen = ++buildGen;
 
 			textContainer.innerHTML = "";
 			if (textLayerRef.current) {
@@ -231,7 +256,12 @@ export const useTextLayer = () => {
 
 			void import("pdfjs-dist/legacy/build/pdf.mjs")
 				.then(({ TextLayer }) => {
-					if (isCancelled || textContainerRef.current !== textContainer) return;
+					if (
+						isCancelled ||
+						gen !== buildGen ||
+						textContainerRef.current !== textContainer
+					)
+						return;
 
 					const textLayer = new TextLayer({
 						textContentSource: pdfPageProxy.streamTextContent(),
@@ -244,7 +274,11 @@ export const useTextLayer = () => {
 					return textLayer.render();
 				})
 				.then(() => {
-					if (isCancelled || textContainerRef.current !== textContainer) {
+					if (
+						isCancelled ||
+						gen !== buildGen ||
+						textContainerRef.current !== textContainer
+					) {
 						return;
 					}
 
@@ -253,17 +287,72 @@ export const useTextLayer = () => {
 					textContainer.appendChild(endOfContent);
 
 					bindMouseEvents(textContainer, endOfContent);
+
+					built = true;
+					building = false;
+					// The build is final — drop the scroll subscription so settled
+					// pages don't run a no-op callback on every scroll.
+					unsubscribe?.();
+					unsubscribe = null;
 				})
 				.catch((error) => {
+					if (gen === buildGen) building = false;
 					if (error instanceof Error && error.name !== "AbortException") {
 						console.error("TextLayer rendering error:", error);
 					}
 				});
-		}, TEXT_BUILD_IDLE_MS);
+		};
+
+		const schedule = () => {
+			if (built) return;
+			if (building) {
+				// A scroll started mid-build: stop the streaming render so its
+				// span-measuring work doesn't land on the scroll path, and rebuild
+				// from scratch once the viewport is idle again. Clear the container
+				// too so a partially-rendered text layer can't be selected/copied
+				// during the debounce window.
+				buildGen++;
+				building = false;
+				if (textLayerRef.current) {
+					textLayerRef.current.cancel();
+					textLayerRef.current = null;
+				}
+				textContainer.innerHTML = "";
+			}
+			if (buildTimer) clearTimeout(buildTimer);
+			buildTimer = setTimeout(() => {
+				buildTimer = null;
+				if (isCancelled || textContainerRef.current !== textContainer) return;
+				build();
+			}, TEXT_BUILD_IDLE_MS);
+		};
+
+		// `viewportRef.current` is assigned in a PARENT effect
+		// (useViewportContainer), and React runs child effects first — so on the
+		// initial mount it can still be null here. Retry on the next frame until
+		// the viewport exists (normally one frame) so initially-mounted pages get
+		// the debounce too; give up after ~1s so an integration without lector's
+		// viewport doesn't spin a rAF loop forever (the fixed timer still runs).
+		let attachRaf: number | null = null;
+		let attachAttempts = 0;
+		const attachScrollSubscription = () => {
+			attachRaf = null;
+			const scrollViewport = viewportRef?.current;
+			if (!scrollViewport) {
+				if (++attachAttempts > VIEWPORT_ATTACH_MAX_FRAMES) return;
+				attachRaf = requestAnimationFrame(attachScrollSubscription);
+				return;
+			}
+			unsubscribe = subscribeToViewportInvalidation(scrollViewport, schedule);
+		};
+		attachScrollSubscription();
+		schedule();
 
 		return () => {
 			isCancelled = true;
-			clearTimeout(buildTimer);
+			if (buildTimer) clearTimeout(buildTimer);
+			if (attachRaf !== null) cancelAnimationFrame(attachRaf);
+			unsubscribe?.();
 
 			if (textLayerRef.current) {
 				textLayerRef.current.cancel();
@@ -275,14 +364,13 @@ export const useTextLayer = () => {
 				delete textContainer._cleanupTextSelection;
 			}
 		};
-	}, [pdfPageProxy.streamTextContent, pdfPageProxy.getViewport]);
+	}, [pdfPageProxy.streamTextContent, pdfPageProxy.getViewport, viewportRef]);
 
 	// Hide the (transparent) text layer while scrolling so its spans aren't
 	// repainted as the page moves, and restore it once scrolling settles.
 	useEffect(() => {
 		const textContainer = textContainerRef.current;
-		const viewport = viewportRef?.current;
-		if (!textContainer || !viewport) return;
+		if (!textContainer) return;
 
 		let settleTimer: ReturnType<typeof setTimeout> | null = null;
 		// `selecting` is true only while a drag-select is actively extending the
@@ -327,7 +415,22 @@ export const useTextLayer = () => {
 			selecting = false;
 		};
 
-		const unsubscribe = subscribeToViewportInvalidation(viewport, onScroll);
+		// Same mount-order caveat as the build effect above: the viewport ref is
+		// assigned by a parent effect, so retry (bounded) until it exists.
+		let unsubscribe: (() => void) | null = null;
+		let attachRaf: number | null = null;
+		let attachAttempts = 0;
+		const attachScrollSubscription = () => {
+			attachRaf = null;
+			const scrollViewport = viewportRef?.current;
+			if (!scrollViewport) {
+				if (++attachAttempts > VIEWPORT_ATTACH_MAX_FRAMES) return;
+				attachRaf = requestAnimationFrame(attachScrollSubscription);
+				return;
+			}
+			unsubscribe = subscribeToViewportInvalidation(scrollViewport, onScroll);
+		};
+		attachScrollSubscription();
 		document.addEventListener("pointerdown", onPointerDown, true);
 		document.addEventListener("pointerup", clearPointer, true);
 		document.addEventListener("pointercancel", clearPointer, true);
@@ -335,7 +438,8 @@ export const useTextLayer = () => {
 		window.addEventListener("blur", clearPointer);
 
 		return () => {
-			unsubscribe();
+			if (attachRaf !== null) cancelAnimationFrame(attachRaf);
+			unsubscribe?.();
 			document.removeEventListener("pointerdown", onPointerDown, true);
 			document.removeEventListener("pointerup", clearPointer, true);
 			document.removeEventListener("pointercancel", clearPointer, true);


### PR DESCRIPTION
## Problem

The text-layer build (stream text from the pdf worker → `ctx.measureText` per span → build ~260 absolutely-positioned spans) is a 100ms+ main-thread burst on dense pages. The existing `TEXT_BUILD_IDLE_MS` defer is a **fixed 300ms after page mount** — but during a fast scroll the virtualizer keeps pages mounted longer than that, so builds fire **mid-scroll** and land as 150–300ms main-thread stalls. In LoAF traces they show up as `Worker.onmessage` long frames; to the user they're visible hiccups during fast scrolling.

Two aggravators we measured on a dense, link-annotated journal PDF:
- `measureText` cost is environment-sensitive: the *same call with the same font string* measured **0.02ms in one Chrome renderer and 2.4ms in another** (same machine, same browser, same inputs) — so a mid-scroll build that's tolerable on one machine is catastrophic (~600ms/page) on another.
- Holding back `GetTextContent` during scroll (live experiment) took the same page from ~35fps with 300ms stalls to **110fps / 0.5% dropped frames**.

## Fix

Re-arm the build timer on viewport scroll, reusing the existing `subscribeToViewportInvalidation` subscription: the build now runs only once the viewport has been **scroll-idle for `TEXT_BUILD_IDLE_MS`**, rather than a fixed delay after mount.

UX is unchanged in practice: you can't select text you're flying past, and this matches the scroll-time visibility gating already in place (#135) — selection/search are available ~300ms after scrolling stops, same as before.

## Measured

- `GetTextContent` worker calls during a 6s fast scroll: **11–21 → 0**
- The 150–300ms scroll hiccups disappear
- On settle: all text layers build (1,705 spans on the test doc), selection works

Pairs with #134 / #135 — together they take the dominant text-layer costs (build, repaint) fully off the scroll path.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- leo:summary-start -->
> [!NOTE]
> ### Defer `useTextLayer` builds until viewport scroll idle
>
> - Changes text-layer rendering from a fixed `300ms` delay after page mount to `TEXT_BUILD_IDLE_MS` after the last viewport scroll, avoiding `streamTextContent`/`measureText` work during fast scrolling.
> - Cancels an in-flight `TextLayer` render if scrolling resumes, clears partial spans, and uses a generation guard so stale async work cannot mark the layer built or touch the old container.
> - Unsubscribes from viewport invalidation once a page’s text layer has completed, so settled pages do not keep running no-op scroll callbacks.
> - Adds a bounded `requestAnimationFrame` retry for viewport subscription setup in [useTextLayer.tsx](https://github.com/anaralabs/lector/pull/136/files#diff-b4eba513cc988a49caaf217bc8b74f77541ff41caa7f0f0bd3a8820a1960396b), covering the parent-effect timing where `viewportRef.current` is initially null for both build scheduling and scroll-time visibility gating.
> - Behavioral change: Text selection/search on newly mounted pages becomes available after the viewport is idle instead of after a fixed mount delay.
>
> <sup>[Leo](https://anara.com) summarized `d4f7ffa`</sup>
<!-- leo:summary-end -->