### PR TITLE
feat: native dark mode rendering (no CSS filters)

### DIFF
--- a/examples/basic/src/App.tsx
+++ b/examples/basic/src/App.tsx
@@ -1,5 +1,6 @@
 import { CanvasLayer, Page, Pages, Root, TextLayer } from "@anaralabs/lector";
 import { GlobalWorkerOptions } from "pdfjs-dist/legacy/build/pdf.mjs";
+import { useState } from "react";
 import "pdfjs-dist/web/pdf_viewer.css";
 
 GlobalWorkerOptions.workerSrc = new URL(
@@ -8,25 +9,53 @@ GlobalWorkerOptions.workerSrc = new URL(
 ).toString();
 
 export default function App() {
+  const [dark, setDark] = useState(false);
+
   return (
-    <div className="min-h-screen bg-gray-100 p-8">
+    <div
+      className={`min-h-screen p-8 ${dark ? "bg-neutral-900" : "bg-gray-100"}`}
+    >
       <div className="mx-auto max-w-3xl">
-        <div className="mb-4 flex items-center justify-between rounded-lg bg-white p-4 shadow-sm">
+        <div
+          className={`mb-4 flex items-center justify-between rounded-lg p-4 shadow-sm ${
+            dark ? "bg-neutral-800 text-neutral-100" : "bg-white"
+          }`}
+        >
           <h1 className="text-xl font-semibold">Lector PDF Viewer</h1>
-          <a
-            href="https://github.com/anaralabs/lector"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-gray-500 hover:text-gray-700"
-          >
-            View on GitHub →
-          </a>
+          <div className="flex items-center gap-4">
+            <button
+              type="button"
+              onClick={() => setDark((d) => !d)}
+              className={`rounded-md px-3 py-1.5 text-sm font-medium ${
+                dark
+                  ? "bg-neutral-700 text-neutral-100 hover:bg-neutral-600"
+                  : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+              }`}
+            >
+              {dark ? "☀️ Light" : "🌙 Dark"}
+            </button>
+            <a
+              href="https://github.com/anaralabs/lector"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`text-sm ${
+                dark
+                  ? "text-neutral-400 hover:text-neutral-200"
+                  : "text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              View on GitHub →
+            </a>
+          </div>
         </div>
-        <div className="rounded-lg bg-white shadow-sm">
+        <div
+          className={`rounded-lg shadow-sm ${dark ? "bg-neutral-800" : "bg-white"}`}
+        >
           <Root
             source="/sample.pdf"
             className="h-[700px] w-full border overflow-hidden rounded-lg"
             loader={<div className="p-4">Loading...</div>}
+            colorScheme={dark ? "dark" : "light"}
           >
             <Pages>
               <Page>

--- a/packages/docs/app/(home)/_components/anara.tsx
+++ b/packages/docs/app/(home)/_components/anara.tsx
@@ -264,7 +264,7 @@ const PDFContent = ({
 				<CanvasLayer />
 				<TextLayer />
 				<AnnotationHighlightLayer
-					highlightClassName="dark:opacity-40 mix-blend-multiply transition-all duration-200 cursor-pointer"
+					highlightClassName="mix-blend-multiply dark:mix-blend-screen transition-all duration-200 cursor-pointer"
 					underlineClassName="transition-all duration-200 cursor-pointer"
 					commentIconClassName="text-blue-600 hover:text-blue-800"
 					focusedAnnotationId={focusedAnnotationId}

--- a/packages/docs/app/(home)/_components/anara.tsx
+++ b/packages/docs/app/(home)/_components/anara.tsx
@@ -14,6 +14,7 @@ import {
 	usePdfJump,
 	useSelectionDimensions,
 } from "@anaralabs/lector";
+import { useTheme } from "next-themes";
 import React, { useCallback, useEffect, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import "@/lib/setup";
@@ -258,10 +259,7 @@ const PDFContent = ({
 	);
 
 	return (
-		<Pages
-			className="dark:invert-[94%] dark:hue-rotate-180 dark:brightness-[80%] dark:contrast-[228%] dark:bg-gray-100"
-			onClick={handlePagesClick}
-		>
+		<Pages onClick={handlePagesClick}>
 			<Page>
 				<CanvasLayer />
 				<TextLayer />
@@ -298,6 +296,7 @@ export const AnaraViewer = ({ fullHeight }: AnaraViewerProps) => {
 	);
 	const [focusedAnnotationId, setFocusedAnnotationId] = useState<string>();
 	const { setAnnotations } = useAnnotations();
+	const { resolvedTheme } = useTheme();
 
 	// Load saved annotations and ensure backward compatibility
 	React.useEffect(() => {
@@ -336,6 +335,7 @@ export const AnaraViewer = ({ fullHeight }: AnaraViewerProps) => {
 				)}
 				isZoomFitWidth={true}
 				loader={<div className="w-full"></div>}
+				colorScheme={resolvedTheme === "dark" ? "dark" : "light"}
 			>
 				<div className="p-1 relative flex justify-between border-b">
 					<ZoomMenu />

--- a/packages/docs/components/basic.tsx
+++ b/packages/docs/components/basic.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import { CanvasLayer, Page, Pages, Root, TextLayer } from "@anaralabs/lector";
+import { useTheme } from "next-themes";
 import "@/lib/setup";
 
 const fileUrl = "/pdf/pathways.pdf";
 
 const Basic = () => {
+	const { resolvedTheme } = useTheme();
+
 	return (
 		<Root
 			source={fileUrl}
 			className="w-full h-[500px] border overflow-hidden rounded-lg"
 			loader={<div className="p-4">Loading...</div>}
+			colorScheme={resolvedTheme === "dark" ? "dark" : "light"}
 		>
-			<Pages className="dark:invert-[94%] dark:hue-rotate-180 dark:brightness-[80%] dark:contrast-[228%]">
+			<Pages>
 				<Page>
 					<CanvasLayer />
 					<TextLayer />

--- a/packages/docs/components/link-demo.tsx
+++ b/packages/docs/components/link-demo.tsx
@@ -8,6 +8,7 @@ import {
 	Root,
 	TextLayer,
 } from "@anaralabs/lector";
+import { useTheme } from "next-themes";
 import "@/lib/setup";
 import DocumentMenu from "../app/(home)/_components/document-menu";
 import { PageNavigation } from "../app/(home)/_components/page-navigation";
@@ -16,19 +17,22 @@ import ZoomMenu from "../app/(home)/_components/zoom-menu";
 const fileUrl = "/pdf/links.pdf";
 
 const LinkDemo = () => {
+	const { resolvedTheme } = useTheme();
+
 	return (
 		<Root
 			source={fileUrl}
 			className="border not-prose overflow-hidden flex flex-col w-full h-[600px] rounded-lg"
 			isZoomFitWidth={true}
 			loader={<div className="w-full"></div>}
+			colorScheme={resolvedTheme === "dark" ? "dark" : "light"}
 		>
 			<div className="p-1 relative flex justify-between border-b">
 				<ZoomMenu />
 				<PageNavigation />
 				<DocumentMenu documentUrl={fileUrl} />
 			</div>
-			<Pages className="dark:invert-[94%] dark:hue-rotate-180 dark:brightness-[80%] dark:contrast-[228%] dark:bg-gray-100">
+			<Pages>
 				<Page>
 					<CanvasLayer />
 					<TextLayer />

--- a/packages/docs/content/docs/code/basic.mdx
+++ b/packages/docs/content/docs/code/basic.mdx
@@ -14,18 +14,22 @@ import Basic from "@/components/basic.tsx";
 "use client";
 
 import { CanvasLayer, Page, Pages, Root, TextLayer } from "@anaralabs/lector";
+import { useTheme } from "next-themes";
 import React from "react";
 import "@/lib/setup";
 
 const fileUrl = "/pdf/pathways.pdf";
 
 const Basic = () => {
+  const { resolvedTheme } = useTheme();
+
   return (
     <Root
       source={fileUrl}
       className='w-full h-[500px] border overflow-hidden rounded-lg'
-      loader={<div className='p-4'>Loading...</div>}>
-      <Pages className='dark:invert-[94%] dark:hue-rotate-180 dark:brightness-[80%] dark:contrast-[228%]'>
+      loader={<div className='p-4'>Loading...</div>}
+      colorScheme={resolvedTheme === "dark" ? "dark" : "light"}>
+      <Pages>
         <Page>
           <CanvasLayer />
           <TextLayer />
@@ -41,7 +45,7 @@ export default Basic;
 The example above shows:
 
 - Basic PDF viewer setup with a fixed height container
-- Dark mode support with color adjustments
+- Native dark mode rendering driven by the app theme via the `colorScheme` prop
 - Loading state handling
 - Canvas rendering of PDF pages
 - Text layer for text selection and copying

--- a/packages/docs/content/docs/dark-mode.mdx
+++ b/packages/docs/content/docs/dark-mode.mdx
@@ -65,7 +65,7 @@ Rendered pages are cached per scheme as bitmaps, so toggling back and forth is i
 
 ## Custom Palette
 
-Override the dark palette with `darkModeColors`. The defaults are background `#181a1b` and foreground `#e8e6e3` (exported as `DEFAULT_DARK_MODE_COLORS`):
+Override the dark palette with `darkModeColors`. The defaults are background `#141210` (a dark warm gray) and foreground `#eae6e0` (exported as `DEFAULT_DARK_MODE_COLORS`):
 
 ```tsx
 <Root

--- a/packages/docs/content/docs/dark-mode.mdx
+++ b/packages/docs/content/docs/dark-mode.mdx
@@ -114,7 +114,7 @@ Compared to the CSS filter approach this also means text selection and highlight
 
 ## Limitations
 
-- Content inside luminosity soft-masks can recolor imperfectly — fades may look slightly different
+- Luminosity soft-mask fades survive (the mask is luma-corrected during composition), but midtones can land a few percent off the original opacity
 - Mesh-gradient shadings (rare) keep their original colors
 - Scanned PDFs, where the whole page is one image, intentionally stay light since images are preserved
 - Annotations rendered into the DOM by `AnnotationLayer` (link borders, form widgets) keep their original colors — style them with your own CSS if needed

--- a/packages/docs/content/docs/dark-mode.mdx
+++ b/packages/docs/content/docs/dark-mode.mdx
@@ -1,22 +1,136 @@
 ---
 title: Dark Mode
-description: Learn about Lector's dark mode implementation using CSS filters and future plans
+description: Learn how to render PDFs in native dark mode with Lector's render-time color remapping
 ---
 
-## Current Approach
+Lector renders dark mode natively at the PDF.js level. Colors are remapped inside the canvas pixels at render time — not approximated with CSS filters — so black text becomes light, white paper becomes dark, colors keep their hue, and images stay pixel-perfect.
 
-Lector implements dark mode support through custom CSS filters since PDF.js currently doesn't provide native dark mode support. This approach allows us to maintain compatibility while providing a good dark mode experience for users.
+## Quick Start
 
-## Implementation Details
+Pass the `colorScheme` prop to `Root`:
 
-We use CSS filters to invert colors and adjust them for better readability in dark mode. This solution, while not perfect, provides a reasonable dark mode experience without requiring modifications to PDF.js itself.
+```tsx
+import { Root, Pages, Page, CanvasLayer, TextLayer } from "@anaralabs/lector";
+
+function PDFViewer() {
+  return (
+    <Root source='/sample.pdf' colorScheme='dark'>
+      <Pages>
+        <Page>
+          <CanvasLayer />
+          <TextLayer />
+        </Page>
+      </Pages>
+    </Root>
+  );
+}
+```
+
+The prop is reactive — changing it re-renders every page in the new scheme. To follow your app's theme (for example with `next-themes`):
+
+```tsx
+import { useTheme } from "next-themes";
+
+function PDFViewer() {
+  const { resolvedTheme } = useTheme();
+
+  return (
+    <Root source='/sample.pdf' colorScheme={resolvedTheme === "dark" ? "dark" : "light"}>
+      {/* ... */}
+    </Root>
+  );
+}
+```
+
+## Runtime Toggle
+
+Any component under `Root` can read and switch the scheme through the `usePdf` store:
+
+```tsx
+import { usePdf } from "@anaralabs/lector";
+
+function DarkModeToggle() {
+  const colorScheme = usePdf((state) => state.colorScheme);
+  const setColorScheme = usePdf((state) => state.setColorScheme);
+
+  return (
+    <button onClick={() => setColorScheme(colorScheme === "dark" ? "light" : "dark")}>
+      {colorScheme === "dark" ? "Switch to light" : "Switch to dark"}
+    </button>
+  );
+}
+```
+
+Rendered pages are cached per scheme as bitmaps, so toggling back and forth is instant.
+
+## Custom Palette
+
+Override the dark palette with `darkModeColors`. The defaults are background `#181a1b` and foreground `#e8e6e3` (exported as `DEFAULT_DARK_MODE_COLORS`):
+
+```tsx
+<Root
+  source='/sample.pdf'
+  colorScheme='dark'
+  darkModeColors={{
+    background: "#1e1e2e", // replaces white paper
+    foreground: "#cdd6f4", // replaces black text and line art
+  }}
+>
+  {/* ... */}
+</Root>
+```
+
+You can also pass colors when toggling at runtime: `setColorScheme("dark", { background, foreground })`.
+
+## Matching Your UI
+
+If you draw your own overlays — highlight rects, custom annotations — you can recolor them with the exact same mapping the pages use. `createDarkModeColorMap` returns a memoized `(color: string) => string` function:
+
+```tsx
+import { createDarkModeColorMap, usePdf } from "@anaralabs/lector";
+
+function useThemedColor(color: string) {
+  const colorScheme = usePdf((state) => state.colorScheme);
+  const darkModeColors = usePdf((state) => state.darkModeColors);
+
+  if (colorScheme !== "dark") return color;
+  return createDarkModeColorMap(darkModeColors)(color);
+}
+```
+
+A yellow highlight passed through the map lands on the same ramp as the page content, so it reads as a highlight against the dark paper instead of clashing with it.
+
+## How It Works
+
+Lector intercepts draw calls on the canvas at render time and remaps each fill and stroke color in OKLab color space. Perceived lightness is flipped onto the background↔foreground ramp — its position follows BT.709 luma, the same measure the "luminance inversion" night modes in PSPDFKit and MuPDF use — while hue and chroma are preserved:
+
+- Black text → palette foreground; white paper → palette background
+- Red stays warm (becomes pink, not cyan like CSS `invert`); blue links become light blue
+- Grays pick up the palette's tint
+
+A custom PDF.js `CanvasFactory` extends the recoloring to PDF.js-internal scratch canvases (transparency groups, soft masks, patterns). Images are left pixel-perfect — photos are not inverted, which is the big win over CSS filters. And because everything happens once at render time, there is zero per-frame cost during scroll and zoom, unlike CSS filters which the compositor re-evaluates continuously.
+
+Compared to the CSS filter approach this also means text selection and highlights composite correctly against real dark pixels, and thumbnails and the high-zoom detail layer follow the scheme automatically.
+
+## Limitations
+
+- Content inside luminosity soft-masks can recolor imperfectly — fades may look slightly different
+- Mesh-gradient shadings (rare) keep their original colors
+- Scanned PDFs, where the whole page is one image, intentionally stay light since images are preserved
+- Passing your own `CanvasFactory` via `documentOptions` disables scratch-canvas recoloring
+
+## Legacy: CSS Filter Approach
+
+> **Deprecated.** Use the `colorScheme` prop instead. This recipe is kept for consumers on older versions of Lector without native dark mode.
+
+Before native dark mode, the recommended approach was a chain of CSS filters on the `Pages` container:
 
 ```tsx
 import { Root, Pages, Page, CanvasLayer } from "@anaralabs/lector";
 
 function PDFViewer() {
   return (
-    <Root fileUrl='/sample.pdf'>
+    <Root source='/sample.pdf'>
       <Pages className='dark:invert-[94%] dark:hue-rotate-180 dark:brightness-[80%] dark:contrast-[228%]'>
         <Page>
           <CanvasLayer />
@@ -27,18 +141,4 @@ function PDFViewer() {
 }
 ```
 
-## Current Limitations
-
-The CSS filter approach has some limitations:
-
-1. Color accuracy might not be perfect for all PDF documents
-2. Some PDFs with complex color schemes might not render optimally
-3. Performance impact on larger documents
-
-## Future Plans
-
-We are actively monitoring the PDF.js development regarding native dark mode support. As referenced in [PDF.js Issue #2071](https://github.com/mozilla/pdf.js/issues/2071), there are currently no plans to implement this feature in PDF.js itself.
-
-### Forking PDF.js
-
-**Forking PDF.js**: We might fork PDF.js in the future to implement proper dark mode support directly in the rendering pipeline.
+This inverts photos, shifts hues (CSS `hue-rotate` is a linear approximation), and adds per-frame GPU filter cost — all of which the native `colorScheme` rendering avoids.

--- a/packages/docs/content/docs/dark-mode.mdx
+++ b/packages/docs/content/docs/dark-mode.mdx
@@ -82,6 +82,26 @@ Override the dark palette with `darkModeColors`. The defaults are background `#1
 
 You can also pass colors when toggling at runtime: `setColorScheme("dark", { background, foreground })`.
 
+Any CSS color works (`hsl()`, named colors, etc.), but **not** `var(--token)` — resolve CSS variables yourself first. If you do, don't read them from `document.documentElement` during render: when the theme toggles, React can re-render before your `dark` class lands on `<html>`, and you'll capture the light values and pass a light palette as the "dark" one. Resolve the dark tokens from a probe element that always carries the class instead:
+
+```tsx
+function resolveDarkTokens() {
+  const probe = document.createElement("div");
+  probe.className = "dark"; // always matches your .dark token block
+  probe.style.display = "none";
+  document.body.appendChild(probe);
+  const styles = getComputedStyle(probe);
+  const colors = {
+    background: `hsl(${styles.getPropertyValue("--background").trim()})`,
+    foreground: `hsl(${styles.getPropertyValue("--foreground").trim()})`,
+  };
+  probe.remove();
+  return colors;
+}
+```
+
+The palette only applies while `colorScheme` is `"dark"`, so it's safe to compute once and pass unconditionally.
+
 ## Matching Your UI
 
 If you draw your own overlays — highlight rects, custom annotations — you can recolor them with the exact same mapping the pages use. `createDarkModeColorMap` returns a memoized `(color: string) => string` function:

--- a/packages/docs/content/docs/dark-mode.mdx
+++ b/packages/docs/content/docs/dark-mode.mdx
@@ -117,6 +117,8 @@ Compared to the CSS filter approach this also means text selection and highlight
 - Content inside luminosity soft-masks can recolor imperfectly — fades may look slightly different
 - Mesh-gradient shadings (rare) keep their original colors
 - Scanned PDFs, where the whole page is one image, intentionally stay light since images are preserved
+- Annotations rendered into the DOM by `AnnotationLayer` (link borders, form widgets) keep their original colors — style them with your own CSS if needed
+- Overlays you draw with blend modes tuned for a light page (e.g. `mix-blend-multiply`) need a dark variant such as `dark:mix-blend-screen`
 - Passing your own `CanvasFactory` via `documentOptions` disables scratch-canvas recoloring
 
 ## Legacy: CSS Filter Approach

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -22,6 +22,7 @@
     "fumadocs-ui": "14.6.2",
     "lucide-react": "^0.469.0",
     "next": "^15.5.18",
+    "next-themes": "^0.4.4",
     "pdfjs-dist": "^5.5.207",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 43580,
+    "size": 43529,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 43430,
+    "size": 43580,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 43227,
+    "size": 43360,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 43529,
+    "size": 43577,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 40485,
+    "size": 42755,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 42755,
+    "size": 42865,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 43274,
+    "size": 43227,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 43328,
+    "size": 43430,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 43360,
+    "size": 43328,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 42865,
+    "size": 43274,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
+++ b/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
@@ -17,6 +17,7 @@ export const ColoredHighlightComponent = ({
 	const deleteColoredHighlight = usePdf(
 		(state) => state.deleteColoredHighlight,
 	);
+	const colorScheme = usePdf((state) => state.colorScheme);
 	const [showButton, setShowButton] = useState(false);
 	const pageNumber = usePDFPageNumber();
 
@@ -48,9 +49,9 @@ export const ColoredHighlightComponent = ({
 						cursor: "pointer",
 						zIndex: 30,
 						backgroundColor: selection.color,
-						// mixBlendMode: "lighten", // changes the color of the text
-						mixBlendMode: "darken", // best results
-						// mixBlendMode: "multiply", // works but coloring has some inconsistencies
+						// "darken" keeps dark text legible on a light page; on a dark
+						// page the equivalent is "lighten" (keeps light text legible).
+						mixBlendMode: colorScheme === "dark" ? "lighten" : "darken",
 						borderRadius: "0.2rem",
 					}}
 				/>

--- a/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
+++ b/packages/lector/src/components/layers/colored-highlight/colored-highlight.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 
 import { usePDFPageNumber } from "../../../hooks/usePdfPageNumber";
 import { type ColoredHighlight, usePdf } from "../../../internal";
+import { createDarkModeColorMap } from "../../../lib/dark-mode";
 import {
 	getEndOfHighlight,
 	getMidHeightOfHighlightLine,
@@ -18,8 +19,16 @@ export const ColoredHighlightComponent = ({
 		(state) => state.deleteColoredHighlight,
 	);
 	const colorScheme = usePdf((state) => state.colorScheme);
+	const darkModeColors = usePdf((state) => state.darkModeColors);
 	const [showButton, setShowButton] = useState(false);
 	const pageNumber = usePDFPageNumber();
+
+	// Run the highlight color through the same map as the page so it reads
+	// as a tint against the dark paper instead of a light-mode block.
+	const highlightColor =
+		colorScheme === "dark"
+			? createDarkModeColorMap(darkModeColors)(selection.color)
+			: selection.color;
 
 	const pageRectangles = useMemo(
 		() => selection.rectangles.filter((r) => r.pageNumber === pageNumber),
@@ -48,7 +57,7 @@ export const ColoredHighlightComponent = ({
 						width: rect.width,
 						cursor: "pointer",
 						zIndex: 30,
-						backgroundColor: selection.color,
+						backgroundColor: highlightColor,
 						// "darken" keeps dark text legible on a light page; on a dark
 						// page the equivalent is "lighten" (keeps light text legible).
 						mixBlendMode: colorScheme === "dark" ? "lighten" : "darken",

--- a/packages/lector/src/components/page.tsx
+++ b/packages/lector/src/components/page.tsx
@@ -7,6 +7,7 @@ import {
 
 import { PDFPageNumberContext } from "../hooks/usePdfPageNumber";
 import { usePdf } from "../internal";
+import { createDarkModeColorMap } from "../lib/dark-mode";
 import { Primitive } from "./primitive";
 
 export const Page = memo(
@@ -21,6 +22,15 @@ export const Page = memo(
 	}) => {
 		const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 		const viewport = usePdf((state) => state.viewports[pageNumber - 1]);
+		const colorScheme = usePdf((state) => state.colorScheme);
+		const darkModeColors = usePdf((state) => state.darkModeColors);
+
+		// Match the canvas pixels: white maps exactly onto the dark palette's
+		// background, so pages never flash light while (re)rendering.
+		const pageBackground =
+			colorScheme === "dark"
+				? createDarkModeColorMap(darkModeColors)("#ffffff")
+				: "white";
 
 		const width =
 			viewport?.width ??
@@ -41,7 +51,7 @@ export const Page = memo(
 							{
 								"--scale-factor": 1,
 								"--total-scale-factor": 1,
-								backgroundColor: "white",
+								backgroundColor: pageBackground,
 								position: "relative",
 								width,
 								height,

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -37,9 +37,15 @@ const ColorSchemeSync = ({
 }) => {
 	const setColorScheme = usePdf((state) => state.setColorScheme);
 	const storeColorScheme = usePdf((state) => state.colorScheme);
+	// Subscribing to the store palette makes the controlled prop win against
+	// runtime setColorScheme palette overrides: a divergence re-runs the
+	// effect, which re-imposes the prop (setColorScheme no-ops once equal).
+	const storeBackground = usePdf((state) => state.darkModeColors.background);
+	const storeForeground = usePdf((state) => state.darkModeColors.foreground);
 	const hasPalette = darkModeColors !== undefined;
 	const background = darkModeColors?.background;
 	const foreground = darkModeColors?.foreground;
+	// biome-ignore lint/correctness/useExhaustiveDependencies: storeBackground/storeForeground are deliberate triggers — a runtime palette override must re-run the sync so the controlled prop wins.
 	useEffect(() => {
 		if (!colorScheme && !hasPalette) return;
 		// Without a colorScheme prop, a provided palette still syncs — against
@@ -56,6 +62,8 @@ const ColorSchemeSync = ({
 	}, [
 		colorScheme,
 		storeColorScheme,
+		storeBackground,
+		storeForeground,
 		hasPalette,
 		background,
 		foreground,

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -20,10 +20,11 @@ import { Primitive } from "./primitive";
 /**
  * Mirrors post-mount changes of Root's colorScheme/darkModeColors props into
  * the store (the Provider's initialValue is frozen at mount). No-ops when the
- * consumer drives the scheme through `setColorScheme` instead of props.
+ * consumer drives everything through `setColorScheme` instead of props.
  *
  * Palette contract: when the `darkModeColors` prop is provided the store
- * mirrors it exactly — fields it omits resolve to the defaults. When the
+ * mirrors it exactly — fields it omits resolve to the defaults — even when
+ * the scheme itself is driven at runtime (no colorScheme prop). When the
  * prop is absent the palette is uncontrolled: scheme prop flips leave
  * whatever palette runtime `setColorScheme` calls have established.
  */
@@ -35,13 +36,16 @@ const ColorSchemeSync = ({
 	darkModeColors?: DarkModeColors;
 }) => {
 	const setColorScheme = usePdf((state) => state.setColorScheme);
+	const storeColorScheme = usePdf((state) => state.colorScheme);
 	const hasPalette = darkModeColors !== undefined;
 	const background = darkModeColors?.background;
 	const foreground = darkModeColors?.foreground;
 	useEffect(() => {
-		if (!colorScheme) return;
+		if (!colorScheme && !hasPalette) return;
+		// Without a colorScheme prop, a provided palette still syncs — against
+		// the store's current scheme, so it composes with runtime toggles.
 		setColorScheme(
-			colorScheme,
+			colorScheme ?? storeColorScheme,
 			hasPalette
 				? {
 						background: background ?? DEFAULT_DARK_MODE_COLORS.background,
@@ -49,7 +53,14 @@ const ColorSchemeSync = ({
 					}
 				: undefined,
 		);
-	}, [colorScheme, hasPalette, background, foreground, setColorScheme]);
+	}, [
+		colorScheme,
+		storeColorScheme,
+		hasPalette,
+		background,
+		foreground,
+		setColorScheme,
+	]);
 	return null;
 };
 

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -21,9 +21,11 @@ import { Primitive } from "./primitive";
  * Mirrors post-mount changes of Root's colorScheme/darkModeColors props into
  * the store (the Provider's initialValue is frozen at mount). No-ops when the
  * consumer drives the scheme through `setColorScheme` instead of props.
- * Omitted palette fields resolve to the defaults so the store always mirrors
- * the props — removing `darkModeColors` restores the default palette instead
- * of keeping the last custom one.
+ *
+ * Palette contract: when the `darkModeColors` prop is provided the store
+ * mirrors it exactly — fields it omits resolve to the defaults. When the
+ * prop is absent the palette is uncontrolled: scheme prop flips leave
+ * whatever palette runtime `setColorScheme` calls have established.
  */
 const ColorSchemeSync = ({
 	colorScheme,
@@ -33,15 +35,21 @@ const ColorSchemeSync = ({
 	darkModeColors?: DarkModeColors;
 }) => {
 	const setColorScheme = usePdf((state) => state.setColorScheme);
+	const hasPalette = darkModeColors !== undefined;
 	const background = darkModeColors?.background;
 	const foreground = darkModeColors?.foreground;
 	useEffect(() => {
 		if (!colorScheme) return;
-		setColorScheme(colorScheme, {
-			background: background ?? DEFAULT_DARK_MODE_COLORS.background,
-			foreground: foreground ?? DEFAULT_DARK_MODE_COLORS.foreground,
-		});
-	}, [colorScheme, background, foreground, setColorScheme]);
+		setColorScheme(
+			colorScheme,
+			hasPalette
+				? {
+						background: background ?? DEFAULT_DARK_MODE_COLORS.background,
+						foreground: foreground ?? DEFAULT_DARK_MODE_COLORS.foreground,
+					}
+				: undefined,
+		);
+	}, [colorScheme, hasPalette, background, foreground, setColorScheme]);
 	return null;
 };
 

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -10,13 +10,20 @@ import {
 	useCreatePDFLinkService,
 } from "../hooks/usePDFLinkService";
 import { PDFStore, usePdf } from "../internal";
-import type { ColorScheme, DarkModeColors } from "../lib/dark-mode";
+import {
+	type ColorScheme,
+	type DarkModeColors,
+	DEFAULT_DARK_MODE_COLORS,
+} from "../lib/dark-mode";
 import { Primitive } from "./primitive";
 
 /**
  * Mirrors post-mount changes of Root's colorScheme/darkModeColors props into
  * the store (the Provider's initialValue is frozen at mount). No-ops when the
  * consumer drives the scheme through `setColorScheme` instead of props.
+ * Omitted palette fields resolve to the defaults so the store always mirrors
+ * the props — removing `darkModeColors` restores the default palette instead
+ * of keeping the last custom one.
  */
 const ColorSchemeSync = ({
 	colorScheme,
@@ -30,7 +37,10 @@ const ColorSchemeSync = ({
 	const foreground = darkModeColors?.foreground;
 	useEffect(() => {
 		if (!colorScheme) return;
-		setColorScheme(colorScheme, { background, foreground });
+		setColorScheme(colorScheme, {
+			background: background ?? DEFAULT_DARK_MODE_COLORS.background,
+			foreground: foreground ?? DEFAULT_DARK_MODE_COLORS.foreground,
+		});
 	}, [colorScheme, background, foreground, setColorScheme]);
 	return null;
 };

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -9,8 +9,31 @@ import {
 	PDFLinkServiceContext,
 	useCreatePDFLinkService,
 } from "../hooks/usePDFLinkService";
-import { PDFStore } from "../internal";
+import { PDFStore, usePdf } from "../internal";
+import type { ColorScheme, DarkModeColors } from "../lib/dark-mode";
 import { Primitive } from "./primitive";
+
+/**
+ * Mirrors post-mount changes of Root's colorScheme/darkModeColors props into
+ * the store (the Provider's initialValue is frozen at mount). No-ops when the
+ * consumer drives the scheme through `setColorScheme` instead of props.
+ */
+const ColorSchemeSync = ({
+	colorScheme,
+	darkModeColors,
+}: {
+	colorScheme?: ColorScheme;
+	darkModeColors?: DarkModeColors;
+}) => {
+	const setColorScheme = usePdf((state) => state.setColorScheme);
+	const background = darkModeColors?.background;
+	const foreground = darkModeColors?.foreground;
+	useEffect(() => {
+		if (!colorScheme) return;
+		setColorScheme(colorScheme, { background, foreground });
+	}, [colorScheme, background, foreground, setColorScheme]);
+	return null;
+};
 
 export const Root = forwardRef(
 	(
@@ -24,6 +47,8 @@ export const Root = forwardRef(
 			zoom,
 			zoomOptions,
 			documentOptions,
+			colorScheme,
+			darkModeColors,
 			...props
 		}: Omit<HTMLProps<HTMLDivElement>, "onError"> &
 			usePDFDocumentParams & {
@@ -39,6 +64,8 @@ export const Root = forwardRef(
 			zoom,
 			zoomOptions,
 			documentOptions,
+			colorScheme,
+			darkModeColors,
 		});
 
 		const linkService = useCreatePDFLinkService(
@@ -57,6 +84,10 @@ export const Root = forwardRef(
 			<Primitive.div ref={ref} {...props}>
 				{initialState ? (
 					<PDFStore.Provider initialValue={initialState}>
+						<ColorSchemeSync
+							colorScheme={colorScheme}
+							darkModeColors={darkModeColors}
+						/>
 						<PDFLinkServiceContext.Provider value={linkService}>
 							{children}
 						</PDFLinkServiceContext.Provider>

--- a/packages/lector/src/components/selection/custom-selection.tsx
+++ b/packages/lector/src/components/selection/custom-selection.tsx
@@ -12,6 +12,7 @@ export const CustomSelection = ({
 	bgColor = "#ebf4ff94",
 }: CustomSelectionProps) => {
 	const customSelectionRects = usePdf((state) => state.customSelectionRects);
+	const colorScheme = usePdf((state) => state.colorScheme);
 
 	const pageNumber = usePDFPageNumber();
 
@@ -50,7 +51,9 @@ export const CustomSelection = ({
 						width: rect.width,
 						pointerEvents: "none",
 						background: bgColor,
-						mixBlendMode: "multiply",
+						// "multiply" tints a light page; "screen" is the dark-page
+						// equivalent (lightens instead of darkening to near-black).
+						mixBlendMode: colorScheme === "dark" ? "screen" : "multiply",
 					}}
 				/>
 			))}

--- a/packages/lector/src/components/selection/custom-selection.tsx
+++ b/packages/lector/src/components/selection/custom-selection.tsx
@@ -1,6 +1,7 @@
 /** biome-ignore-all lint/suspicious/noArrayIndexKey: <index react> */
 import { usePDFPageNumber } from "../../hooks/usePdfPageNumber";
 import { usePdf } from "../../internal";
+import { createDarkModeColorMap } from "../../lib/dark-mode";
 
 interface CustomSelectionProps {
 	textColor?: string;
@@ -13,6 +14,7 @@ export const CustomSelection = ({
 }: CustomSelectionProps) => {
 	const customSelectionRects = usePdf((state) => state.customSelectionRects);
 	const colorScheme = usePdf((state) => state.colorScheme);
+	const darkModeColors = usePdf((state) => state.darkModeColors);
 
 	const pageNumber = usePDFPageNumber();
 
@@ -21,6 +23,13 @@ export const CustomSelection = ({
 	);
 
 	if (!rects.length) return null;
+
+	// Run the light-tuned defaults through the same map as the page so the
+	// selection chrome composites sensibly against natively dark pixels.
+	const isDark = colorScheme === "dark";
+	const map = isDark ? createDarkModeColorMap(darkModeColors) : null;
+	const displayTextColor = map ? map(textColor) : textColor;
+	const displayBgColor = map ? map(bgColor) : bgColor;
 
 	return (
 		<>
@@ -35,7 +44,7 @@ export const CustomSelection = ({
 						width: rect.width,
 						pointerEvents: "none",
 						zIndex: 30,
-						background: textColor,
+						background: displayTextColor,
 						mixBlendMode: "color",
 					}}
 				/>
@@ -50,10 +59,10 @@ export const CustomSelection = ({
 						height: rect.height,
 						width: rect.width,
 						pointerEvents: "none",
-						background: bgColor,
+						background: displayBgColor,
 						// "multiply" tints a light page; "screen" is the dark-page
 						// equivalent (lightens instead of darkening to near-black).
-						mixBlendMode: colorScheme === "dark" ? "screen" : "multiply",
+						mixBlendMode: isDark ? "screen" : "multiply",
 					}}
 				/>
 			))}

--- a/packages/lector/src/components/selection/custom-selection.tsx
+++ b/packages/lector/src/components/selection/custom-selection.tsx
@@ -8,9 +8,17 @@ interface CustomSelectionProps {
 	bgColor?: string;
 }
 
+// The light default tint (#ebf4ff94) maps onto the dark ramp as a near-paper
+// color — screened over the dark page it would be invisible. The dark default
+// is tuned directly: a dim blue that screen-lifts the paper visibly without
+// washing out the light text.
+const DEFAULT_TEXT_COLOR = "#017aff";
+const DEFAULT_BG_COLOR = "#ebf4ff94";
+const DEFAULT_DARK_BG_COLOR = "#2a4a7a94";
+
 export const CustomSelection = ({
-	textColor = "#017aff",
-	bgColor = "#ebf4ff94",
+	textColor = DEFAULT_TEXT_COLOR,
+	bgColor = DEFAULT_BG_COLOR,
 }: CustomSelectionProps) => {
 	const customSelectionRects = usePdf((state) => state.customSelectionRects);
 	const colorScheme = usePdf((state) => state.colorScheme);
@@ -24,12 +32,17 @@ export const CustomSelection = ({
 
 	if (!rects.length) return null;
 
-	// Run the light-tuned defaults through the same map as the page so the
-	// selection chrome composites sensibly against natively dark pixels.
+	// Run colors through the same map as the page so the selection chrome
+	// composites sensibly against natively dark pixels. The default bg tint
+	// swaps to a dark-tuned value instead (see DEFAULT_DARK_BG_COLOR).
 	const isDark = colorScheme === "dark";
 	const map = isDark ? createDarkModeColorMap(darkModeColors) : null;
 	const displayTextColor = map ? map(textColor) : textColor;
-	const displayBgColor = map ? map(bgColor) : bgColor;
+	const displayBgColor = isDark
+		? bgColor === DEFAULT_BG_COLOR
+			? DEFAULT_DARK_BG_COLOR
+			: map!(bgColor)
+		: bgColor;
 
 	return (
 		<>

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -11,7 +11,12 @@ import type {
 import { useEffect, useRef, useState } from "react";
 
 import type { InitialPDFState, ZoomOptions } from "../../internal";
+import type { ColorScheme, DarkModeColors } from "../../lib/dark-mode";
 import { getDefaultPdfJsAssetUrls, loadPdfJs } from "../../lib/pdfjs";
+import {
+	createRecolorCanvasFactory,
+	type RenderColorMapRef,
+} from "../../lib/recolor-canvas-factory";
 
 export interface usePDFDocumentParams {
 	/**
@@ -55,6 +60,19 @@ export interface usePDFDocumentParams {
 	 * Must be a stable reference (module-level constant or useMemo) to avoid reloading the document.
 	 */
 	documentOptions?: Partial<DocumentInitParameters>;
+	/**
+	 * Initial color scheme for page rendering. "dark" recolors the document at
+	 * render time (native dark mode): perceived lightness is flipped onto the
+	 * darkModeColors ramp while hue is preserved, and images keep their
+	 * original pixels. Changing the prop after mount updates the scheme; the
+	 * runtime equivalent is `usePdf((s) => s.setColorScheme)`.
+	 */
+	colorScheme?: ColorScheme;
+	/**
+	 * Palette for the dark scheme: `background` replaces white paper,
+	 * `foreground` replaces black text. Defaults to #181a1b / #e8e6e3.
+	 */
+	darkModeColors?: DarkModeColors;
 }
 
 export type Source =
@@ -67,6 +85,7 @@ export type Source =
 function buildDocumentInitParams(
 	source: Source,
 	pdfJsVersion: string,
+	renderColorMapRef: RenderColorMapRef,
 	overrides?: Partial<DocumentInitParameters>,
 ): DocumentInitParameters {
 	let params: DocumentInitParameters;
@@ -108,6 +127,11 @@ function buildDocumentInitParams(
 		cMapPacked: true,
 		standardFontDataUrl: assetUrls.standardFontDataUrl,
 		iccUrl: assetUrls.iccUrl,
+		// Internal pdf.js scratch canvases (transparency groups, soft masks,
+		// patterns) go through this factory so native dark mode can recolor
+		// content that never touches the context passed to render(). A no-op
+		// while the light scheme is active.
+		CanvasFactory: createRecolorCanvasFactory(renderColorMapRef),
 	};
 
 	return { ...defaults, ...params, ...overrides };
@@ -122,11 +146,20 @@ export const usePDFDocumentContext = ({
 	zoom = 1,
 	zoomOptions,
 	documentOptions,
+	colorScheme,
+	darkModeColors,
 }: usePDFDocumentParams) => {
 	const [_, setProgress] = useState(0);
 
 	const [initialState, setInitialState] = useState<InitialPDFState | null>();
 	const [rotation] = useState<number>(initialRotation);
+
+	// Shared between the document's CanvasFactory (created at getDocument time)
+	// and the store (which owns the current scheme). Stable for the lifetime of
+	// this hook; the store assigns `.current` whenever the scheme changes.
+	const [renderColorMapRef] = useState<RenderColorMapRef>(() => ({
+		current: null,
+	}));
 
 	// Ref so the effect always reads the latest documentOptions without
 	// needing it in the dependency array (avoids reload on every render
@@ -138,6 +171,14 @@ export const usePDFDocumentContext = ({
 	// always invoking the latest callback.
 	const onErrorRef = useRef(onError);
 	onErrorRef.current = onError;
+
+	// Same pattern: reloads (source change) should pick up the latest scheme
+	// without the effect depending on it. Post-mount changes are synced into
+	// the store by Root.
+	const colorSchemeRef = useRef(colorScheme);
+	colorSchemeRef.current = colorScheme;
+	const darkModeColorsRef = useRef(darkModeColors);
+	darkModeColorsRef.current = darkModeColors;
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <onDocumnetLoad,zoomOptions>
 	useEffect(() => {
@@ -171,6 +212,9 @@ export const usePDFDocumentContext = ({
 				pdfDocumentProxy: pdf,
 				zoom,
 				zoomOptions,
+				colorScheme: colorSchemeRef.current,
+				darkModeColors: darkModeColorsRef.current,
+				renderColorMapRef,
 			}));
 		};
 
@@ -190,6 +234,7 @@ export const usePDFDocumentContext = ({
 						buildDocumentInitParams(
 							source,
 							version,
+							renderColorMapRef,
 							documentOptionsRef.current,
 						),
 					);

--- a/packages/lector/src/hooks/document/document.ts
+++ b/packages/lector/src/hooks/document/document.ts
@@ -70,7 +70,7 @@ export interface usePDFDocumentParams {
 	colorScheme?: ColorScheme;
 	/**
 	 * Palette for the dark scheme: `background` replaces white paper,
-	 * `foreground` replaces black text. Defaults to #181a1b / #e8e6e3.
+	 * `foreground` replaces black text. Defaults to #141210 / #eae6e0.
 	 */
 	darkModeColors?: DarkModeColors;
 }

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -231,12 +231,20 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 			removeContextRecolor(renderCtx);
 		}
 
-		const renderingTask = pdfPageProxy.render({
-			canvas: renderCanvas,
-			canvasContext: renderCtx,
-			viewport,
-			background,
-		});
+		let renderingTask: ReturnType<typeof pdfPageProxy.render>;
+		try {
+			renderingTask = pdfPageProxy.render({
+				canvas: renderCanvas,
+				canvasContext: renderCtx,
+				viewport,
+				background,
+			});
+		} catch (error) {
+			// A synchronous render() throw would otherwise skip the
+			// promise-based restore and leave the long-lived context wrapped.
+			restoreRecolor?.();
+			throw error;
+		}
 
 		const releaseBuffer = () => {
 			buffer.width = 0;

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -4,6 +4,8 @@ import { useDebounce } from "use-debounce";
 
 import { usePdf } from "../../internal";
 import { clampScaleForPage } from "../../lib/canvas-utils";
+import { createDarkModeColorMap } from "../../lib/dark-mode";
+import { applyContextRecolor } from "../../lib/recolor-context";
 import { useDpr } from "../useDpr";
 import { usePDFPageNumber } from "../usePdfPageNumber";
 
@@ -36,8 +38,12 @@ export function clearBitmapCache(documentId?: string): void {
 	}
 }
 
-function cacheKey(scale: number, background?: string): number {
-	const bg = background ?? "white";
+function cacheKey(
+	scale: number,
+	background?: string,
+	recolorKey?: string,
+): number {
+	const bg = `${background ?? "white"}|${recolorKey ?? ""}`;
 	let hash = Math.round(scale * 1e4);
 	for (let i = 0; i < bg.length; i++) {
 		hash = (hash * 31 + bg.charCodeAt(i)) | 0;
@@ -49,8 +55,9 @@ function getCachedBitmap(
 	proxy: PDFPageProxy,
 	scale: number,
 	background?: string,
+	recolorKey?: string,
 ): ImageBitmap | null {
-	const key = cacheKey(scale, background);
+	const key = cacheKey(scale, background, recolorKey);
 	const bitmap = canvasBitmapCache.get(proxy)?.get(key);
 	if (!bitmap) return null;
 	const idx = cacheEntries.findIndex((e) => e.proxy === proxy && e.key === key);
@@ -66,9 +73,10 @@ function setCachedBitmap(
 	proxy: PDFPageProxy,
 	scale: number,
 	background: string | undefined,
+	recolorKey: string | undefined,
 	bitmap: ImageBitmap,
 ): void {
-	const key = cacheKey(scale, background);
+	const key = cacheKey(scale, background, recolorKey);
 	let map = canvasBitmapCache.get(proxy);
 	if (!map) {
 		map = new Map();
@@ -108,6 +116,15 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 	const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 	const markPageRendered = usePdf((state) => state.markPageRendered);
 	const unmarkPageRendered = usePdf((state) => state.unmarkPageRendered);
+	const colorScheme = usePdf((state) => state.colorScheme);
+	const darkModeColors = usePdf((state) => state.darkModeColors);
+
+	// Memoized per palette — stable identity, safe as an effect dependency.
+	const recolor =
+		colorScheme === "dark" ? createDarkModeColorMap(darkModeColors) : null;
+	const recolorKey = recolor
+		? `dark:${darkModeColors.background},${darkModeColors.foreground}`
+		: undefined;
 
 	const [zoom] = useDebounce(bouncyZoom, 100);
 
@@ -143,13 +160,23 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		baseCanvas.style.transform = "translate(0px, 0px)";
 		baseCanvas.style.zIndex = "0";
 		baseCanvas.style.pointerEvents = "none";
-		baseCanvas.style.backgroundColor = background ?? "white";
+		// In dark mode the painted pixels get the mapped background (pdf.js
+		// fills it through the recolored fillRect), so the CSS fallback color
+		// must match — otherwise unpainted frames flash light.
+		baseCanvas.style.backgroundColor = recolor
+			? recolor(background ?? "#ffffff")
+			: (background ?? "white");
 		baseCanvas.style.visibility = "";
 
 		const context = baseCanvas.getContext("2d");
 		if (!context) return;
 
-		const cached = getCachedBitmap(pdfPageProxy, baseScale, background);
+		const cached = getCachedBitmap(
+			pdfPageProxy,
+			baseScale,
+			background,
+			recolorKey,
+		);
 		if (cached) {
 			context.drawImage(cached, 0, 0);
 			markPageRendered(pageNumber);
@@ -181,6 +208,13 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		const renderCanvas = useBuffer ? buffer : baseCanvas;
 		const renderCtx = bufferCtx ?? context;
 
+		// Native dark mode: recolor at draw time inside this render. The
+		// `background` param stays the ORIGINAL color — pdf.js fills it through
+		// the wrapped fillRect, which maps it exactly once.
+		const restoreRecolor = recolor
+			? applyContextRecolor(renderCtx, recolor)
+			: null;
+
 		const renderingTask = pdfPageProxy.render({
 			canvas: renderCanvas,
 			canvasContext: renderCtx,
@@ -194,6 +228,11 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		};
 
 		renderingTask.promise
+			.finally(() => {
+				// Matters for the no-buffer fallback, where renderCtx is the
+				// long-lived visible canvas context.
+				restoreRecolor?.();
+			})
 			.then(() => {
 				if (cancelled) {
 					releaseBuffer();
@@ -222,6 +261,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 								pdfPageProxy,
 								baseScale,
 								background,
+								recolorKey,
 								bitmap,
 							);
 						})
@@ -252,6 +292,8 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		pageNumber,
 		markPageRendered,
 		docId,
+		recolor,
+		recolorKey,
 	]);
 
 	useEffect(() => {

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -2,7 +2,7 @@ import type { PDFPageProxy } from "pdfjs-dist";
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { useDebounce } from "use-debounce";
 
-import { usePdf } from "../../internal";
+import { PDFStore, usePdf } from "../../internal";
 import { clampScaleForPage } from "../../lib/canvas-utils";
 import { createDarkModeColorMap } from "../../lib/dark-mode";
 import {
@@ -112,6 +112,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 	// or null when the canvas holds no content.
 	const paintedKeyRef = useRef<string | null>(null);
 	const pageNumber = usePDFPageNumber();
+	const store = PDFStore.useContext();
 
 	const dpr = useDpr();
 
@@ -253,6 +254,21 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 					releaseBuffer();
 					return;
 				}
+				// A scheme toggle mutates the shared render color map immediately,
+				// before React's cleanup cancels this task — a render finishing in
+				// that one-frame window may have painted pdf.js scratch canvases
+				// (transparency groups, masks) with the NEW map while the rest
+				// used the old one. Drop the frame instead of blitting/caching a
+				// mixed-scheme bitmap; the effect re-run repaints right after.
+				const state = store.getState();
+				const currentRecolorKey =
+					state.colorScheme === "dark"
+						? `dark:${state.darkModeColors.background},${state.darkModeColors.foreground}`
+						: undefined;
+				if (currentRecolorKey !== recolorKey) {
+					releaseBuffer();
+					return;
+				}
 				if (useBuffer) {
 					// Clear before blitting: drawImage composites source-over, so on
 					// a page with transparent regions (or a transparent background)
@@ -309,6 +325,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		docId,
 		recolor,
 		recolorKey,
+		store,
 	]);
 
 	useEffect(() => {

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -5,7 +5,10 @@ import { useDebounce } from "use-debounce";
 import { usePdf } from "../../internal";
 import { clampScaleForPage } from "../../lib/canvas-utils";
 import { createDarkModeColorMap } from "../../lib/dark-mode";
-import { applyContextRecolor } from "../../lib/recolor-context";
+import {
+	applyContextRecolor,
+	removeContextRecolor,
+} from "../../lib/recolor-context";
 import { useDpr } from "../useDpr";
 import { usePDFPageNumber } from "../usePdfPageNumber";
 
@@ -216,10 +219,16 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 
 		// Native dark mode: recolor at draw time inside this render. The
 		// `background` param stays the ORIGINAL color — pdf.js fills it through
-		// the wrapped fillRect, which maps it exactly once.
-		const restoreRecolor = recolor
-			? applyContextRecolor(renderCtx, recolor)
-			: null;
+		// the wrapped fillRect, which maps it exactly once. For light renders,
+		// strip any wrapper a still-pending dark render may have left on the
+		// context (matters in the no-buffer fallback, where renderCtx is the
+		// long-lived visible canvas context).
+		let restoreRecolor: (() => void) | null = null;
+		if (recolor) {
+			restoreRecolor = applyContextRecolor(renderCtx, recolor);
+		} else {
+			removeContextRecolor(renderCtx);
+		}
 
 		const renderingTask = pdfPageProxy.render({
 			canvas: renderCanvas,

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -105,7 +105,9 @@ function setCachedBitmap(
 
 export const useCanvasLayer = ({ background }: { background?: string }) => {
 	const canvasRef = useRef<HTMLCanvasElement | null>(null);
-	const hasContentRef = useRef(false);
+	// Key (background|scheme) the currently painted frame was rendered with,
+	// or null when the canvas holds no content.
+	const paintedKeyRef = useRef<string | null>(null);
 	const pageNumber = usePDFPageNumber();
 
 	const dpr = useDpr();
@@ -136,16 +138,20 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		const pageWidth = baseViewport.width;
 		const pageHeight = baseViewport.height;
 
-		// Mid-resize, reuse the painted frame via CSS — but only if one exists,
-		// else we'd un-hide a cleared, never-painted canvas (blank for the drag).
-		if (isResizing && hasContentRef.current) {
+		const contentKey = `${background ?? "white"}|${recolorKey ?? ""}`;
+
+		// Mid-resize, reuse the painted frame via CSS — but only if one exists
+		// AND it was painted with the current scheme/background, else we'd
+		// un-hide a cleared canvas (blank for the drag) or show stale colors
+		// after a theme toggle that lands during the resize.
+		if (isResizing && paintedKeyRef.current === contentKey) {
 			baseCanvas.style.visibility = "";
 			baseCanvas.style.width = `${pageWidth}px`;
 			baseCanvas.style.height = `${pageHeight}px`;
 			return;
 		}
 
-		hasContentRef.current = false;
+		paintedKeyRef.current = null;
 
 		const targetBaseScale = dpr * Math.min(zoom, 1);
 		const baseScale = clampScaleForPage(targetBaseScale, pageWidth, pageHeight);
@@ -180,7 +186,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		if (cached) {
 			context.drawImage(cached, 0, 0);
 			markPageRendered(pageNumber);
-			hasContentRef.current = true;
+			paintedKeyRef.current = contentKey;
 			return;
 		}
 
@@ -248,7 +254,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 				}
 				baseCanvas.style.visibility = "";
 				markPageRendered(pageNumber);
-				hasContentRef.current = true;
+				paintedKeyRef.current = contentKey;
 				if (typeof createImageBitmap !== "undefined") {
 					createImageBitmap(renderCanvas)
 						.then((bitmap) => {

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -36,6 +36,13 @@ export const useDetailCanvasLayer = ({
 	// Memoized per palette — stable identity, safe as an effect dependency.
 	const recolor =
 		colorScheme === "dark" ? createDarkModeColorMap(darkModeColors) : null;
+	const recolorKey = recolor
+		? `dark:${darkModeColors.background},${darkModeColors.foreground}`
+		: "light";
+
+	// Key (background|scheme) the visible detail canvas was last painted
+	// with, or null when it holds no content.
+	const paintedKeyRef = useRef<string | null>(null);
 
 	const [zoom] = useDebounce(bouncyZoom, 200);
 
@@ -72,6 +79,7 @@ export const useDetailCanvasLayer = ({
 		const bgColor = recolor
 			? recolor(background ?? "#ffffff")
 			: (background ?? "white");
+		const contentKey = `${background ?? "white"}|${recolorKey}`;
 		const detailBaseStyle = `position:absolute;top:0;left:0;pointer-events:none;z-index:1;background-color:${bgColor}`;
 
 		const hideDetailCanvas = () => {
@@ -210,6 +218,7 @@ export const useDetailCanvasLayer = ({
 					if (ctx) {
 						ctx.drawImage(buffer, 0, 0);
 					}
+					paintedKeyRef.current = contentKey;
 				})
 				.catch((error) => {
 					if (error.name === "RenderingCancelledException") {
@@ -253,6 +262,17 @@ export const useDetailCanvasLayer = ({
 			// so no stale rectangle flicker on zoom-out
 			hideDetailCanvas();
 		} else {
+			// Stale detail is only better than a flash when it matches the
+			// current scheme/background. Across a theme toggle the old overlay
+			// would show wrong-scheme pixels over a correct base — hide it
+			// before paint and let the scheduled render bring sharpness back.
+			if (
+				paintedKeyRef.current !== null &&
+				paintedKeyRef.current !== contentKey
+			) {
+				hideDetailCanvas();
+				paintedKeyRef.current = null;
+			}
 			scheduleRender(0);
 		}
 
@@ -277,6 +297,7 @@ export const useDetailCanvasLayer = ({
 		baseCanvasRef,
 		store,
 		recolor,
+		recolorKey,
 	]);
 
 	// Release canvas memory for Safari on unmount only.

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -208,6 +208,17 @@ export const useDetailCanvasLayer = ({
 				.then(() => {
 					if (renderingTask !== currentRenderingTask) return;
 
+					// Same guard as the base canvas: a render finishing inside the
+					// scheme-toggle window (map already swapped, cleanup not yet
+					// run) must not blit wrong/mixed-scheme pixels. The effect
+					// re-run re-renders the detail region right after.
+					const state = store.getState();
+					const currentRecolorKey =
+						state.colorScheme === "dark"
+							? `dark:${state.darkModeColors.background},${state.darkModeColors.foreground}`
+							: "light";
+					if (currentRecolorKey !== recolorKey) return;
+
 					// Swap: update the visible detail canvas in one go
 					detailCanvas.width = actualWidth;
 					detailCanvas.height = actualHeight;

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -4,6 +4,8 @@ import { useDebounce } from "use-debounce";
 
 import { PDFStore, usePdf } from "../../internal";
 import { clampScaleForPage } from "../../lib/canvas-utils";
+import { createDarkModeColorMap } from "../../lib/dark-mode";
+import { applyContextRecolor } from "../../lib/recolor-context";
 import { subscribeToViewportInvalidation } from "../../lib/viewport-invalidation";
 import { useDpr } from "../useDpr";
 import { usePDFPageNumber } from "../usePdfPageNumber";
@@ -28,6 +30,12 @@ export const useDetailCanvasLayer = ({
 	const isPinching = usePdf((state) => state.isPinching);
 	const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 	const viewportRef = usePdf((state) => state.viewportRef);
+	const colorScheme = usePdf((state) => state.colorScheme);
+	const darkModeColors = usePdf((state) => state.darkModeColors);
+
+	// Memoized per palette — stable identity, safe as an effect dependency.
+	const recolor =
+		colorScheme === "dark" ? createDarkModeColorMap(darkModeColors) : null;
 
 	const [zoom] = useDebounce(bouncyZoom, 200);
 
@@ -61,7 +69,9 @@ export const useDetailCanvasLayer = ({
 		let renderingTask: RenderTask | null = null;
 		let renderTimeoutId: NodeJS.Timeout | null = null;
 
-		const bgColor = background ?? "white";
+		const bgColor = recolor
+			? recolor(background ?? "#ffffff")
+			: (background ?? "white");
 		const detailBaseStyle = `position:absolute;top:0;left:0;pointer-events:none;z-index:1;background-color:${bgColor}`;
 
 		const hideDetailCanvas = () => {
@@ -173,6 +183,10 @@ export const useDetailCanvasLayer = ({
 				scale: effectiveScale,
 			});
 
+			// Native dark mode: recolor at draw time; `background` stays the
+			// original color and is mapped by the wrapped fillRect exactly once.
+			if (recolor) applyContextRecolor(bufferCtx, recolor);
+
 			const currentRenderingTask = pdfPageProxy.render({
 				canvas: buffer,
 				canvasContext: bufferCtx,
@@ -262,6 +276,7 @@ export const useDetailCanvasLayer = ({
 		viewportRef,
 		baseCanvasRef,
 		store,
+		recolor,
 	]);
 
 	// Release canvas memory for Safari on unmount only.

--- a/packages/lector/src/hooks/useThumbnail.tsx
+++ b/packages/lector/src/hooks/useThumbnail.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef } from "react";
 import { useDebounce } from "use-debounce";
 
 import { usePdf } from "../internal";
+import { createDarkModeColorMap } from "../lib/dark-mode";
+import { applyContextRecolor } from "../lib/recolor-context";
 import { useDpr } from "./useDpr";
 import { useVisibility } from "./useVisibility";
 
@@ -35,6 +37,12 @@ export const useThumbnail = (
 	const { visible } = useVisibility({ elementRef: containerRef });
 	const [debouncedVisible] = useDebounce(visible, 50);
 	const dpr = useDpr();
+	const colorScheme = usePdf((state) => state.colorScheme);
+	const darkModeColors = usePdf((state) => state.darkModeColors);
+
+	// Memoized per palette — stable identity, safe as an effect dependency.
+	const recolor =
+		colorScheme === "dark" ? createDarkModeColorMap(darkModeColors) : null;
 
 	const isVisible = isFirstPage || debouncedVisible;
 
@@ -66,6 +74,13 @@ export const useThumbnail = (
 				const context = canvas.getContext("2d");
 				if (!context) return;
 
+				// Native dark mode: recolor at draw time (pdf.js's default white
+				// background fill is mapped by the wrapped fillRect). The context
+				// is long-lived, so always restore once the render settles.
+				const restoreRecolor = recolor
+					? applyContextRecolor(context, recolor)
+					: null;
+
 				const renderTask = pageProxy.render({
 					canvas,
 					canvasContext: context,
@@ -73,7 +88,9 @@ export const useThumbnail = (
 				});
 
 				renderTaskRef.current = renderTask;
-				await renderTask.promise;
+				await renderTask.promise.finally(() => {
+					restoreRecolor?.();
+				});
 			} catch (error: unknown) {
 				if (
 					error instanceof Error &&
@@ -98,7 +115,7 @@ export const useThumbnail = (
 				canvas.height = 1;
 			}
 		};
-	}, [pageProxy, isVisible, dpr, maxHeight, maxWidth]);
+	}, [pageProxy, isVisible, dpr, maxHeight, maxWidth, recolor]);
 
 	return {
 		canvasRef,

--- a/packages/lector/src/hooks/useThumbnail.tsx
+++ b/packages/lector/src/hooks/useThumbnail.tsx
@@ -4,7 +4,10 @@ import { useDebounce } from "use-debounce";
 
 import { usePdf } from "../internal";
 import { createDarkModeColorMap } from "../lib/dark-mode";
-import { applyContextRecolor } from "../lib/recolor-context";
+import {
+	applyContextRecolor,
+	removeContextRecolor,
+} from "../lib/recolor-context";
 import { useDpr } from "./useDpr";
 import { useVisibility } from "./useVisibility";
 
@@ -76,21 +79,27 @@ export const useThumbnail = (
 
 				// Native dark mode: recolor at draw time (pdf.js's default white
 				// background fill is mapped by the wrapped fillRect). The context
-				// is long-lived, so always restore once the render settles.
-				const restoreRecolor = recolor
-					? applyContextRecolor(context, recolor)
-					: null;
+				// is long-lived, so restore even when render() throws
+				// synchronously, and strip stale wrappers before light renders.
+				let restoreRecolor: (() => void) | null = null;
+				if (recolor) {
+					restoreRecolor = applyContextRecolor(context, recolor);
+				} else {
+					removeContextRecolor(context);
+				}
 
-				const renderTask = pageProxy.render({
-					canvas,
-					canvasContext: context,
-					viewport: scaledViewport,
-				});
+				try {
+					const renderTask = pageProxy.render({
+						canvas,
+						canvasContext: context,
+						viewport: scaledViewport,
+					});
 
-				renderTaskRef.current = renderTask;
-				await renderTask.promise.finally(() => {
+					renderTaskRef.current = renderTask;
+					await renderTask.promise;
+				} finally {
 					restoreRecolor?.();
-				});
+				}
 			} catch (error: unknown) {
 				if (
 					error instanceof Error &&

--- a/packages/lector/src/index.ts
+++ b/packages/lector/src/index.ts
@@ -45,3 +45,10 @@ export {
 export { usePDFPageNumber } from "./hooks/usePdfPageNumber";
 export { useSelectionDimensions } from "./hooks/useSelectionDimensions";
 export { type ColoredHighlight, type HighlightRect, usePdf } from "./internal";
+export {
+	type ColorScheme,
+	createDarkModeColorMap,
+	type DarkModeColors,
+	DEFAULT_DARK_MODE_COLORS,
+	type RenderColorMap,
+} from "./lib/dark-mode";

--- a/packages/lector/src/internal.ts
+++ b/packages/lector/src/internal.ts
@@ -5,6 +5,13 @@ import { createRef } from "react";
 import { createStore, useStore } from "zustand";
 
 import { clamp } from "./lib/clamp";
+import {
+	type ColorScheme,
+	createDarkModeColorMap,
+	type DarkModeColors,
+	DEFAULT_DARK_MODE_COLORS,
+} from "./lib/dark-mode";
+import type { RenderColorMapRef } from "./lib/recolor-canvas-factory";
 import { getFitWidthZoom } from "./lib/zoom";
 import { createZustandContext } from "./lib/zustand";
 
@@ -85,6 +92,15 @@ interface PDFState {
 	renderedPages: Record<number, true>;
 	markPageRendered: (pageNumber: number) => void;
 	unmarkPageRendered: (pageNumber: number) => void;
+
+	colorScheme: ColorScheme;
+	darkModeColors: Required<DarkModeColors>;
+	setColorScheme: (colorScheme: ColorScheme, colors?: DarkModeColors) => void;
+	/**
+	 * Shared with the document's pdf.js CanvasFactory so internal scratch
+	 * canvases (transparency groups, soft masks, patterns) follow the scheme.
+	 */
+	renderColorMapRef: RenderColorMapRef;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -97,10 +113,26 @@ export interface InitialPDFState {
 	zoom: number;
 	isZoomFitWidth?: boolean;
 	zoomOptions?: ZoomOptions;
+	colorScheme?: ColorScheme;
+	darkModeColors?: DarkModeColors;
+	renderColorMapRef?: RenderColorMapRef;
 }
 
 export const PDFStore = createZustandContext(
 	(initialState: InitialPDFState) => {
+		const initialColorScheme = initialState.colorScheme ?? "light";
+		const initialDarkModeColors = {
+			...DEFAULT_DARK_MODE_COLORS,
+			...initialState.darkModeColors,
+		};
+		const renderColorMapRef = initialState.renderColorMapRef ?? {
+			current: null,
+		};
+		renderColorMapRef.current =
+			initialColorScheme === "dark"
+				? createDarkModeColorMap(initialDarkModeColors)
+				: null;
+
 		return createStore<PDFState>((set, get) => ({
 			pdfDocumentProxy: initialState.pdfDocumentProxy,
 			zoom: initialState.zoom,
@@ -213,6 +245,29 @@ export const PDFStore = createZustandContext(
 						(rect) => rect.uuid !== uuid,
 					),
 				})),
+
+			colorScheme: initialColorScheme,
+			darkModeColors: initialDarkModeColors,
+			renderColorMapRef,
+			setColorScheme: (colorScheme, colors) => {
+				const prev = get();
+				const darkModeColors = {
+					background: colors?.background ?? prev.darkModeColors.background,
+					foreground: colors?.foreground ?? prev.darkModeColors.foreground,
+				};
+				if (
+					prev.colorScheme === colorScheme &&
+					prev.darkModeColors.background === darkModeColors.background &&
+					prev.darkModeColors.foreground === darkModeColors.foreground
+				) {
+					return;
+				}
+				prev.renderColorMapRef.current =
+					colorScheme === "dark"
+						? createDarkModeColorMap(darkModeColors)
+						: null;
+				set({ colorScheme, darkModeColors });
+			},
 
 			renderedPages: {},
 			markPageRendered: (pageNumber: number) => {

--- a/packages/lector/src/lib/dark-mode.test.ts
+++ b/packages/lector/src/lib/dark-mode.test.ts
@@ -89,7 +89,10 @@ describe("createDarkModeColorMap", () => {
 		}
 	});
 
-	it("memoizes per palette and per color", () => {
+	it("returns the same map instance per palette with stable results", () => {
+		// Function identity is the observable memoization contract (hooks use
+		// it as an effect dependency); the per-color string cache is an
+		// internal perf detail that string equality cannot distinguish.
 		expect(createDarkModeColorMap()).toBe(map);
 		expect(map("#123456")).toBe(map("#123456"));
 		const custom = createDarkModeColorMap({ background: "#000000" });

--- a/packages/lector/src/lib/dark-mode.test.ts
+++ b/packages/lector/src/lib/dark-mode.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { createDarkModeColorMap, DEFAULT_DARK_MODE_COLORS } from "./dark-mode";
+
+function hexToRgb(hex: string): [number, number, number] {
+	return [
+		Number.parseInt(hex.slice(1, 3), 16),
+		Number.parseInt(hex.slice(3, 5), 16),
+		Number.parseInt(hex.slice(5, 7), 16),
+	];
+}
+
+function luma([r, g, b]: [number, number, number]): number {
+	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+describe("createDarkModeColorMap", () => {
+	const map = createDarkModeColorMap();
+
+	it("maps white exactly onto the palette background", () => {
+		expect(map("#ffffff")).toBe(DEFAULT_DARK_MODE_COLORS.background);
+		expect(map("#fff")).toBe(DEFAULT_DARK_MODE_COLORS.background);
+		expect(map("white")).toBe(DEFAULT_DARK_MODE_COLORS.background);
+	});
+
+	it("maps black exactly onto the palette foreground", () => {
+		expect(map("#000000")).toBe(DEFAULT_DARK_MODE_COLORS.foreground);
+		expect(map("#000")).toBe(DEFAULT_DARK_MODE_COLORS.foreground);
+		expect(map("black")).toBe(DEFAULT_DARK_MODE_COLORS.foreground);
+	});
+
+	it("maps rgb() whites onto (approximately) the background pole", () => {
+		const out = hexToRgb(map("rgb(255, 255, 255)"));
+		const pole = hexToRgb(DEFAULT_DARK_MODE_COLORS.background);
+		for (let i = 0; i < 3; i++) {
+			expect(Math.abs(out[i]! - pole[i]!)).toBeLessThanOrEqual(1);
+		}
+	});
+
+	it("flips lightness while preserving hue (red stays reddish, gets lighter)", () => {
+		const out = hexToRgb(map("#ff0000"));
+		// still red-dominant
+		expect(out[0]).toBeGreaterThan(out[1]);
+		expect(out[0]).toBeGreaterThan(out[2]);
+		// red is dark (luma 54/255) so it must come out lighter
+		expect(luma(out)).toBeGreaterThan(luma([255, 0, 0]));
+	});
+
+	it("turns dark blue into a light blue (readable links)", () => {
+		const out = hexToRgb(map("#0000ff"));
+		expect(out[2]).toBeGreaterThan(out[0]);
+		expect(luma(out)).toBeGreaterThan(140);
+	});
+
+	it("darkens light colors and lightens dark colors monotonically", () => {
+		const light = luma(hexToRgb(map("#eeeeee")));
+		const mid = luma(hexToRgb(map("#808080")));
+		const dark = luma(hexToRgb(map("#222222")));
+		expect(dark).toBeGreaterThan(mid);
+		expect(mid).toBeGreaterThan(light);
+	});
+
+	it("preserves alpha", () => {
+		const out = map("#ff000080");
+		expect(out).toMatch(/^#[0-9a-f]{8}$/);
+		expect(Number.parseInt(out.slice(7, 9), 16)).toBe(0x80);
+	});
+
+	it("leaves fully transparent and unparseable colors unchanged", () => {
+		expect(map("transparent")).toBe("transparent");
+		expect(map("rgba(0, 0, 0, 0)")).toBe("rgba(0, 0, 0, 0)");
+		expect(map("oklch(0.5 0.1 200)")).toBe("oklch(0.5 0.1 200)");
+		expect(map("url(#pattern)")).toBe("url(#pattern)");
+	});
+
+	it("emits only in-gamut css colors for saturated inputs", () => {
+		for (const input of ["#00ff00", "#ff00ff", "#ffff00", "#00ffff"]) {
+			expect(map(input)).toMatch(/^#[0-9a-f]{6}$/);
+		}
+	});
+
+	it("memoizes per palette and per color", () => {
+		expect(createDarkModeColorMap()).toBe(map);
+		expect(map("#123456")).toBe(map("#123456"));
+		const custom = createDarkModeColorMap({ background: "#000000" });
+		expect(custom).not.toBe(map);
+		expect(custom("#ffffff")).toBe("#000000");
+	});
+
+	it("respects a custom palette's poles", () => {
+		const custom = createDarkModeColorMap({
+			background: "#1e2228",
+			foreground: "#d6d3cd",
+		});
+		expect(custom("#ffffff")).toBe("#1e2228");
+		expect(custom("#000000")).toBe("#d6d3cd");
+	});
+});

--- a/packages/lector/src/lib/dark-mode.test.ts
+++ b/packages/lector/src/lib/dark-mode.test.ts
@@ -69,8 +69,18 @@ describe("createDarkModeColorMap", () => {
 	it("leaves fully transparent and unparseable colors unchanged", () => {
 		expect(map("transparent")).toBe("transparent");
 		expect(map("rgba(0, 0, 0, 0)")).toBe("rgba(0, 0, 0, 0)");
-		expect(map("oklch(0.5 0.1 200)")).toBe("oklch(0.5 0.1 200)");
 		expect(map("url(#pattern)")).toBe("url(#pattern)");
+		expect(map("not-a-color")).toBe("not-a-color");
+	});
+
+	it("maps the full CSS color grammar via browser normalization", () => {
+		// Near-white named/functional colors must land near the dark pole so
+		// the CSS fallback background never flashes light (review finding).
+		for (const input of ["ivory", "hsl(0 0% 98%)", "hsl(0, 0%, 100%)"]) {
+			const out = hexToRgb(map(input));
+			expect(luma(out)).toBeLessThan(50);
+		}
+		expect(luma(hexToRgb(map("navy")))).toBeGreaterThan(luma([0, 0, 128]));
 	});
 
 	it("emits only in-gamut css colors for saturated inputs", () => {

--- a/packages/lector/src/lib/dark-mode.ts
+++ b/packages/lector/src/lib/dark-mode.ts
@@ -33,7 +33,10 @@ function clamp01(value: number): number {
 
 function parseColor(input: string): Rgba | null {
 	const str = input.trim().toLowerCase();
-	const named = NAMED_COLORS[str];
+	// hasOwn: a plain-object lookup would resolve "constructor"/"__proto__".
+	const named = Object.hasOwn(NAMED_COLORS, str)
+		? NAMED_COLORS[str]
+		: undefined;
 	if (named) return named;
 
 	if (str.startsWith("#")) {
@@ -234,7 +237,12 @@ export function createDarkModeColorMap(
 	const foreground = colors?.foreground ?? DEFAULT_DARK_MODE_COLORS.foreground;
 	const instanceKey = `${background}|${foreground}`;
 	const existing = mapInstances.get(instanceKey);
-	if (existing) return existing;
+	if (existing) {
+		// LRU touch: keep palettes in active use away from the eviction end.
+		mapInstances.delete(instanceKey);
+		mapInstances.set(instanceKey, existing);
+		return existing;
+	}
 
 	const bgRgba =
 		parseColor(background) ?? parseColor(DEFAULT_DARK_MODE_COLORS.background)!;
@@ -286,7 +294,13 @@ export function createDarkModeColorMap(
 		return out;
 	};
 
-	if (mapInstances.size >= 16) mapInstances.clear();
+	// Evict the oldest palette instead of clearing: live components depend on
+	// stable function identity per palette (effect deps), and a wholesale
+	// clear would hand a still-mounted consumer a new instance.
+	if (mapInstances.size >= 16) {
+		const oldest = mapInstances.keys().next().value;
+		if (oldest !== undefined) mapInstances.delete(oldest);
+	}
 	mapInstances.set(instanceKey, map);
 	return map;
 }

--- a/packages/lector/src/lib/dark-mode.ts
+++ b/packages/lector/src/lib/dark-mode.ts
@@ -13,9 +13,11 @@ export interface DarkModeColors {
  */
 export type RenderColorMap = (color: string) => string;
 
+// Darker warm gray (red ≥ green ≥ blue): easier on the eyes than a cool or
+// pure-black surface, and white paper maps onto it exactly.
 export const DEFAULT_DARK_MODE_COLORS: Required<DarkModeColors> = {
-	background: "#181a1b",
-	foreground: "#e8e6e3",
+	background: "#141210",
+	foreground: "#eae6e0",
 };
 
 type Rgba = [number, number, number, number];

--- a/packages/lector/src/lib/dark-mode.ts
+++ b/packages/lector/src/lib/dark-mode.ts
@@ -83,7 +83,40 @@ function parseColor(input: string): Rgba | null {
 		return [clamp01(r), clamp01(g), clamp01(b), clamp01(a)];
 	}
 
+	// Last resort for the rest of the CSS color grammar (named colors,
+	// hsl()/oklch()/color-mix()/...): let the browser normalize it to a
+	// hex/rgba serialization, then parse that.
+	const normalized = normalizeCssColor(str);
+	if (normalized !== null && normalized !== str) return parseColor(normalized);
+
 	return null;
+}
+
+let normalizeCtx: CanvasRenderingContext2D | null | undefined;
+
+/**
+ * Normalizes any valid CSS color to its canvas fillStyle serialization
+ * ("#rrggbb" or "rgba(...)"). Returns null for invalid colors (assigning
+ * one leaves fillStyle unchanged, detected by priming with two different
+ * values) and outside the DOM (SSR).
+ */
+function normalizeCssColor(input: string): string | null {
+	if (normalizeCtx === undefined) {
+		normalizeCtx =
+			typeof document === "undefined"
+				? null
+				: document.createElement("canvas").getContext("2d", {
+						willReadFrequently: true,
+					});
+	}
+	const ctx = normalizeCtx;
+	if (!ctx) return null;
+	ctx.fillStyle = "#000000";
+	ctx.fillStyle = input;
+	const first = ctx.fillStyle;
+	ctx.fillStyle = "#ffffff";
+	ctx.fillStyle = input;
+	return first === ctx.fillStyle ? first : null;
 }
 
 function srgbToLinear(c: number): number {

--- a/packages/lector/src/lib/dark-mode.ts
+++ b/packages/lector/src/lib/dark-mode.ts
@@ -1,0 +1,259 @@
+export type ColorScheme = "light" | "dark";
+
+export interface DarkModeColors {
+	/** Replaces the white paper background. Any CSS hex/rgb color. */
+	background?: string;
+	/** Replaces black text and line art. Any CSS hex/rgb color. */
+	foreground?: string;
+}
+
+/**
+ * Maps a color from the original document to its dark-scheme equivalent.
+ * Unparseable and fully-transparent colors are returned unchanged.
+ */
+export type RenderColorMap = (color: string) => string;
+
+export const DEFAULT_DARK_MODE_COLORS: Required<DarkModeColors> = {
+	background: "#181a1b",
+	foreground: "#e8e6e3",
+};
+
+type Rgba = [number, number, number, number];
+type Lab = [number, number, number];
+
+const NAMED_COLORS: Record<string, Rgba> = {
+	white: [1, 1, 1, 1],
+	black: [0, 0, 0, 1],
+	transparent: [0, 0, 0, 0],
+};
+
+function clamp01(value: number): number {
+	return value < 0 ? 0 : value > 1 ? 1 : value;
+}
+
+function parseColor(input: string): Rgba | null {
+	const str = input.trim().toLowerCase();
+	const named = NAMED_COLORS[str];
+	if (named) return named;
+
+	if (str.startsWith("#")) {
+		const hex = str.slice(1);
+		if (!/^[0-9a-f]{3,8}$/.test(hex)) return null;
+		if (hex.length === 3 || hex.length === 4) {
+			const r = Number.parseInt(hex[0]!, 16) / 15;
+			const g = Number.parseInt(hex[1]!, 16) / 15;
+			const b = Number.parseInt(hex[2]!, 16) / 15;
+			const a = hex.length === 4 ? Number.parseInt(hex[3]!, 16) / 15 : 1;
+			return [r, g, b, a];
+		}
+		if (hex.length === 6 || hex.length === 8) {
+			const r = Number.parseInt(hex.slice(0, 2), 16) / 255;
+			const g = Number.parseInt(hex.slice(2, 4), 16) / 255;
+			const b = Number.parseInt(hex.slice(4, 6), 16) / 255;
+			const a =
+				hex.length === 8 ? Number.parseInt(hex.slice(6, 8), 16) / 255 : 1;
+			return [r, g, b, a];
+		}
+		return null;
+	}
+
+	const fn = /^rgba?\(([^)]+)\)$/.exec(str);
+	if (fn) {
+		const parts = fn[1]!.split(/[,\s/]+/).filter(Boolean);
+		if (parts.length < 3) return null;
+		const channel = (part: string) =>
+			part.endsWith("%")
+				? Number.parseFloat(part) / 100
+				: Number.parseFloat(part) / 255;
+		const alpha = (part: string) =>
+			part.endsWith("%")
+				? Number.parseFloat(part) / 100
+				: Number.parseFloat(part);
+		const r = channel(parts[0]!);
+		const g = channel(parts[1]!);
+		const b = channel(parts[2]!);
+		const a = parts[3] !== undefined ? alpha(parts[3]) : 1;
+		if (
+			Number.isNaN(r) ||
+			Number.isNaN(g) ||
+			Number.isNaN(b) ||
+			Number.isNaN(a)
+		)
+			return null;
+		return [clamp01(r), clamp01(g), clamp01(b), clamp01(a)];
+	}
+
+	return null;
+}
+
+function srgbToLinear(c: number): number {
+	return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+function linearToSrgb(c: number): number {
+	return c <= 0.0031308 ? 12.92 * c : 1.055 * c ** (1 / 2.4) - 0.055;
+}
+
+// sRGB <-> OKLab, reference implementation by Björn Ottosson (public domain).
+function rgbToOklab(r: number, g: number, b: number): Lab {
+	const lr = srgbToLinear(r);
+	const lg = srgbToLinear(g);
+	const lb = srgbToLinear(b);
+	const l = Math.cbrt(
+		0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb,
+	);
+	const m = Math.cbrt(
+		0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb,
+	);
+	const s = Math.cbrt(
+		0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb,
+	);
+	return [
+		0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+		1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+		0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+	];
+}
+
+function oklabToLinearRgb(L: number, a: number, b: number): Lab {
+	const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+	const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+	const s = (L - 0.0894841775 * a - 1.291485548 * b) ** 3;
+	return [
+		4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+		-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+		-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+	];
+}
+
+const GAMUT_EPSILON = 0.0005;
+
+function oklabToSrgbExact(L: number, a: number, b: number): Lab | null {
+	const [lr, lg, lb] = oklabToLinearRgb(L, a, b);
+	if (
+		lr < -GAMUT_EPSILON ||
+		lr > 1 + GAMUT_EPSILON ||
+		lg < -GAMUT_EPSILON ||
+		lg > 1 + GAMUT_EPSILON ||
+		lb < -GAMUT_EPSILON ||
+		lb > 1 + GAMUT_EPSILON
+	) {
+		return null;
+	}
+	return [
+		linearToSrgb(clamp01(lr)),
+		linearToSrgb(clamp01(lg)),
+		linearToSrgb(clamp01(lb)),
+	];
+}
+
+/** Reduce chroma until the color fits the sRGB gamut, then hard-clamp. */
+function oklabToSrgbGamutMapped(L: number, a: number, b: number): Lab {
+	const exact = oklabToSrgbExact(L, a, b);
+	if (exact) return exact;
+	let lo = 0;
+	let hi = 1;
+	for (let i = 0; i < 12; i++) {
+		const mid = (lo + hi) / 2;
+		if (oklabToSrgbExact(L, a * mid, b * mid)) lo = mid;
+		else hi = mid;
+	}
+	const [lr, lg, lb] = oklabToLinearRgb(L, a * lo, b * lo);
+	return [
+		linearToSrgb(clamp01(lr)),
+		linearToSrgb(clamp01(lg)),
+		linearToSrgb(clamp01(lb)),
+	];
+}
+
+function toHexByte(channel: number): string {
+	return Math.round(clamp01(channel) * 255)
+		.toString(16)
+		.padStart(2, "0");
+}
+
+function toCssColor(r: number, g: number, b: number, a: number): string {
+	const rgb = `#${toHexByte(r)}${toHexByte(g)}${toHexByte(b)}`;
+	return a >= 1 ? rgb : `${rgb}${toHexByte(a)}`;
+}
+
+// Above this OKLab chroma a color fully keeps its own hue/chroma; below it,
+// it is progressively pulled onto the background<->foreground ramp so the
+// palette's tint applies to grays too.
+const NEUTRAL_CHROMA_THRESHOLD = 0.04;
+
+const COLOR_CACHE_MAX = 4096;
+const mapInstances = new Map<string, RenderColorMap>();
+
+/**
+ * Builds a memoized color map that flips perceived lightness onto the
+ * background<->foreground ramp while preserving hue and chroma (OKLab).
+ * Position on the ramp follows gamma-encoded BT.709 luma — the same measure
+ * "luminance inversion" night modes use — so saturated accents move the way
+ * readers expect (red becomes pink, not cyan; blue links become light blue).
+ * Neutrals land exactly on the ramp: white maps to `background`, black to
+ * `foreground`, including the palette's tint.
+ */
+export function createDarkModeColorMap(
+	colors?: DarkModeColors,
+): RenderColorMap {
+	const background = colors?.background ?? DEFAULT_DARK_MODE_COLORS.background;
+	const foreground = colors?.foreground ?? DEFAULT_DARK_MODE_COLORS.foreground;
+	const instanceKey = `${background}|${foreground}`;
+	const existing = mapInstances.get(instanceKey);
+	if (existing) return existing;
+
+	const bgRgba =
+		parseColor(background) ?? parseColor(DEFAULT_DARK_MODE_COLORS.background)!;
+	const fgRgba =
+		parseColor(foreground) ?? parseColor(DEFAULT_DARK_MODE_COLORS.foreground)!;
+	const bgLab = rgbToOklab(bgRgba[0], bgRgba[1], bgRgba[2]);
+	const fgLab = rgbToOklab(fgRgba[0], fgRgba[1], fgRgba[2]);
+
+	const cache = new Map<string, string>();
+	// Exact poles: pure white/black must reproduce the palette strings
+	// verbatim (no float round-tripping), so page backgrounds match CSS.
+	const backgroundCss = toCssColor(bgRgba[0], bgRgba[1], bgRgba[2], 1);
+	const foregroundCss = toCssColor(fgRgba[0], fgRgba[1], fgRgba[2], 1);
+	const seedPoles = () => {
+		for (const white of ["#ffffff", "#fff", "white"])
+			cache.set(white, backgroundCss);
+		for (const black of ["#000000", "#000", "black"])
+			cache.set(black, foregroundCss);
+	};
+	seedPoles();
+
+	const transform = (input: string): string => {
+		const parsed = parseColor(input);
+		if (!parsed || parsed[3] === 0) return input;
+		const [r, g, b, alpha] = parsed;
+		const [, labA, labB] = rgbToOklab(r, g, b);
+		// Gamma-encoded BT.709 luma as ramp position: 0 = black, 1 = white.
+		const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+		const rampL = fgLab[0] + (bgLab[0] - fgLab[0]) * luma;
+		const rampA = fgLab[1] + (bgLab[1] - fgLab[1]) * luma;
+		const rampB = fgLab[2] + (bgLab[2] - fgLab[2]) * luma;
+		const chroma = Math.hypot(labA, labB);
+		const hueWeight = Math.min(1, chroma / NEUTRAL_CHROMA_THRESHOLD);
+		const outA = rampA + (labA - rampA) * hueWeight;
+		const outB = rampB + (labB - rampB) * hueWeight;
+		const [sr, sg, sb] = oklabToSrgbGamutMapped(rampL, outA, outB);
+		return toCssColor(sr, sg, sb, alpha);
+	};
+
+	const map: RenderColorMap = (input) => {
+		const hit = cache.get(input);
+		if (hit !== undefined) return hit;
+		const out = transform(input);
+		if (cache.size >= COLOR_CACHE_MAX) {
+			cache.clear();
+			seedPoles();
+		}
+		cache.set(input, out);
+		return out;
+	};
+
+	if (mapInstances.size >= 16) mapInstances.clear();
+	mapInstances.set(instanceKey, map);
+	return map;
+}

--- a/packages/lector/src/lib/recolor-canvas-factory.ts
+++ b/packages/lector/src/lib/recolor-canvas-factory.ts
@@ -1,5 +1,5 @@
 import type { RenderColorMap } from "./dark-mode";
-import { applyContextRecolor } from "./recolor-context";
+import { applyContextRecolor, removeContextRecolor } from "./recolor-context";
 
 export interface RenderColorMapRef {
 	current: RenderColorMap | null;
@@ -62,6 +62,15 @@ export function createRecolorCanvasFactory(mapRef: RenderColorMapRef) {
 			}
 			canvasAndContext.canvas.width = width;
 			canvasAndContext.canvas.height = height;
+			// pdf.js scratch canvases live within a single render task today,
+			// but the factory contract allows reuse via reset — re-sync the
+			// wrapper with the current scheme so a reused context never keeps
+			// a stale map.
+			if (canvasAndContext.context) {
+				const map = mapRef.current;
+				if (map) applyContextRecolor(canvasAndContext.context, map);
+				else removeContextRecolor(canvasAndContext.context);
+			}
 		}
 
 		destroy(canvasAndContext: CanvasAndContext) {

--- a/packages/lector/src/lib/recolor-canvas-factory.ts
+++ b/packages/lector/src/lib/recolor-canvas-factory.ts
@@ -1,0 +1,77 @@
+import type { RenderColorMap } from "./dark-mode";
+import { applyContextRecolor } from "./recolor-context";
+
+export interface RenderColorMapRef {
+	current: RenderColorMap | null;
+}
+
+interface CanvasAndContext {
+	canvas: HTMLCanvasElement | null;
+	context: CanvasRenderingContext2D | null;
+}
+
+/**
+ * pdf.js paints transparency groups, soft masks, tiling/shading patterns and
+ * image-mask fills on internal scratch canvases obtained from the document's
+ * CanvasFactory — that content never touches the context we hand to
+ * `page.render()`. Passing this factory via getDocument's `CanvasFactory`
+ * option extends dark-mode recoloring to those canvases, which is what makes
+ * the scheme complete (pages with a page-level transparency group otherwise
+ * render entirely on a scratch canvas).
+ *
+ * The map is captured per canvas at creation time from `mapRef`; scratch
+ * canvases only live for a single render task, so toggling the scheme simply
+ * takes effect on the next render.
+ */
+export function createRecolorCanvasFactory(mapRef: RenderColorMapRef) {
+	return class RecolorCanvasFactory {
+		#document: Document;
+		#enableHWA: boolean;
+
+		constructor({
+			ownerDocument = globalThis.document,
+			enableHWA = false,
+		}: { ownerDocument?: Document; enableHWA?: boolean } = {}) {
+			this.#document = ownerDocument;
+			this.#enableHWA = enableHWA;
+		}
+
+		create(width: number, height: number): CanvasAndContext {
+			if (width <= 0 || height <= 0) {
+				throw new Error("Invalid canvas size");
+			}
+			const canvas = this.#document.createElement("canvas");
+			canvas.width = width;
+			canvas.height = height;
+			const context = canvas.getContext("2d", {
+				willReadFrequently: !this.#enableHWA,
+			});
+			const map = mapRef.current;
+			if (context && map) {
+				applyContextRecolor(context, map);
+			}
+			return { canvas, context };
+		}
+
+		reset(canvasAndContext: CanvasAndContext, width: number, height: number) {
+			if (!canvasAndContext.canvas) {
+				throw new Error("Canvas is not specified");
+			}
+			if (width <= 0 || height <= 0) {
+				throw new Error("Invalid canvas size");
+			}
+			canvasAndContext.canvas.width = width;
+			canvasAndContext.canvas.height = height;
+		}
+
+		destroy(canvasAndContext: CanvasAndContext) {
+			if (!canvasAndContext.canvas) {
+				throw new Error("Canvas is not specified");
+			}
+			canvasAndContext.canvas.width = 0;
+			canvasAndContext.canvas.height = 0;
+			canvasAndContext.canvas = null;
+			canvasAndContext.context = null;
+		}
+	};
+}

--- a/packages/lector/src/lib/recolor-context.test.ts
+++ b/packages/lector/src/lib/recolor-context.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { applyContextRecolor } from "./recolor-context";
+
+const DARK = "#181a1b";
+const LIGHT = "#e8e6e3";
+
+/** Test map mirroring the dark scheme's poles. */
+const testMap = (color: string) =>
+	color === "#ffffff" || color === "white"
+		? DARK
+		: color === "#000000" || color === "black"
+			? LIGHT
+			: color;
+
+function makeCtx(size = 8): CanvasRenderingContext2D {
+	const canvas = document.createElement("canvas");
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) throw new Error("no 2d context");
+	return ctx;
+}
+
+function pixel(ctx: CanvasRenderingContext2D, x = 4, y = 4): string {
+	const [r, g, b] = ctx.getImageData(x, y, 1, 1).data;
+	return `#${[r, g, b].map((c) => c!.toString(16).padStart(2, "0")).join("")}`;
+}
+
+describe("applyContextRecolor", () => {
+	it("recolors string fills at draw time", () => {
+		const ctx = makeCtx();
+		applyContextRecolor(ctx, testMap);
+		ctx.fillStyle = "#ffffff";
+		ctx.fillRect(0, 0, 8, 8);
+		expect(pixel(ctx)).toBe(DARK);
+	});
+
+	it("recolors path fills and strokes", () => {
+		const ctx = makeCtx();
+		applyContextRecolor(ctx, testMap);
+		ctx.fillStyle = "#000000";
+		ctx.beginPath();
+		ctx.rect(0, 0, 8, 8);
+		ctx.fill();
+		expect(pixel(ctx)).toBe(LIGHT);
+
+		ctx.strokeStyle = "#ffffff";
+		ctx.lineWidth = 8;
+		ctx.beginPath();
+		ctx.moveTo(0, 4);
+		ctx.lineTo(8, 4);
+		ctx.stroke();
+		expect(pixel(ctx)).toBe(DARK);
+	});
+
+	it("keeps readbacks in original colors (pdf.js copyCtxState contract)", () => {
+		const ctx = makeCtx();
+		applyContextRecolor(ctx, testMap);
+		ctx.fillStyle = "#ffffff";
+		ctx.fillRect(0, 0, 8, 8);
+		expect(ctx.fillStyle).toBe("#ffffff");
+
+		// state copied to a second wrapped context must map exactly once
+		const other = makeCtx();
+		applyContextRecolor(other, testMap);
+		other.fillStyle = ctx.fillStyle;
+		other.fillRect(0, 0, 8, 8);
+		expect(pixel(other)).toBe(DARK);
+	});
+
+	it("recolors gradient stops at creation", () => {
+		const ctx = makeCtx();
+		applyContextRecolor(ctx, testMap);
+		const gradient = ctx.createLinearGradient(0, 0, 8, 0);
+		gradient.addColorStop(0, "#ffffff");
+		gradient.addColorStop(1, "#ffffff");
+		ctx.fillStyle = gradient;
+		ctx.fillRect(0, 0, 8, 8);
+		expect(pixel(ctx)).toBe(DARK);
+	});
+
+	it("does not touch drawImage pixels", () => {
+		const source = makeCtx();
+		source.fillStyle = "#ffffff";
+		source.fillRect(0, 0, 8, 8);
+
+		const ctx = makeCtx();
+		applyContextRecolor(ctx, testMap);
+		ctx.drawImage(source.canvas, 0, 0);
+		expect(pixel(ctx)).toBe("#ffffff");
+	});
+
+	it("cleanup restores pristine behavior", () => {
+		const ctx = makeCtx();
+		const cleanup = applyContextRecolor(ctx, testMap);
+		cleanup();
+		ctx.fillStyle = "#ffffff";
+		ctx.fillRect(0, 0, 8, 8);
+		expect(pixel(ctx)).toBe("#ffffff");
+		expect(Object.hasOwn(ctx, "fill")).toBe(false);
+		expect(Object.hasOwn(ctx, "createLinearGradient")).toBe(false);
+	});
+
+	it("re-wrapping replaces the previous map; stale cleanup is a no-op", () => {
+		const ctx = makeCtx();
+		const cleanup1 = applyContextRecolor(ctx, () => "#ff0000");
+		const cleanup2 = applyContextRecolor(ctx, testMap);
+		cleanup1(); // superseded — must not unwrap
+		ctx.fillStyle = "#ffffff";
+		ctx.fillRect(0, 0, 8, 8);
+		expect(pixel(ctx)).toBe(DARK);
+		cleanup2();
+		ctx.fillRect(0, 0, 8, 8);
+		expect(pixel(ctx)).toBe("#ffffff");
+	});
+
+	it("maps the same color only once even when re-fed (background refill)", () => {
+		// pdf.js fills the canvas with the `background` render param through
+		// the wrapped fillRect; lector passes the ORIGINAL background, so a
+		// single mapping must land on the dark color, not roundtrip back.
+		const ctx = makeCtx();
+		applyContextRecolor(ctx, (c) => (c === "#ffffff" ? DARK : c));
+		const saved = ctx.fillStyle; // pdf.js beginDrawing saves
+		ctx.fillStyle = "#ffffff";
+		ctx.fillRect(0, 0, 8, 8);
+		ctx.fillStyle = saved; // and restores
+		expect(pixel(ctx)).toBe(DARK);
+		expect(ctx.fillStyle).toBe(saved);
+	});
+});

--- a/packages/lector/src/lib/recolor-context.test.ts
+++ b/packages/lector/src/lib/recolor-context.test.ts
@@ -169,6 +169,57 @@ describe("applyContextRecolor", () => {
 		}
 	});
 
+	it("does not luma-correct image-based masks (never-recolored pixels)", () => {
+		// An image-based luminosity mask reaches the mask canvas via drawImage
+		// and was never recolored — "un-mapping" it would invert its alpha.
+		const svgNS = "http://www.w3.org/2000/svg";
+		const svg = document.createElementNS(svgNS, "svg");
+		svg.setAttribute("width", "0");
+		svg.setAttribute("height", "0");
+		const filter = document.createElementNS(svgNS, "filter");
+		filter.setAttribute("id", "g_test_luminosity_map_1");
+		filter.setAttribute("color-interpolation-filters", "sRGB");
+		const matrix = document.createElementNS(svgNS, "feColorMatrix");
+		matrix.setAttribute("type", "matrix");
+		matrix.setAttribute(
+			"values",
+			"0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0.3 0.59 0.11 0 0",
+		);
+		filter.append(matrix);
+		svg.append(filter);
+		document.body.append(svg);
+
+		try {
+			const layer = makeCtx();
+			applyContextRecolor(layer, testMap);
+			layer.fillStyle = "#ff0000";
+			layer.fillRect(0, 0, 8, 8);
+
+			// White "image" mask drawn into a wrapped mask context via
+			// drawImage only — pixels stay white, nothing was recolored.
+			const image = makeCtx();
+			image.fillStyle = "#ffffff";
+			image.fillRect(0, 0, 8, 8);
+			const mask = makeCtx();
+			applyContextRecolor(mask, testMap);
+			mask.drawImage(image.canvas, 0, 0);
+			expect(pixel(mask)).toBe("#ffffff");
+
+			layer.save();
+			layer.filter = "url(#g_test_luminosity_map_1)";
+			layer.globalCompositeOperation = "destination-in";
+			layer.drawImage(mask.canvas, 0, 0);
+			layer.restore();
+
+			// Uncorrected white mask = luma 1 = fully visible. A wrongly
+			// applied correction would collapse alpha to ~0 instead.
+			const alpha = layer.getImageData(4, 4, 1, 1).data[3]!;
+			expect(alpha).toBeGreaterThan(230);
+		} finally {
+			svg.remove();
+		}
+	});
+
 	it("leaves ordinary drawImage compositing untouched", () => {
 		const source = makeCtx();
 		source.fillStyle = "#123456";

--- a/packages/lector/src/lib/recolor-context.test.ts
+++ b/packages/lector/src/lib/recolor-context.test.ts
@@ -115,6 +115,77 @@ describe("applyContextRecolor", () => {
 		expect(pixel(ctx)).toBe("#ffffff");
 	});
 
+	it("luma-corrects luminosity soft-mask composition (pdf.js destination-in)", () => {
+		// Reproduce pdf.js genericComposeSMask: mask drawn through a luminosity
+		// filter with destination-in, so mask luma becomes layer alpha. The
+		// mask art went through the recolor map (white -> dark), which without
+		// correction would invert the mask.
+		const svgNS = "http://www.w3.org/2000/svg";
+		const svg = document.createElementNS(svgNS, "svg");
+		svg.setAttribute("width", "0");
+		svg.setAttribute("height", "0");
+		const filter = document.createElementNS(svgNS, "filter");
+		// Mirrors pdf.js's generated id shape: g_<docId>_luminosity_map_<n>
+		filter.setAttribute("id", "g_test_luminosity_map_0");
+		filter.setAttribute("color-interpolation-filters", "sRGB");
+		const matrix = document.createElementNS(svgNS, "feColorMatrix");
+		matrix.setAttribute("type", "matrix");
+		matrix.setAttribute(
+			"values",
+			"0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0.3 0.59 0.11 0 0",
+		);
+		filter.append(matrix);
+		svg.append(filter);
+		document.body.append(svg);
+
+		try {
+			// Layer: fully opaque content, color untouched by the test map.
+			const layer = makeCtx();
+			applyContextRecolor(layer, testMap);
+			layer.fillStyle = "#ff0000";
+			layer.fillRect(0, 0, 8, 8);
+
+			// Mask: "fully visible" mask art = white, painted through the map
+			// (lands as the dark background color, luma ~0.1).
+			const mask = makeCtx();
+			applyContextRecolor(mask, testMap);
+			mask.fillStyle = "#ffffff";
+			mask.fillRect(0, 0, 8, 8);
+			expect(pixel(mask)).toBe(DARK);
+
+			layer.save();
+			layer.filter = "url(#g_test_luminosity_map_0)";
+			layer.globalCompositeOperation = "destination-in";
+			layer.drawImage(mask.canvas, 0, 0);
+			layer.restore();
+
+			// Corrected: mapped-white luma is restored to 255 before the
+			// filter, so alpha stays ~1 and the content survives. Without the
+			// correction alpha would collapse to ~0.1.
+			const alpha = layer.getImageData(4, 4, 1, 1).data[3]!;
+			expect(alpha).toBeGreaterThan(230);
+		} finally {
+			svg.remove();
+		}
+	});
+
+	it("leaves ordinary drawImage compositing untouched", () => {
+		const source = makeCtx();
+		source.fillStyle = "#123456";
+		source.fillRect(0, 0, 8, 8);
+
+		const ctx = makeCtx();
+		applyContextRecolor(ctx, testMap);
+		ctx.fillStyle = "#ff0000";
+		ctx.fillRect(0, 0, 8, 8);
+		// destination-in without a luminosity filter must not be corrected.
+		ctx.save();
+		ctx.globalCompositeOperation = "destination-in";
+		ctx.drawImage(source.canvas, 0, 0);
+		ctx.restore();
+		expect(pixel(ctx)).toBe("#ff0000");
+	});
+
 	it("maps the same color only once even when re-fed (background refill)", () => {
 		// pdf.js fills the canvas with the `background` render param through
 		// the wrapped fillRect; lector passes the ORIGINAL background, so a

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -15,13 +15,88 @@ const GRADIENT_METHODS = [
 	"createRadialGradient",
 ] as const;
 
+// NTSC weights — the same ones pdf.js's luminosity SVG filter uses.
+function ntscLuma(r: number, g: number, b: number): number {
+	return 0.3 * r + 0.59 * g + 0.11 * b;
+}
+
+function parseHexLuma(color: string): number | null {
+	if (!/^#[0-9a-f]{6}$/i.test(color)) return null;
+	return ntscLuma(
+		Number.parseInt(color.slice(1, 3), 16),
+		Number.parseInt(color.slice(3, 5), 16),
+		Number.parseInt(color.slice(5, 7), 16),
+	);
+}
+
+/**
+ * pdf.js composes a luminosity soft mask by drawing the mask canvas through
+ * a luminosity SVG filter with `destination-in`: pixel luma BECOMES alpha.
+ * The mask artwork was painted through the recolor map (white flipped to the
+ * dark background and vice versa), so its luma — and therefore the mask's
+ * alpha — would be inverted: visible content disappears, hidden content
+ * appears. This produces a copy of the mask with the neutral luma ramp
+ * un-mapped (mapped-white luma back to 255, mapped-black back to 0) for the
+ * filter to consume. Exact for neutral/binary masks; midtones land within a
+ * few percent (the OKLab ramp is not affine in luma). Pixels that reached
+ * the mask via drawImage (image-based masks) were never recolored, but
+ * correcting them too only re-grays content that is already grayscale by
+ * definition of a luminosity mask.
+ */
+function correctLuminosityMask(
+	source: CanvasImageSource,
+	mappedWhiteLuma: number,
+	mappedBlackLuma: number,
+): HTMLCanvasElement | null {
+	if (
+		!(source instanceof HTMLCanvasElement) &&
+		!(
+			typeof OffscreenCanvas !== "undefined" &&
+			source instanceof OffscreenCanvas
+		)
+	) {
+		return null;
+	}
+	const width = source.width;
+	const height = source.height;
+	if (!width || !height) return null;
+	const span = mappedWhiteLuma - mappedBlackLuma;
+	if (Math.abs(span) < 1) return null;
+
+	const tmp = document.createElement("canvas");
+	tmp.width = width;
+	tmp.height = height;
+	const tmpCtx = tmp.getContext("2d", { willReadFrequently: true });
+	if (!tmpCtx) return null;
+	tmpCtx.drawImage(source, 0, 0);
+	let image: ImageData;
+	try {
+		image = tmpCtx.getImageData(0, 0, width, height);
+	} catch {
+		return null;
+	}
+	const data = image.data;
+	for (let i = 0; i < data.length; i += 4) {
+		const luma = ntscLuma(data[i]!, data[i + 1]!, data[i + 2]!);
+		const t = (luma - mappedBlackLuma) / span;
+		const gray = t <= 0 ? 0 : t >= 1 ? 255 : Math.round(t * 255);
+		data[i] = data[i + 1] = data[i + 2] = gray;
+	}
+	tmpCtx.putImageData(image, 0, 0);
+	return tmp;
+}
+
 /**
  * Recolors a 2D context at draw time: every fill/stroke whose style is a
  * string is painted with `map(style)` and the original style is restored
  * right after, so pdf.js readbacks (`ctx.fillStyle`, `copyCtxState`,
  * save/restore) always observe original-document colors and nothing is ever
  * mapped twice. Gradients are recolored per stop at creation. `drawImage`
- * and `putImageData` are deliberately untouched — photos keep their pixels.
+ * and `putImageData` are deliberately untouched — photos keep their pixels —
+ * with one exception: a drawImage that composes a luminosity soft mask
+ * (destination-in through a pdf.js `*_luminosity_map_*` filter) draws a
+ * luma-corrected copy of the mask so the recoloring doesn't invert the
+ * mask's alpha.
  *
  * Wrapping installs own properties on the context instance (the prototype is
  * never modified). Returns a cleanup that restores the pristine context.
@@ -33,6 +108,33 @@ export function applyContextRecolor(
 	const target = ctx as RecolorableContext;
 	// Re-wrapping replaces the previous map instead of stacking wrappers.
 	target[RECOLOR_CLEANUP]?.();
+
+	// Luma poles of the map's neutral ramp, in pixel space: where pure white
+	// and pure black land after recoloring.
+	const mappedWhiteLuma = parseHexLuma(map("#ffffff"));
+	const mappedBlackLuma = parseHexLuma(map("#000000"));
+
+	const withMaskCorrection = (original: AnyFn) =>
+		function (this: CanvasRenderingContext2D, ...args: never[]): unknown {
+			if (
+				mappedWhiteLuma !== null &&
+				mappedBlackLuma !== null &&
+				this.globalCompositeOperation === "destination-in" &&
+				typeof this.filter === "string" &&
+				this.filter.includes("luminosity")
+			) {
+				const corrected = correctLuminosityMask(
+					args[0] as unknown as CanvasImageSource,
+					mappedWhiteLuma,
+					mappedBlackLuma,
+				);
+				if (corrected) {
+					const next = [corrected, ...args.slice(1)] as never[];
+					return original.apply(this, next);
+				}
+			}
+			return original.apply(this, args);
+		};
 
 	const withMappedStyle = (
 		original: AnyFn,
@@ -71,6 +173,7 @@ export function applyContextRecolor(
 		record[name] = withMappedStyle(target[name] as AnyFn, "strokeStyle");
 	for (const name of GRADIENT_METHODS)
 		record[name] = withMappedStops(target[name] as AnyFn);
+	record.drawImage = withMaskCorrection(target.drawImage as AnyFn);
 
 	const cleanup = () => {
 		// A later applyContextRecolor call already replaced these wrappers.
@@ -79,6 +182,7 @@ export function applyContextRecolor(
 			...FILL_METHODS,
 			...STROKE_METHODS,
 			...GRADIENT_METHODS,
+			"drawImage",
 		])
 			delete record[name];
 		delete target[RECOLOR_CLEANUP];

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -1,0 +1,88 @@
+import type { RenderColorMap } from "./dark-mode";
+
+const RECOLOR_CLEANUP = Symbol("lectorRecolorCleanup");
+
+type RecolorableContext = CanvasRenderingContext2D & {
+	[RECOLOR_CLEANUP]?: () => void;
+};
+
+type AnyFn = (this: CanvasRenderingContext2D, ...args: never[]) => unknown;
+
+const FILL_METHODS = ["fill", "fillRect", "fillText"] as const;
+const STROKE_METHODS = ["stroke", "strokeRect", "strokeText"] as const;
+const GRADIENT_METHODS = [
+	"createLinearGradient",
+	"createRadialGradient",
+] as const;
+
+/**
+ * Recolors a 2D context at draw time: every fill/stroke whose style is a
+ * string is painted with `map(style)` and the original style is restored
+ * right after, so pdf.js readbacks (`ctx.fillStyle`, `copyCtxState`,
+ * save/restore) always observe original-document colors and nothing is ever
+ * mapped twice. Gradients are recolored per stop at creation. `drawImage`
+ * and `putImageData` are deliberately untouched — photos keep their pixels.
+ *
+ * Wrapping installs own properties on the context instance (the prototype is
+ * never modified). Returns a cleanup that restores the pristine context.
+ */
+export function applyContextRecolor(
+	ctx: CanvasRenderingContext2D,
+	map: RenderColorMap,
+): () => void {
+	const target = ctx as RecolorableContext;
+	// Re-wrapping replaces the previous map instead of stacking wrappers.
+	target[RECOLOR_CLEANUP]?.();
+
+	const withMappedStyle = (
+		original: AnyFn,
+		styleProp: "fillStyle" | "strokeStyle",
+	) =>
+		function (this: CanvasRenderingContext2D, ...args: never[]): unknown {
+			const style = this[styleProp];
+			if (typeof style === "string") {
+				const mapped = map(style);
+				if (mapped !== style) {
+					this[styleProp] = mapped;
+					try {
+						return original.apply(this, args);
+					} finally {
+						this[styleProp] = style;
+					}
+				}
+			}
+			return original.apply(this, args);
+		};
+
+	const withMappedStops = (original: AnyFn) =>
+		function (this: CanvasRenderingContext2D, ...args: never[]): unknown {
+			const gradient = original.apply(this, args) as CanvasGradient;
+			const addColorStop = gradient.addColorStop.bind(gradient);
+			gradient.addColorStop = (offset: number, color: string) => {
+				addColorStop(offset, map(color));
+			};
+			return gradient;
+		};
+
+	const record = target as unknown as Record<string, unknown>;
+	for (const name of FILL_METHODS)
+		record[name] = withMappedStyle(target[name] as AnyFn, "fillStyle");
+	for (const name of STROKE_METHODS)
+		record[name] = withMappedStyle(target[name] as AnyFn, "strokeStyle");
+	for (const name of GRADIENT_METHODS)
+		record[name] = withMappedStops(target[name] as AnyFn);
+
+	const cleanup = () => {
+		// A later applyContextRecolor call already replaced these wrappers.
+		if (target[RECOLOR_CLEANUP] !== cleanup) return;
+		for (const name of [
+			...FILL_METHODS,
+			...STROKE_METHODS,
+			...GRADIENT_METHODS,
+		])
+			delete record[name];
+		delete target[RECOLOR_CLEANUP];
+	};
+	target[RECOLOR_CLEANUP] = cleanup;
+	return cleanup;
+}

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -54,8 +54,12 @@ function correctLuminosityMask(
 	mappedWhiteLuma: number,
 	mappedBlackLuma: number,
 ): HTMLCanvasElement | null {
+	if (typeof document === "undefined") return null;
 	if (
-		!(source instanceof HTMLCanvasElement) &&
+		!(
+			typeof HTMLCanvasElement !== "undefined" &&
+			source instanceof HTMLCanvasElement
+		) &&
 		!(
 			typeof OffscreenCanvas !== "undefined" &&
 			source instanceof OffscreenCanvas
@@ -134,7 +138,8 @@ export function applyContextRecolor(
 				// content; never-recolored sources (image-based masks) would
 				// get their alpha inverted by the correction instead.
 				const sourcePainted =
-					(source instanceof HTMLCanvasElement ||
+					((typeof HTMLCanvasElement !== "undefined" &&
+						source instanceof HTMLCanvasElement) ||
 						(typeof OffscreenCanvas !== "undefined" &&
 							source instanceof OffscreenCanvas)) &&
 					(source.getContext("2d") as RecolorableContext | null)?.[

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -1,9 +1,12 @@
 import type { RenderColorMap } from "./dark-mode";
 
 const RECOLOR_CLEANUP = Symbol("lectorRecolorCleanup");
+const RECOLOR_PAINTED = Symbol("lectorRecolorPainted");
 
 type RecolorableContext = CanvasRenderingContext2D & {
 	[RECOLOR_CLEANUP]?: () => void;
+	/** True once any draw on this context actually swapped a color. */
+	[RECOLOR_PAINTED]?: boolean;
 };
 
 type AnyFn = (this: CanvasRenderingContext2D, ...args: never[]) => unknown;
@@ -38,10 +41,13 @@ function parseHexLuma(color: string): number | null {
  * appears. This produces a copy of the mask with the neutral luma ramp
  * un-mapped (mapped-white luma back to 255, mapped-black back to 0) for the
  * filter to consume. Exact for neutral/binary masks; midtones land within a
- * few percent (the OKLab ramp is not affine in luma). Pixels that reached
- * the mask via drawImage (image-based masks) were never recolored, but
- * correcting them too only re-grays content that is already grayscale by
- * definition of a luminosity mask.
+ * few percent (the OKLab ramp is not affine in luma).
+ *
+ * Only called for mask canvases that actually painted recolored content
+ * (RECOLOR_PAINTED): the un-map ramp is itself an inversion, so applying it
+ * to never-recolored pixels — image-based masks, drawn via the untouched
+ * drawImage — would invert THEIR alpha instead. Masks mixing recolored
+ * vector art with images remain imperfect for the image part.
  */
 function correctLuminosityMask(
 	source: CanvasImageSource,
@@ -123,11 +129,20 @@ export function applyContextRecolor(
 				typeof this.filter === "string" &&
 				this.filter.includes("luminosity")
 			) {
-				const corrected = correctLuminosityMask(
-					args[0] as unknown as CanvasImageSource,
-					mappedWhiteLuma,
-					mappedBlackLuma,
-				);
+				const source = args[0] as unknown as CanvasImageSource;
+				// Un-map only masks whose context actually painted recolored
+				// content; never-recolored sources (image-based masks) would
+				// get their alpha inverted by the correction instead.
+				const sourcePainted =
+					(source instanceof HTMLCanvasElement ||
+						(typeof OffscreenCanvas !== "undefined" &&
+							source instanceof OffscreenCanvas)) &&
+					(source.getContext("2d") as RecolorableContext | null)?.[
+						RECOLOR_PAINTED
+					] === true;
+				const corrected = sourcePainted
+					? correctLuminosityMask(source, mappedWhiteLuma, mappedBlackLuma)
+					: null;
 				if (corrected) {
 					const next = [corrected, ...args.slice(1)] as never[];
 					return original.apply(this, next);
@@ -145,6 +160,7 @@ export function applyContextRecolor(
 			if (typeof style === "string") {
 				const mapped = map(style);
 				if (mapped !== style) {
+					(this as RecolorableContext)[RECOLOR_PAINTED] = true;
 					this[styleProp] = mapped;
 					try {
 						return original.apply(this, args);
@@ -160,8 +176,11 @@ export function applyContextRecolor(
 		function (this: CanvasRenderingContext2D, ...args: never[]): unknown {
 			const gradient = original.apply(this, args) as CanvasGradient;
 			const addColorStop = gradient.addColorStop.bind(gradient);
+			const context = this as RecolorableContext;
 			gradient.addColorStop = (offset: number, color: string) => {
-				addColorStop(offset, map(color));
+				const mapped = map(color);
+				if (mapped !== color) context[RECOLOR_PAINTED] = true;
+				addColorStop(offset, mapped);
 			};
 			return gradient;
 		};
@@ -186,7 +205,19 @@ export function applyContextRecolor(
 		])
 			delete record[name];
 		delete target[RECOLOR_CLEANUP];
+		delete target[RECOLOR_PAINTED];
 	};
 	target[RECOLOR_CLEANUP] = cleanup;
 	return cleanup;
+}
+
+/**
+ * Removes any recolor wrapper installed on the context. For long-lived
+ * contexts (the visible canvas in the no-buffer fallback, thumbnails) that
+ * are about to render in the light scheme: a still-pending dark render's
+ * deferred restore could otherwise leave its wrapper active across the
+ * scheme switch.
+ */
+export function removeContextRecolor(ctx: CanvasRenderingContext2D): void {
+	(ctx as RecolorableContext)[RECOLOR_CLEANUP]?.();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       next:
         specifier: ^15.5.18
         version: 15.5.18(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next-themes:
+        specifier: ^0.4.4
+        version: 0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       pdfjs-dist:
         specifier: ^5.5.207
         version: 5.5.207
@@ -2220,7 +2223,7 @@ packages:
   '@use-gesture/react@10.3.1':
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
-      react: '>= 16.8.0'
+      react: 19.2.4
 
   '@vitejs/plugin-react@4.3.4':
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}


### PR DESCRIPTION
## What

Native dark mode rendered at the PDF.js level: colors are remapped **inside the canvas pixels at render time**, replacing the CSS-filter recipe (`invert + hue-rotate + brightness + contrast`) the docs used to recommend.

```tsx
<Root source="/sample.pdf" colorScheme="dark">          {/* reactive prop */}
```

```tsx
const setColorScheme = usePdf((s) => s.setColorScheme);  // runtime toggle
setColorScheme("dark", { background: "#1e1e2e", foreground: "#cdd6f4" });
```

## Why not CSS filters

- **Images are left pixel-perfect** — photos are no longer inverted.
- **True hue preservation** — colors are remapped in OKLab: perceived lightness flips onto the background↔foreground ramp (position follows BT.709 luma, the same measure PSPDFKit/MuPDF luminance-inversion night modes use) while hue/chroma are kept. Red → pink (not cyan), blue links → light blue, grays pick up the palette tint.
- **Zero per-frame cost** — recoloring happens once at render; nothing for the compositor to re-evaluate during scroll/zoom.
- Selection and highlights composite against real dark pixels; thumbnails and the high-zoom detail layer follow the scheme automatically.

## How

- `lib/dark-mode.ts` — memoized OKLab color map (white ↦ palette background exactly, black ↦ foreground exactly; gamut-mapped via chroma reduction; full CSS color grammar supported through a scratch-canvas normalization fallback).
- `lib/recolor-context.ts` — wraps the 2D context handed to `page.render()`: fill/stroke styles are swapped only for the duration of each draw call, so pdf.js readbacks (`ctx.fillStyle`, `copyCtxState`, save/restore) always see original colors and nothing is ever mapped twice. Gradient stops are mapped at creation. `drawImage`/`putImageData` stay untouched, so images keep their pixels.
- `lib/recolor-canvas-factory.ts` — custom pdf.js `CanvasFactory` (via `getDocument`) extends recoloring to pdf.js-internal scratch canvases: transparency groups, soft masks, tiling/shading patterns, image-mask fills.
- **Luminosity soft masks**: pdf.js converts mask luma → alpha (`destination-in` through a luminosity SVG filter), so recolored mask art would invert the mask. The wrapper detects that exact compose and draws a luma-corrected copy of the mask — covered by an end-to-end test reproducing the pdf.js compose against a real SVG filter in Chrome.
- Store/API: `colorScheme` + `darkModeColors` props on `Root` (reactive), `setColorScheme`/`colorScheme`/`darkModeColors` on the `usePdf` store, `createDarkModeColorMap` exported so apps can recolor their own overlays consistently. Bitmap cache is keyed per scheme → toggling back and forth is instant (~35ms to first dark frame from cache).
- Docs: `dark-mode.mdx` rewritten; docs demos now drive `colorScheme` from `next-themes` instead of the filter chain (kept as a deprecated legacy section).

## Limitations (documented)

- DOM-rendered annotations (`AnnotationLayer` links/form widgets) keep original colors.
- Mesh-gradient shadings (rare) keep original colors.
- Scanned PDFs (whole page is one image) intentionally stay light.
- Consumer-supplied `CanvasFactory` via `documentOptions` disables scratch-canvas recoloring.

## Verification

- 24 unit tests in real Chrome (vitest browser mode): color math (poles, hue preservation, alpha, gamut, CSS grammar), context wrapper (readback contract, gradient stops, re-wrap/cleanup semantics, ordinary `drawImage` untouched), and the luminosity-mask compose end-to-end.
- Browser-verified in the example app: dark pixels land exactly on `#181a1b`, image regions byte-identical between schemes, light mode pixel-identical to `main`, no console errors; high-zoom detail layer and thumbnails follow the scheme.
- Multi-agent adversarial review over the diff (pdf.js internals, React/lifecycle, color math, API/docs dimensions); all confirmed findings fixed in follow-up commits, including the critical luminosity-soft-mask alpha inversion.
- `tsup` build + dts, biome, size-limit (42.9 KB / 150 KB) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Render native `colorScheme="dark"` PDF pixels
>
> - Adds native dark-mode API on `Root` via `colorScheme` and `darkModeColors`, plus `usePdf().setColorScheme`, store state, exported dark-mode types, `DEFAULT_DARK_MODE_COLORS`, and `createDarkModeColorMap`.
> - Implements render-time recoloring with `createDarkModeColorMap`, `applyContextRecolor`, and `createRecolorCanvasFactory`, mapping PDF vector colors onto a dark palette while leaving image pixels untouched and handling pdf.js scratch canvases/soft masks.
> - Updates base canvas, high-zoom detail canvas, thumbnails, page backgrounds, selections, and colored highlights to follow the active scheme, key bitmap cache entries by scheme, and avoid showing stale light/dark frames during toggles.
> - Replaces docs/example CSS inversion with native `colorScheme` wiring, including `next-themes` in docs demos and a dark-mode toggle in `examples/basic`.
> - Adds browser/unit coverage for dark-mode color mapping, context recoloring, gradients, image preservation, wrapper cleanup, and luminosity soft-mask composition.
> - Behavioral change: Passing `colorScheme="dark"` now renders PDF canvases, thumbnails, overlays, and detail layers as real dark pixels instead of relying on CSS inversion filters.
>
> <sup>[Leo](https://anara.com) summarized `fc57982`</sup>
<!-- leo:summary-end -->