### PR TITLE
perf(zoom): gate text-layer paint and detail renders during zoom gestures

### DIFF
--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -9,6 +9,8 @@ import { useDpr } from "../useDpr";
 import { usePDFPageNumber } from "../usePdfPageNumber";
 
 const DETAIL_RENDER_IDLE_MS = 80;
+// How long the live zoom must be stable before the detail pass may render.
+const ZOOM_SETTLE_MS = 250;
 
 export const useDetailCanvasLayer = ({
 	background,
@@ -30,6 +32,23 @@ export const useDetailCanvasLayer = ({
 	const viewportRef = usePdf((state) => state.viewportRef);
 
 	const [zoom] = useDebounce(bouncyZoom, 200);
+
+	// Track when the live zoom last changed so the render can wait out a
+	// multi-segment gesture (wheel pulses end the use-gesture pinch between
+	// segments, so `isPinching` alone lets a 100ms+ detail render fire
+	// mid-gesture).
+	// Seed so an idle mount renders immediately, but a layer mounting during
+	// an active pinch waits out the settle window. (A mount in the brief
+	// isPinching=false window between wheel pulses may render once and get
+	// cancelled by the next pulse — rare and bounded.)
+	const lastZoomChangeRef = useRef(
+		store.getState().isPinching ? performance.now() : 0,
+	);
+	const prevBouncyZoomRef = useRef(bouncyZoom);
+	if (prevBouncyZoomRef.current !== bouncyZoom) {
+		prevBouncyZoomRef.current = bouncyZoom;
+		lastZoomChangeRef.current = performance.now();
+	}
 
 	// Cache base viewport dimensions — they never change for a given page proxy.
 	const pageDimsRef = useRef<{
@@ -77,6 +96,18 @@ export const useDetailCanvasLayer = ({
 			// sharpening is invisible mid-scroll anyway. Poll until scroll settles.
 			const virtualizer = store.getState().virtualizer;
 			if (virtualizer?.isScrolling) {
+				scheduleRender(160);
+				return;
+			}
+
+			// Likewise, don't render between segments of a zoom gesture (wheel
+			// pulses, pinch pauses): the 100ms+ sharpening pass would land
+			// mid-gesture and be thrown away by the next zoom change anyway.
+			// Wait until the live zoom has been stable for a beat.
+			if (
+				store.getState().isPinching ||
+				performance.now() - lastZoomChangeRef.current < ZOOM_SETTLE_MS
+			) {
 				scheduleRender(160);
 				return;
 			}

--- a/packages/lector/src/hooks/layers/useTextLayer.tsx
+++ b/packages/lector/src/hooks/layers/useTextLayer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-import { usePdf } from "../../internal";
+import { PDFStore, usePdf } from "../../internal";
 import { subscribeToViewportInvalidation } from "../../lib/viewport-invalidation";
 import { usePDFPageNumber } from "../usePdfPageNumber";
 
@@ -218,6 +218,7 @@ export const useTextLayer = () => {
 	const pageNumber = usePDFPageNumber();
 	const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 	const viewportRef = usePdf((state) => state.viewportRef);
+	const store = PDFStore.useContext();
 
 	useEffect(() => {
 		const textContainer = textContainerRef.current;
@@ -386,11 +387,30 @@ export const useTextLayer = () => {
 			textContainer.style.visibility = "";
 		};
 
-		const onScroll = () => {
+		const restoreWhenSettled = () => {
+			settleTimer = null;
+			// A pinch can outlast the settle window with the zoom value clamped
+			// (no further zoom changes to re-arm the timer) — stay hidden until
+			// the gesture actually ends.
+			if (store.getState().isPinching) {
+				settleTimer = setTimeout(restoreWhenSettled, TEXT_SCROLL_SETTLE_MS);
+				return;
+			}
+			show();
+		};
+
+		const hideAndDebounce = () => {
+			// Never hide under an active drag-select (scroll-driven or
+			// zoom-driven) — the guard lives here so every hide trigger
+			// respects it.
 			if (selecting) return;
 			textContainer.style.visibility = "hidden";
 			if (settleTimer) clearTimeout(settleTimer);
-			settleTimer = setTimeout(show, TEXT_SCROLL_SETTLE_MS);
+			settleTimer = setTimeout(restoreWhenSettled, TEXT_SCROLL_SETTLE_MS);
+		};
+
+		const onScroll = () => {
+			hideAndDebounce();
 		};
 
 		const onPointerDown = () => {
@@ -431,6 +451,28 @@ export const useTextLayer = () => {
 			unsubscribe = subscribeToViewportInvalidation(scrollViewport, onScroll);
 		};
 		attachScrollSubscription();
+
+		// Zooming re-rasterizes every (transparent) span under the animating CSS
+		// transform, just like scrolling moves them — hide during zoom changes
+		// and active pinches too. Scroll re-anchoring during zoom only fires
+		// scroll events incidentally, so the scroll subscription alone misses
+		// most of the gesture.
+		const initialState = store.getState();
+		let prevZoom = initialState.zoom;
+		let prevPinching = initialState.isPinching;
+		// `subscribe` doesn't replay the current state — a layer mounting in the
+		// middle of an ongoing pinch must start hidden or it defeats the gating.
+		if (prevPinching) hideAndDebounce();
+		const unsubscribeStore = store.subscribe(
+			(state: ReturnType<typeof store.getState>) => {
+				const zoomChanged = state.zoom !== prevZoom;
+				const pinchStarted = state.isPinching && !prevPinching;
+				prevZoom = state.zoom;
+				prevPinching = state.isPinching;
+				if (zoomChanged || pinchStarted) hideAndDebounce();
+			},
+		);
+
 		document.addEventListener("pointerdown", onPointerDown, true);
 		document.addEventListener("pointerup", clearPointer, true);
 		document.addEventListener("pointercancel", clearPointer, true);
@@ -440,6 +482,7 @@ export const useTextLayer = () => {
 		return () => {
 			if (attachRaf !== null) cancelAnimationFrame(attachRaf);
 			unsubscribe?.();
+			unsubscribeStore();
 			document.removeEventListener("pointerdown", onPointerDown, true);
 			document.removeEventListener("pointerup", clearPointer, true);
 			document.removeEventListener("pointercancel", clearPointer, true);
@@ -448,7 +491,7 @@ export const useTextLayer = () => {
 			if (settleTimer) clearTimeout(settleTimer);
 			show();
 		};
-	}, [viewportRef]);
+	}, [viewportRef, store]);
 
 	return {
 		textContainerRef,


### PR DESCRIPTION
Follow-up to #134/#135/#136 — same family (layer work landing during interaction), zoom edition. Investigated on a production build with LoAF attribution + live A/B, like the scroll series.

## Problems (measured)

1. **Text layer repaints throughout the gesture.** The transparent text layer (selection/search only — visible text is on the canvas) re-rasterizes under the animating CSS transform on every zoom tick. The scroll-time visibility gating (#135) never engages: zoom fires scroll events only incidentally. Measured: hidden in just **10/32** samples during a pinch on a ~1,700-span doc.

2. **Detail-canvas sharpening fires mid-gesture.** Wheel pulses end the use-gesture pinch between segments, so the `isPinching` gate leaks; the 100ms+ visible-region render lands mid-gesture (130–230ms `Worker.onmessage` main-thread paint chunks) only to be thrown away by the next zoom change.

## Fixes (mirror the existing scroll gating)

- **`useTextLayer`**: subscribe to store `zoom`/`isPinching` changes and feed the same hide/settle machinery as scroll; restore is deferred while a pinch is still active (zoom can sit clamped with no further changes mid-gesture, so the timer alone isn't enough).
- **`useDetailCanvasLayer`**: track when the live (undebounced) zoom last changed and poll-defer `renderDetailCanvas` until it's been stable for `ZOOM_SETTLE_MS` (250ms), alongside the existing `isScrolling`/`isPinching` checks.

## Measured (dense journal PDF, fit-width ≈229%, ctrl+wheel in/out cycle)

| | before | after |
|---|---|---|
| text layer hidden during gesture | 10/32 samples | **32/32** |
| long frames (>40ms) per cycle | 4 | **1** |
| dropped frames | 3.1% | **1.3%** |
| post-settle canvas reallocations | 24 | **2** |
| sharpening passes mid-gesture | yes | **none** |

Text restores + is selectable on settle; scroll-path behavior regression-checked (builds still deferred, hide/restore + selection intact).

## Note for reviewers
Deliberately scoped to gating: the *cost* of the post-settle sharpening pass itself (main-thread `executeOperatorList` chunks) is being addressed separately (OffscreenCanvas work in `useCanvasLayer`). Also documented along the way: pdf.js's TextLayer measures on a DOM-**attached** hidden canvas, where `ctx.font`/`measureText` forces a full document style-recalc — pathological under large single-stylesheet prod builds (the codebase already notes ~6ms/call); that's why these gating fixes matter much more in production than in dev.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- leo:summary-start -->
> [!NOTE]
> ### Gate `useTextLayer` and detail canvas renders during `zoom` gestures
>
> - `useTextLayer` now subscribes to `PDFStore` zoom/`isPinching` changes so the transparent text layer is hidden during zoom gestures, not only incidental scroll invalidations.
> - Text-layer restore now waits for the pinch to actually end before showing again, while keeping the existing guard that avoids hiding during active drag selection.
> - `useDetailCanvasLayer` tracks live `bouncyZoom` changes and defers `renderDetailCanvas` until zoom has been stable for `ZOOM_SETTLE_MS` (`250ms`) and no pinch is active.
> - Author-measured zoom results improved text-layer hiding during the gesture `10/32→32/32`, long frames `4→1`, dropped frames `3.1%→1.3%`, and eliminated mid-gesture sharpening passes.
> - Behavioral change: During zoom gestures, text-layer restoration and detail-canvas sharpening are deferred until the gesture settles.
>
> <sup>[Leo](https://anara.com) summarized `a35430d`</sup>
<!-- leo:summary-end -->