### PR TITLE
fix: sharp rendering during scroll and zoom — DPR tracking, base canvas at dpr×zoom, overscanned detail layer

### DIFF
--- a/packages/lector/src/components/pages.tsx
+++ b/packages/lector/src/components/pages.tsx
@@ -125,6 +125,12 @@ export const Pages = ({
 		scrollToFn,
 		gap,
 		initialOffset: initialOffset,
+		// Never trust scrollend alone to reset isScrolling: a single missed
+		// event (a documented browser flake — TanStack flipped this default to
+		// false in later 3.x) would pin isScrolling=true forever, and every
+		// consumer gated on it (text layer, detail canvas) would stop painting.
+		// false keeps the isScrollingResetDelay debounce active as a fallback.
+		useScrollendEvent: false,
 	});
 
 	useEffect(() => {

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -4,7 +4,10 @@ import {
 	usePDFDocumentContext,
 	type usePDFDocumentParams,
 } from "../hooks/document/document";
-import { clearBitmapCache } from "../hooks/layers/useCanvasLayer";
+import {
+	clearBitmapCache,
+	getDocumentCacheId,
+} from "../hooks/layers/useCanvasLayer";
 import {
 	PDFLinkServiceContext,
 	useCreatePDFLinkService,
@@ -112,12 +115,13 @@ export const Root = forwardRef(
 		// Key the cleanup on the proxy identity, not the fingerprint: two
 		// fingerprint-less documents in a row would otherwise look identical
 		// to the effect (both undefined) and the first one's cache bucket
-		// ("" — the canvas layer's fallback docId) would never be cleared,
-		// pinning its bitmaps and page proxies.
+		// would never be cleared, pinning its bitmaps and page proxies.
+		// getDocumentCacheId also gives each fingerprint-less document its own
+		// bucket, so clearing one viewer never evicts another's entries.
 		const pdfDocumentProxy = initialState?.pdfDocumentProxy ?? null;
 		useEffect(() => {
 			if (!pdfDocumentProxy) return;
-			const documentId = pdfDocumentProxy.fingerprints?.[0] ?? "";
+			const documentId = getDocumentCacheId(pdfDocumentProxy);
 			return () => {
 				clearBitmapCache(documentId);
 			};

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -109,17 +109,19 @@ export const Root = forwardRef(
 			initialState?.pdfDocumentProxy ?? null,
 		);
 
-		const documentId = initialState?.pdfDocumentProxy?.fingerprints?.[0];
-		const hasDocument = !!initialState;
+		// Key the cleanup on the proxy identity, not the fingerprint: two
+		// fingerprint-less documents in a row would otherwise look identical
+		// to the effect (both undefined) and the first one's cache bucket
+		// ("" — the canvas layer's fallback docId) would never be cleared,
+		// pinning its bitmaps and page proxies.
+		const pdfDocumentProxy = initialState?.pdfDocumentProxy ?? null;
 		useEffect(() => {
-			if (!hasDocument) return;
+			if (!pdfDocumentProxy) return;
+			const documentId = pdfDocumentProxy.fingerprints?.[0] ?? "";
 			return () => {
-				// Documents without a fingerprint cache under "" (the canvas
-				// layer's fallback docId) — clear that bucket too, or their
-				// bitmaps and the page proxies they pin outlive the document.
-				clearBitmapCache(documentId ?? "");
+				clearBitmapCache(documentId);
 			};
-		}, [documentId, hasDocument]);
+		}, [pdfDocumentProxy]);
 
 		return (
 			<Primitive.div ref={ref} {...props}>

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -112,20 +112,23 @@ export const Root = forwardRef(
 			initialState?.pdfDocumentProxy ?? null,
 		);
 
-		// Key the cleanup on the proxy identity, not the fingerprint: two
-		// fingerprint-less documents in a row would otherwise look identical
-		// to the effect (both undefined) and the first one's cache bucket
-		// would never be cleared, pinning its bitmaps and page proxies.
-		// getDocumentCacheId also gives each fingerprint-less document its own
-		// bucket, so clearing one viewer never evicts another's entries.
+		// Key the cleanup on the cache id, not the proxy identity: reloading
+		// the SAME document yields a new proxy with the same fingerprint, and
+		// a proxy-keyed cleanup would clear the bucket the new document's
+		// layers just populated. Same-id swaps leave the old proxies' dead
+		// entries to the byte-budget LRU instead. getDocumentCacheId gives
+		// fingerprint-less documents their own synthetic bucket, so distinct
+		// documents (and viewers) never clear each other.
 		const pdfDocumentProxy = initialState?.pdfDocumentProxy ?? null;
+		const documentId = pdfDocumentProxy
+			? getDocumentCacheId(pdfDocumentProxy)
+			: null;
 		useEffect(() => {
-			if (!pdfDocumentProxy) return;
-			const documentId = getDocumentCacheId(pdfDocumentProxy);
+			if (!documentId) return;
 			return () => {
 				clearBitmapCache(documentId);
 			};
-		}, [pdfDocumentProxy]);
+		}, [documentId]);
 
 		return (
 			<Primitive.div ref={ref} {...props}>

--- a/packages/lector/src/components/root.tsx
+++ b/packages/lector/src/components/root.tsx
@@ -110,12 +110,16 @@ export const Root = forwardRef(
 		);
 
 		const documentId = initialState?.pdfDocumentProxy?.fingerprints?.[0];
+		const hasDocument = !!initialState;
 		useEffect(() => {
-			if (!documentId) return;
+			if (!hasDocument) return;
 			return () => {
-				clearBitmapCache(documentId);
+				// Documents without a fingerprint cache under "" (the canvas
+				// layer's fallback docId) — clear that bucket too, or their
+				// bitmaps and the page proxies they pin outlive the document.
+				clearBitmapCache(documentId ?? "");
 			};
-		}, [documentId]);
+		}, [documentId, hasDocument]);
 
 		return (
 			<Primitive.div ref={ref} {...props}>

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -42,6 +42,26 @@ const cacheEntries: CacheEntry[] = [];
 const canvasBitmapCache = new WeakMap<PDFPageProxy, Map<number, ImageBitmap>>();
 let cacheBytes = 0;
 
+// Fingerprint-less documents get a unique synthetic cache id, so two of
+// them mounted at once never share a bucket (clearing one viewer's cache
+// must not evict the other's bitmaps).
+const documentIdFallbacks = new WeakMap<object, string>();
+let documentIdCounter = 0;
+
+export function getDocumentCacheId(pdfDocumentProxy: {
+	fingerprints?: (string | null)[];
+}): string {
+	const fingerprint = pdfDocumentProxy.fingerprints?.[0];
+	if (fingerprint) return fingerprint;
+	let id = documentIdFallbacks.get(pdfDocumentProxy);
+	if (!id) {
+		documentIdCounter += 1;
+		id = `anonymous-document-${documentIdCounter}`;
+		documentIdFallbacks.set(pdfDocumentProxy, id);
+	}
+	return id;
+}
+
 function evictEntryAt(index: number): void {
 	const [entry] = cacheEntries.splice(index, 1);
 	if (!entry) return;
@@ -158,7 +178,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 	const bouncyZoom = usePdf((state) => state.zoom);
 	const isResizing = usePdf((state) => state.isResizing);
 	const isPinching = usePdf((state) => state.isPinching);
-	const docId = usePdf((state) => state.pdfDocumentProxy.fingerprints[0] ?? "");
+	const docId = usePdf((state) => getDocumentCacheId(state.pdfDocumentProxy));
 	const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 	const markPageRendered = usePdf((state) => state.markPageRendered);
 	const unmarkPageRendered = usePdf((state) => state.unmarkPageRendered);
@@ -190,9 +210,15 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 
 		// When neither the backing scale nor the scheme changed (gesture-flag
 		// flips, scheme-unchanged re-runs, budget-clamped zooms that resolve
-		// to the same scale) there is nothing to do — and touching
-		// canvas.width would clear the bitmap.
+		// to the same scale) the bitmap can be kept — touching canvas.width
+		// would clear it. The CSS geometry still tracks the current zoom
+		// (style writes don't clear the canvas): budget-clamped zooms share a
+		// scale, and a stale inverse factor would leave the net transform at
+		// zoomNew/zoomOld instead of identity.
 		if (hasCurrentFrame && paintedRef.current?.scale === baseScale) {
+			baseCanvas.style.width = `${pageWidth * zoom}px`;
+			baseCanvas.style.height = `${pageHeight * zoom}px`;
+			baseCanvas.style.transform = `scale3d(${1 / zoom},${1 / zoom},1)`;
 			return;
 		}
 

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -227,7 +227,18 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		const backingHeight = Math.floor(pageHeight * baseScale);
 
 		const context = baseCanvas.getContext("2d");
-		if (!context) return;
+		if (!context) {
+			// Context allocation failed (canvas memory pressure). If the canvas
+			// shows another page's or scheme's pixels, blank it — wrong content
+			// is worse than a hidden canvas. A matching frame can stay.
+			if (!hasCurrentFrame) {
+				paintedRef.current = null;
+				baseCanvas.width = backingWidth;
+				baseCanvas.height = backingHeight;
+				baseCanvas.style.visibility = "hidden";
+			}
+			return;
+		}
 
 		const applyBackingSize = () => {
 			// Assigning width/height clears the canvas, even to the same value.

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -208,6 +208,30 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 			paintedRef.current?.proxy === pdfPageProxy &&
 			paintedRef.current?.key === contentKey;
 
+		// Inverse-scale trick (same as the detail overlay): at zoom != 1 the
+		// canvas is laid out at zoom-scaled size and counter-scaled by 1/zoom,
+		// so its NET transform under the stack's scale3d(zoom) is identity —
+		// net page-coordinate extent is (pageWidth*zoom)/zoom = pageWidth for
+		// any zoom, so geometry stays exact even when a stale frame is shown
+		// under a different live zoom.
+		// At EXACTLY zoom 1 we instead emit the legacy 2D identity transform:
+		// a scale3d — even identity — forces the canvas onto its own
+		// GPU-sampled compositor layer in WebKit, which visibly softens
+		// native 1:1 content (verified via a pipeline matrix on real Safari);
+		// a 2D translate(0,0) keeps it in the page raster, pixel-snapped.
+		const applyGeometry = () => {
+			if (zoom === 1) {
+				baseCanvas.style.width = `${pageWidth}px`;
+				baseCanvas.style.height = `${pageHeight}px`;
+				baseCanvas.style.transform = "translate(0px, 0px)";
+			} else {
+				baseCanvas.style.width = `${pageWidth * zoom}px`;
+				baseCanvas.style.height = `${pageHeight * zoom}px`;
+				baseCanvas.style.transform = `scale3d(${1 / zoom},${1 / zoom},1)`;
+				baseCanvas.style.transformOrigin = "0 0";
+			}
+		};
+
 		// When neither the backing scale nor the scheme changed (gesture-flag
 		// flips, scheme-unchanged re-runs, budget-clamped zooms that resolve
 		// to the same scale) the bitmap can be kept — touching canvas.width
@@ -216,9 +240,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		// scale, and a stale inverse factor would leave the net transform at
 		// zoomNew/zoomOld instead of identity.
 		if (hasCurrentFrame && paintedRef.current?.scale === baseScale) {
-			baseCanvas.style.width = `${pageWidth * zoom}px`;
-			baseCanvas.style.height = `${pageHeight * zoom}px`;
-			baseCanvas.style.transform = `scale3d(${1 / zoom},${1 / zoom},1)`;
+			applyGeometry();
 			return;
 		}
 
@@ -235,23 +257,10 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 
 		// CSS-only writes — never touch the backing store here, a same-scheme
 		// previous frame may still be on display while the new one renders.
-		//
-		// Inverse-scale trick (same as the detail overlay): the canvas is laid
-		// out at zoom-scaled size and counter-scaled by 1/zoom, so its NET
-		// transform under the stack's scale3d(zoom) is identity. Safari samples
-		// canvases under a non-identity composited scale with unsnapped
-		// bilinear filtering — visibly soft text even at a 1:1 pixel ratio —
-		// while ~identity-transformed layers get pixel-snapped and stay crisp.
-		// Net page-coordinate extent is (pageWidth*zoom)/zoom = pageWidth for
-		// any zoom, so geometry stays exact even when a stale frame is shown
-		// under a different live zoom.
 		baseCanvas.style.position = "absolute";
 		baseCanvas.style.top = "0";
 		baseCanvas.style.left = "0";
-		baseCanvas.style.width = `${pageWidth * zoom}px`;
-		baseCanvas.style.height = `${pageHeight * zoom}px`;
-		baseCanvas.style.transform = `scale3d(${1 / zoom},${1 / zoom},1)`;
-		baseCanvas.style.transformOrigin = "0 0";
+		applyGeometry();
 		baseCanvas.style.zIndex = "0";
 		baseCanvas.style.pointerEvents = "none";
 		// In dark mode the painted pixels get the mapped background (pdf.js

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -219,15 +219,19 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		// GPU-sampled compositor layer in WebKit, which visibly softens
 		// native 1:1 content (verified via a pipeline matrix on real Safari);
 		// a 2D translate(0,0) keeps it in the page raster, pixel-snapped.
+		// Floored like computeTargetScale: a degenerate zoom (0/NaN from a bad
+		// initial prop) must not become scale3d(Infinity)/NaN CSS here while
+		// the backing scale was safely clamped.
+		const geometryZoom = Math.max(Number.isFinite(zoom) ? zoom : 0, 0.01);
 		const applyGeometry = () => {
-			if (zoom === 1) {
+			if (geometryZoom === 1) {
 				baseCanvas.style.width = `${pageWidth}px`;
 				baseCanvas.style.height = `${pageHeight}px`;
 				baseCanvas.style.transform = "translate(0px, 0px)";
 			} else {
-				baseCanvas.style.width = `${pageWidth * zoom}px`;
-				baseCanvas.style.height = `${pageHeight * zoom}px`;
-				baseCanvas.style.transform = `scale3d(${1 / zoom},${1 / zoom},1)`;
+				baseCanvas.style.width = `${pageWidth * geometryZoom}px`;
+				baseCanvas.style.height = `${pageHeight * geometryZoom}px`;
+				baseCanvas.style.transform = `scale3d(${1 / geometryZoom},${1 / geometryZoom},1)`;
 				baseCanvas.style.transformOrigin = "0 0";
 			}
 		};

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -188,9 +188,10 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 			paintedRef.current?.proxy === pdfPageProxy &&
 			paintedRef.current?.key === contentKey;
 
-		// Zoom quantization maps many debounced zoom values onto one backing
-		// scale — when neither the scale nor the scheme changed there is
-		// nothing to do, and touching canvas.width would clear the bitmap.
+		// When neither the backing scale nor the scheme changed (gesture-flag
+		// flips, scheme-unchanged re-runs, budget-clamped zooms that resolve
+		// to the same scale) there is nothing to do — and touching
+		// canvas.width would clear the bitmap.
 		if (hasCurrentFrame && paintedRef.current?.scale === baseScale) {
 			return;
 		}

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -199,22 +199,33 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		// Mid-gesture (fit-width resize drag, pinch), reuse the painted frame
 		// via CSS — the stack transform scales it coherently — and re-render
 		// once the gesture settles. Only valid when the frame matches the
-		// current scheme/background, else we'd show stale colors.
+		// current scheme/background, else we'd show stale colors. Geometry
+		// styles are left untouched: the inverse-scale scheme below keeps the
+		// canvas page-glued at any live zoom.
 		if ((isResizing || isPinching) && hasCurrentFrame) {
 			baseCanvas.style.visibility = "";
-			baseCanvas.style.width = `${pageWidth}px`;
-			baseCanvas.style.height = `${pageHeight}px`;
 			return;
 		}
 
 		// CSS-only writes — never touch the backing store here, a same-scheme
 		// previous frame may still be on display while the new one renders.
+		//
+		// Inverse-scale trick (same as the detail overlay): the canvas is laid
+		// out at zoom-scaled size and counter-scaled by 1/zoom, so its NET
+		// transform under the stack's scale3d(zoom) is identity. Safari samples
+		// canvases under a non-identity composited scale with unsnapped
+		// bilinear filtering — visibly soft text even at a 1:1 pixel ratio —
+		// while ~identity-transformed layers get pixel-snapped and stay crisp.
+		// Net page-coordinate extent is (pageWidth*zoom)/zoom = pageWidth for
+		// any zoom, so geometry stays exact even when a stale frame is shown
+		// under a different live zoom.
 		baseCanvas.style.position = "absolute";
 		baseCanvas.style.top = "0";
 		baseCanvas.style.left = "0";
-		baseCanvas.style.width = `${pageWidth}px`;
-		baseCanvas.style.height = `${pageHeight}px`;
-		baseCanvas.style.transform = "translate(0px, 0px)";
+		baseCanvas.style.width = `${pageWidth * zoom}px`;
+		baseCanvas.style.height = `${pageHeight * zoom}px`;
+		baseCanvas.style.transform = `scale3d(${1 / zoom},${1 / zoom},1)`;
+		baseCanvas.style.transformOrigin = "0 0";
 		baseCanvas.style.zIndex = "0";
 		baseCanvas.style.pointerEvents = "none";
 		// In dark mode the painted pixels get the mapped background (pdf.js

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useLayoutEffect, useRef } from "react";
 import { useDebounce } from "use-debounce";
 
 import { PDFStore, usePdf } from "../../internal";
-import { computeBaseScale } from "../../lib/canvas-utils";
+import { computeBaseScale, IS_MOBILE_DEVICE } from "../../lib/canvas-utils";
 import { createDarkModeColorMap } from "../../lib/dark-mode";
 import {
 	applyContextRecolor,
@@ -14,20 +14,19 @@ import { usePDFPageNumber } from "../usePdfPageNumber";
 
 const CACHE_MAX_ENTRIES = 60;
 
-// Coarse mobile detection (pdf.js pattern — iPads report MacIntel but expose
-// maxTouchPoints > 1). Mobile budgets are conservative because canvases count
-// toward the page's jetsam memory limit on iOS.
-const IS_MOBILE =
-	typeof navigator !== "undefined" &&
-	(navigator.maxTouchPoints > 1 || /Android/i.test(navigator.userAgent));
-
 // The cache is budgeted in BYTES, not entries: entries vary from ~2MB
 // (fit-width letter page) to ~64MB (budget-clamped high-zoom page), so an
-// entry count alone can pin hundreds of MB of ImageBitmaps.
-const CACHE_MAX_BYTES = (IS_MOBILE ? 64 : 192) * 1024 * 1024;
+// entry count alone can pin hundreds of MB of ImageBitmaps. Mobile budgets
+// are conservative because canvases count toward the page's jetsam memory
+// limit on iOS.
+const CACHE_MAX_BYTES = (IS_MOBILE_DEVICE ? 64 : 192) * 1024 * 1024;
 // A single bitmap near the budget would evict most of the cache for one
-// entry — frames that big are cheaper to re-render than to cache.
-const CACHE_MAX_ENTRY_BYTES = CACHE_MAX_BYTES / 4;
+// entry — frames that big are cheaper to re-render than to cache. The
+// mobile divisor must leave room for a letter/A4 page at dpr 3 (~17.5MB),
+// the everyday frame on the phones the cache exists for.
+const CACHE_MAX_ENTRY_BYTES = IS_MOBILE_DEVICE
+	? CACHE_MAX_BYTES / 3
+	: CACHE_MAX_BYTES / 4;
 // Old scales/schemes of the same page are near-duplicates; keep only the
 // most recent few so a zoom session doesn't fill the cache with one page.
 const MAX_VARIANTS_PER_PROXY = 2;
@@ -424,6 +423,11 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 				canvas.width = 0;
 				canvas.height = 0;
 			}
+			// Keep the "paintedRef non-null implies the canvas holds that
+			// frame" invariant — under StrictMode this cleanup runs on a
+			// simulated unmount and the component lives on with the same refs;
+			// without this the no-op early return would keep a blank canvas.
+			paintedRef.current = null;
 		};
 	}, [pageNumber, unmarkPageRendered]);
 

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useLayoutEffect, useRef } from "react";
 import { useDebounce } from "use-debounce";
 
 import { PDFStore, usePdf } from "../../internal";
-import { clampScaleForPage } from "../../lib/canvas-utils";
+import { computeBaseScale } from "../../lib/canvas-utils";
 import { createDarkModeColorMap } from "../../lib/dark-mode";
 import {
 	applyContextRecolor,
@@ -12,32 +12,53 @@ import {
 import { useDpr } from "../useDpr";
 import { usePDFPageNumber } from "../usePdfPageNumber";
 
-const CACHE_MAX = 60;
+const CACHE_MAX_ENTRIES = 60;
+
+// Coarse mobile detection (pdf.js pattern — iPads report MacIntel but expose
+// maxTouchPoints > 1). Mobile budgets are conservative because canvases count
+// toward the page's jetsam memory limit on iOS.
+const IS_MOBILE =
+	typeof navigator !== "undefined" &&
+	(navigator.maxTouchPoints > 1 || /Android/i.test(navigator.userAgent));
+
+// The cache is budgeted in BYTES, not entries: entries vary from ~2MB
+// (fit-width letter page) to ~64MB (budget-clamped high-zoom page), so an
+// entry count alone can pin hundreds of MB of ImageBitmaps.
+const CACHE_MAX_BYTES = (IS_MOBILE ? 64 : 192) * 1024 * 1024;
+// A single bitmap near the budget would evict most of the cache for one
+// entry — frames that big are cheaper to re-render than to cache.
+const CACHE_MAX_ENTRY_BYTES = CACHE_MAX_BYTES / 4;
+// Old scales/schemes of the same page are near-duplicates; keep only the
+// most recent few so a zoom session doesn't fill the cache with one page.
+const MAX_VARIANTS_PER_PROXY = 2;
 
 type CacheEntry = {
 	docId: string;
 	proxy: PDFPageProxy;
 	key: number;
 	bitmap: ImageBitmap;
+	bytes: number;
 };
 const cacheEntries: CacheEntry[] = [];
 const canvasBitmapCache = new WeakMap<PDFPageProxy, Map<number, ImageBitmap>>();
+let cacheBytes = 0;
+
+function evictEntryAt(index: number): void {
+	const [entry] = cacheEntries.splice(index, 1);
+	if (!entry) return;
+	cacheBytes -= entry.bytes;
+	const map = canvasBitmapCache.get(entry.proxy);
+	if (map?.get(entry.key) === entry.bitmap) {
+		map.delete(entry.key);
+	}
+	entry.bitmap.close();
+}
 
 export function clearBitmapCache(documentId?: string): void {
-	if (documentId === undefined) {
-		for (const entry of cacheEntries) {
-			entry.bitmap.close();
-			canvasBitmapCache.get(entry.proxy)?.delete(entry.key);
-		}
-		cacheEntries.length = 0;
-		return;
-	}
 	for (let i = cacheEntries.length - 1; i >= 0; i--) {
-		const entry = cacheEntries[i]!;
-		if (entry.docId !== documentId) continue;
-		entry.bitmap.close();
-		canvasBitmapCache.get(entry.proxy)?.delete(entry.key);
-		cacheEntries.splice(i, 1);
+		if (documentId === undefined || cacheEntries[i]!.docId === documentId) {
+			evictEntryAt(i);
+		}
 	}
 }
 
@@ -79,38 +100,57 @@ function setCachedBitmap(
 	recolorKey: string | undefined,
 	bitmap: ImageBitmap,
 ): void {
+	const bytes = bitmap.width * bitmap.height * 4;
+	if (bytes > CACHE_MAX_ENTRY_BYTES) {
+		bitmap.close();
+		return;
+	}
 	const key = cacheKey(scale, background, recolorKey);
+	const existingIdx = cacheEntries.findIndex(
+		(e) => e.proxy === proxy && e.key === key,
+	);
+	if (existingIdx !== -1) {
+		if (cacheEntries[existingIdx]!.bitmap === bitmap) return;
+		evictEntryAt(existingIdx);
+	}
 	let map = canvasBitmapCache.get(proxy);
 	if (!map) {
 		map = new Map();
 		canvasBitmapCache.set(proxy, map);
 	}
-	const existing = map.get(key);
-	if (existing && existing !== bitmap) {
-		existing.close();
-		const idx = cacheEntries.findIndex(
-			(e) => e.proxy === proxy && e.key === key,
-		);
-		if (idx !== -1) cacheEntries.splice(idx, 1);
-	}
 	map.set(key, bitmap);
-	cacheEntries.push({ docId, proxy, key, bitmap });
+	cacheEntries.push({ docId, proxy, key, bitmap, bytes });
+	cacheBytes += bytes;
 
-	while (cacheEntries.length > CACHE_MAX) {
-		const evicted = cacheEntries.shift()!;
-		const evictedMap = canvasBitmapCache.get(evicted.proxy);
-		if (evictedMap?.get(evicted.key) === evicted.bitmap) {
-			evictedMap.delete(evicted.key);
-			evicted.bitmap.close();
+	// Trim stale variants of this page (older scales/schemes), newest first.
+	let variants = 0;
+	for (let i = cacheEntries.length - 1; i >= 0; i--) {
+		if (cacheEntries[i]!.proxy !== proxy) continue;
+		variants++;
+		if (variants > MAX_VARIANTS_PER_PROXY) {
+			evictEntryAt(i);
 		}
+	}
+
+	while (
+		cacheEntries.length > 0 &&
+		(cacheEntries.length > CACHE_MAX_ENTRIES || cacheBytes > CACHE_MAX_BYTES)
+	) {
+		evictEntryAt(0);
 	}
 }
 
 export const useCanvasLayer = ({ background }: { background?: string }) => {
 	const canvasRef = useRef<HTMLCanvasElement | null>(null);
-	// Key (background|scheme) the currently painted frame was rendered with,
-	// or null when the canvas holds no content.
-	const paintedKeyRef = useRef<string | null>(null);
+	// What the visible canvas currently shows — page proxy, scheme/background
+	// key, and the backing scale it was rendered at — or null when it holds no
+	// content. The proxy guards against a recycled component showing another
+	// page's frame.
+	const paintedRef = useRef<{
+		proxy: PDFPageProxy;
+		key: string;
+		scale: number;
+	} | null>(null);
 	const pageNumber = usePDFPageNumber();
 	const store = PDFStore.useContext();
 
@@ -118,6 +158,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 
 	const bouncyZoom = usePdf((state) => state.zoom);
 	const isResizing = usePdf((state) => state.isResizing);
+	const isPinching = usePdf((state) => state.isPinching);
 	const docId = usePdf((state) => state.pdfDocumentProxy.fingerprints[0] ?? "");
 	const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 	const markPageRendered = usePdf((state) => state.markPageRendered);
@@ -143,25 +184,31 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		const pageHeight = baseViewport.height;
 
 		const contentKey = `${background ?? "white"}|${recolorKey ?? ""}`;
+		const baseScale = computeBaseScale(dpr, zoom, pageWidth, pageHeight);
+		const hasCurrentFrame =
+			paintedRef.current?.proxy === pdfPageProxy &&
+			paintedRef.current?.key === contentKey;
 
-		// Mid-resize, reuse the painted frame via CSS — but only if one exists
-		// AND it was painted with the current scheme/background, else we'd
-		// un-hide a cleared canvas (blank for the drag) or show stale colors
-		// after a theme toggle that lands during the resize.
-		if (isResizing && paintedKeyRef.current === contentKey) {
+		// Zoom quantization maps many debounced zoom values onto one backing
+		// scale — when neither the scale nor the scheme changed there is
+		// nothing to do, and touching canvas.width would clear the bitmap.
+		if (hasCurrentFrame && paintedRef.current?.scale === baseScale) {
+			return;
+		}
+
+		// Mid-gesture (fit-width resize drag, pinch), reuse the painted frame
+		// via CSS — the stack transform scales it coherently — and re-render
+		// once the gesture settles. Only valid when the frame matches the
+		// current scheme/background, else we'd show stale colors.
+		if ((isResizing || isPinching) && hasCurrentFrame) {
 			baseCanvas.style.visibility = "";
 			baseCanvas.style.width = `${pageWidth}px`;
 			baseCanvas.style.height = `${pageHeight}px`;
 			return;
 		}
 
-		paintedKeyRef.current = null;
-
-		const targetBaseScale = dpr * Math.min(zoom, 1);
-		const baseScale = clampScaleForPage(targetBaseScale, pageWidth, pageHeight);
-
-		baseCanvas.width = Math.floor(pageWidth * baseScale);
-		baseCanvas.height = Math.floor(pageHeight * baseScale);
+		// CSS-only writes — never touch the backing store here, a same-scheme
+		// previous frame may still be on display while the new one renders.
 		baseCanvas.style.position = "absolute";
 		baseCanvas.style.top = "0";
 		baseCanvas.style.left = "0";
@@ -176,10 +223,18 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		baseCanvas.style.backgroundColor = recolor
 			? recolor(background ?? "#ffffff")
 			: (background ?? "white");
-		baseCanvas.style.visibility = "";
+
+		const backingWidth = Math.floor(pageWidth * baseScale);
+		const backingHeight = Math.floor(pageHeight * baseScale);
 
 		const context = baseCanvas.getContext("2d");
 		if (!context) return;
+
+		const applyBackingSize = () => {
+			// Assigning width/height clears the canvas, even to the same value.
+			baseCanvas.width = backingWidth;
+			baseCanvas.height = backingHeight;
+		};
 
 		const cached = getCachedBitmap(
 			pdfPageProxy,
@@ -188,16 +243,29 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 			recolorKey,
 		);
 		if (cached) {
+			applyBackingSize();
 			context.drawImage(cached, 0, 0);
+			baseCanvas.style.visibility = "";
 			markPageRendered(pageNumber);
-			paintedKeyRef.current = contentKey;
+			paintedRef.current = {
+				proxy: pdfPageProxy,
+				key: contentKey,
+				scale: baseScale,
+			};
 			return;
 		}
 
-		context.setTransform(1, 0, 0, 1, 0, 0);
-		context.clearRect(0, 0, baseCanvas.width, baseCanvas.height);
-
-		baseCanvas.style.visibility = "hidden";
+		// Keep a same-scheme previous frame visible (CSS-stretched) while the
+		// replacement renders off-DOM — no blank flash at zoom/dpr changes.
+		// Only when the canvas holds nothing useful do we clear and hide.
+		const hideUntilPainted = () => {
+			paintedRef.current = null;
+			applyBackingSize();
+			baseCanvas.style.visibility = "hidden";
+		};
+		if (!hasCurrentFrame) {
+			hideUntilPainted();
+		}
 
 		let cancelled = false;
 		const viewport = pdfPageProxy.getViewport({ scale: baseScale });
@@ -211,12 +279,22 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		// 2D context can't be allocated (canvas memory pressure), fall back to
 		// rendering directly into the visible canvas so the page still renders.
 		const buffer = document.createElement("canvas");
-		buffer.width = baseCanvas.width;
-		buffer.height = baseCanvas.height;
+		buffer.width = backingWidth;
+		buffer.height = backingHeight;
 		const bufferCtx = buffer.getContext("2d");
 		const useBuffer = bufferCtx !== null;
+		if (!useBuffer && hasCurrentFrame) {
+			// The fallback draws straight into the visible canvas — the previous
+			// frame can't survive that.
+			hideUntilPainted();
+		}
 		const renderCanvas = useBuffer ? buffer : baseCanvas;
 		const renderCtx = bufferCtx ?? context;
+
+		const releaseBuffer = () => {
+			buffer.width = 0;
+			buffer.height = 0;
+		};
 
 		// Native dark mode: recolor at draw time inside this render. The
 		// `background` param stays the ORIGINAL color — pdf.js fills it through
@@ -243,13 +321,9 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 			// A synchronous render() throw would otherwise skip the
 			// promise-based restore and leave the long-lived context wrapped.
 			restoreRecolor?.();
+			releaseBuffer();
 			throw error;
 		}
-
-		const releaseBuffer = () => {
-			buffer.width = 0;
-			buffer.height = 0;
-		};
 
 		renderingTask.promise
 			.finally(() => {
@@ -278,17 +352,22 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 					return;
 				}
 				if (useBuffer) {
-					// Clear before blitting: drawImage composites source-over, so on
-					// a page with transparent regions (or a transparent background)
-					// any pixels already on the canvas would show through. The render
-					// task resolves async, so don't rely on the clear at effect start.
-					context.clearRect(0, 0, baseCanvas.width, baseCanvas.height);
+					// Swap: size (which clears) and blit in one go — the previous
+					// frame stays on screen up to this exact paint.
+					applyBackingSize();
 					context.drawImage(buffer, 0, 0);
 				}
 				baseCanvas.style.visibility = "";
 				markPageRendered(pageNumber);
-				paintedKeyRef.current = contentKey;
-				if (typeof createImageBitmap !== "undefined") {
+				paintedRef.current = {
+					proxy: pdfPageProxy,
+					key: contentKey,
+					scale: baseScale,
+				};
+				if (
+					typeof createImageBitmap !== "undefined" &&
+					renderCanvas.width * renderCanvas.height * 4 <= CACHE_MAX_ENTRY_BYTES
+				) {
 					createImageBitmap(renderCanvas)
 						.then((bitmap) => {
 							if (cancelled) {
@@ -328,6 +407,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		dpr,
 		zoom,
 		isResizing,
+		isPinching,
 		pageNumber,
 		markPageRendered,
 		docId,

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -165,7 +165,14 @@ export const useDetailCanvasLayer = ({
 			// scroll/resize regardless of zoom — when the base canvas already
 			// covers full output resolution there is nothing to sharpen, and an
 			// overlay rendered here could even be SOFTER than the quantized base.
-			if (!needsDetail) {
+			// Recomputed live rather than trusting the effect-time value: the
+			// pixel budget reads screen dimensions, which can change (monitor
+			// move) without any effect dependency changing.
+			if (
+				targetDetailScale -
+					computeBaseScale(dpr, zoom, pageWidth, pageHeight) <=
+				1e-3
+			) {
 				hideDetailCanvas();
 				return;
 			}

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -404,7 +404,14 @@ export const useDetailCanvasLayer = ({
 				});
 			} catch (error) {
 				releaseBuffer();
-				throw error;
+				// renderDetailCanvas runs from timer callbacks — a rethrow here
+				// would surface as an uncaught timer error (no React boundary,
+				// no promise chain). Degrade to the base canvas instead: blur,
+				// never a crash. Sync throws happen on destroyed pages during
+				// document teardown or rejected canvas allocations.
+				hideDetailCanvas();
+				console.error("PDF detail render error:", error);
+				return;
 			}
 			renderingTask = currentRenderingTask;
 

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -3,7 +3,11 @@ import { useEffect, useLayoutEffect, useRef } from "react";
 import { useDebounce } from "use-debounce";
 
 import { PDFStore, usePdf } from "../../internal";
-import { clampScaleForPage } from "../../lib/canvas-utils";
+import {
+	clampScaleForPage,
+	computeBaseScale,
+	getCanvasPixelBudget,
+} from "../../lib/canvas-utils";
 import { createDarkModeColorMap } from "../../lib/dark-mode";
 import { applyContextRecolor } from "../../lib/recolor-context";
 import { subscribeToViewportInvalidation } from "../../lib/viewport-invalidation";
@@ -11,8 +15,23 @@ import { useDpr } from "../useDpr";
 import { usePDFPageNumber } from "../usePdfPageNumber";
 
 const DETAIL_RENDER_IDLE_MS = 80;
-// How long the live zoom must be stable before the detail pass may render.
-const ZOOM_SETTLE_MS = 250;
+const SCROLL_POLL_MS = 160;
+const ZOOM_DEBOUNCE_MS = 200;
+// Must exceed ZOOM_DEBOUNCE_MS plus one rAF of store-push latency: a render
+// that passes the settle gate is then guaranteed to hold the settled
+// (debounced) zoom in its closure, never a stale one — otherwise it would
+// compute a wrong-region rect. The live-zoom re-check in renderDetailCanvas
+// backstops this invariant anyway.
+const ZOOM_SETTLE_MS = ZOOM_DEBOUNCE_MS + 50;
+// Overscan around the visible rect, as a fraction of the viewport per side,
+// so normal scrolling stays inside the sharp region instead of revealing the
+// upscaled base canvas. Vertical gets more because documents mostly scroll
+// vertically. The actual padding shrinks to fit the pixel budget.
+const OVERSCAN_X = 0.25;
+const OVERSCAN_Y = 0.5;
+// A hidden overlay keeps its last frame briefly (re-showing beats a flash),
+// then releases its backing store — Safari counts it against page memory.
+const RELEASE_HIDDEN_MS = 2000;
 
 export const useDetailCanvasLayer = ({
 	background,
@@ -29,7 +48,6 @@ export const useDetailCanvasLayer = ({
 	const store = PDFStore.useContext();
 
 	const bouncyZoom = usePdf((state) => state.zoom);
-	const isPinching = usePdf((state) => state.isPinching);
 	const pdfPageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 	const viewportRef = usePdf((state) => state.viewportRef);
 	const colorScheme = usePdf((state) => state.colorScheme);
@@ -42,20 +60,26 @@ export const useDetailCanvasLayer = ({
 		? `dark:${darkModeColors.background},${darkModeColors.foreground}`
 		: "light";
 
-	// Key (background|scheme) the visible detail canvas was last painted
-	// with, or null when it holds no content.
-	const paintedKeyRef = useRef<string | null>(null);
+	// What the visible overlay currently shows: content key, render scale and
+	// the covered page-space rect — or null when the overlay is hidden.
+	const paintedRef = useRef<{
+		key: string;
+		scale: number;
+		left: number;
+		top: number;
+		width: number;
+		height: number;
+	} | null>(null);
+	const releaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-	const [zoom] = useDebounce(bouncyZoom, 200);
+	const [zoom] = useDebounce(bouncyZoom, ZOOM_DEBOUNCE_MS);
 
 	// Track when the live zoom last changed so the render can wait out a
 	// multi-segment gesture (wheel pulses end the use-gesture pinch between
 	// segments, so `isPinching` alone lets a 100ms+ detail render fire
 	// mid-gesture).
 	// Seed so an idle mount renders immediately, but a layer mounting during
-	// an active pinch waits out the settle window. (A mount in the brief
-	// isPinching=false window between wheel pulses may render once and get
-	// cancelled by the next pulse — rare and bounded.)
+	// an active pinch waits out the settle window.
 	const lastZoomChangeRef = useRef(
 		store.getState().isPinching ? performance.now() : 0,
 	);
@@ -95,17 +119,37 @@ export const useDetailCanvasLayer = ({
 		let renderingTask: RenderTask | null = null;
 		let renderTimeoutId: NodeJS.Timeout | null = null;
 
-		const bgColor = recolor
-			? recolor(background ?? "#ffffff")
-			: (background ?? "white");
 		const contentKey = `${background ?? "white"}|${recolorKey}`;
-		const detailBaseStyle = `position:absolute;top:0;left:0;pointer-events:none;z-index:1;background-color:${bgColor}`;
+		// No CSS background: if a backing-store allocation ever fails (Safari
+		// limits), the overlay must degrade to showing the blurry base through
+		// it, not cover the page with an opaque blank rectangle.
+		const detailBaseStyle =
+			"position:absolute;top:0;left:0;pointer-events:none;z-index:1";
 
 		const hideDetailCanvas = () => {
 			renderingTask?.cancel();
 			detailCanvas.style.cssText = `${detailBaseStyle};display:block;opacity:0`;
 			container.style.cssText = "";
+			paintedRef.current = null;
+			if (releaseTimerRef.current === null) {
+				releaseTimerRef.current = setTimeout(() => {
+					releaseTimerRef.current = null;
+					detailCanvas.width = 1;
+					detailCanvas.height = 1;
+				}, RELEASE_HIDDEN_MS);
+			}
 		};
+
+		const { width: pageWidth, height: pageHeight } = pageDimsRef.current!;
+
+		// Decide from cached page dims + zoom only — NO layout reads. The
+		// detail pass is needed exactly when the base canvas could not reach
+		// full output resolution (its budget clamp bound), which the shared
+		// computeBaseScale tells us directly. This also covers oversized pages
+		// (posters, plans) that are clamped below device resolution at zoom <= 1.
+		const targetDetailScale = dpr * zoom;
+		const baseScale = computeBaseScale(dpr, zoom, pageWidth, pageHeight);
+		const needsDetail = targetDetailScale - baseScale > 1e-3;
 
 		const renderDetailCanvas = () => {
 			// Don't read layout (getBoundingClientRect below) while the user is
@@ -114,19 +158,27 @@ export const useDetailCanvasLayer = ({
 			// sharpening is invisible mid-scroll anyway. Poll until scroll settles.
 			const virtualizer = store.getState().virtualizer;
 			if (virtualizer?.isScrolling) {
-				scheduleRender(160);
+				scheduleRender(SCROLL_POLL_MS);
 				return;
 			}
 
 			// Likewise, don't render between segments of a zoom gesture (wheel
 			// pulses, pinch pauses): the 100ms+ sharpening pass would land
 			// mid-gesture and be thrown away by the next zoom change anyway.
-			// Wait until the live zoom has been stable for a beat.
-			if (
-				store.getState().isPinching ||
-				performance.now() - lastZoomChangeRef.current < ZOOM_SETTLE_MS
-			) {
-				scheduleRender(160);
+			// Wait until the live zoom has been stable for a beat, polling just
+			// past the settle deadline instead of on a fixed quantum.
+			const settleElapsed = performance.now() - lastZoomChangeRef.current;
+			if (store.getState().isPinching || settleElapsed < ZOOM_SETTLE_MS) {
+				scheduleRender(Math.max(50, ZOOM_SETTLE_MS - settleElapsed + 10));
+				return;
+			}
+
+			// The closure zoom is the debounced value; if the live zoom has
+			// moved on, this closure would compute a wrong-region rect. The
+			// settle gate above makes this unreachable today — this is the
+			// guard that keeps it unreachable if the constants are ever tuned.
+			if (store.getState().zoom !== zoom) {
+				scheduleRender(ZOOM_SETTLE_MS);
 				return;
 			}
 
@@ -136,28 +188,7 @@ export const useDetailCanvasLayer = ({
 				return;
 			}
 
-			const { width: pageWidth, height: pageHeight } = pageDimsRef.current!;
-
-			// Decide whether a high-res detail pass is needed from cached page
-			// dims + zoom only — NO layout reads. Bail before any
-			// getBoundingClientRect so the common fit-width case (zoom <= 1, where
-			// the base canvas already covers it) never forces a synchronous
-			// reflow of the (text-span-laden) page tree on scroll.
-			const targetDetailScale = dpr * zoom * 1.3;
-			const baseTargetScale = dpr * Math.min(zoom, 1);
-			const baseScale = clampScaleForPage(
-				baseTargetScale,
-				pageWidth,
-				pageHeight,
-			);
-			const needsDetail = zoom > 1 && targetDetailScale - baseScale > 1e-3;
-
-			if (isPinching || !needsDetail) {
-				hideDetailCanvas();
-				return;
-			}
-
-			// zoom > 1: read layout to find the visible region of the page.
+			// Visible region of the page, in page units (scale-1 CSS px).
 			const scrollX = scrollContainer.scrollLeft / zoom;
 			const scrollY = scrollContainer.scrollTop / zoom;
 
@@ -189,13 +220,67 @@ export const useDetailCanvasLayer = ({
 				return;
 			}
 
+			// The budget clamp keeps every allocation under the Safari area
+			// limit even on huge viewports — degrade resolution, never blank.
+			const budget = getCanvasPixelBudget();
+			const effectiveScale = clampScaleForPage(
+				targetDetailScale,
+				visibleWidth,
+				visibleHeight,
+				budget,
+			);
+
+			// Still sharp at the right scale and the visible region is inside
+			// the painted (overscanned) rect — scrolling within the overscan
+			// margin costs zero work.
+			const painted = paintedRef.current;
+			if (
+				painted &&
+				painted.key === contentKey &&
+				painted.scale === effectiveScale &&
+				visibleLeft >= painted.left - 0.5 &&
+				visibleTop >= painted.top - 0.5 &&
+				visibleRight <= painted.left + painted.width + 0.5 &&
+				visibleBottom <= painted.top + painted.height + 0.5
+			) {
+				return;
+			}
+
+			// Spend whatever pixel budget remains after the visible rect on
+			// overscan, shrinking the padding factor f so that
+			// (w + 2·padX·f)(h + 2·padY·f) <= maxArea.
+			const maxArea = budget / (effectiveScale * effectiveScale);
+			const padX = OVERSCAN_X * viewportWidth;
+			const padY = OVERSCAN_Y * viewportHeight;
+			const a = 4 * padX * padY;
+			const b = 2 * (visibleWidth * padY + visibleHeight * padX);
+			const c = visibleWidth * visibleHeight - maxArea;
+			let padFactor = 1;
+			if (a > 0) {
+				padFactor = Math.min(
+					1,
+					Math.max(
+						0,
+						(-b + Math.sqrt(Math.max(b * b - 4 * a * c, 0))) / (2 * a),
+					),
+				);
+			} else if (b > 0) {
+				padFactor = Math.min(1, Math.max(0, -c / b));
+			}
+
+			const rectLeft = Math.max(0, visibleLeft - padX * padFactor);
+			const rectTop = Math.max(0, visibleTop - padY * padFactor);
+			const rectRight = Math.min(pageWidth, visibleRight + padX * padFactor);
+			const rectBottom = Math.min(pageHeight, visibleBottom + padY * padFactor);
+			const rectWidth = rectRight - rectLeft;
+			const rectHeight = rectBottom - rectTop;
+
+			// A new render is starting — the in-flight one (if any) targets an
+			// outdated rect, so replace it.
 			renderingTask?.cancel();
 
-			const pdfOffsetX = visibleLeft;
-			const pdfOffsetY = visibleTop;
-			const effectiveScale = targetDetailScale;
-			const actualWidth = visibleWidth * effectiveScale;
-			const actualHeight = visibleHeight * effectiveScale;
+			const actualWidth = Math.max(1, Math.floor(rectWidth * effectiveScale));
+			const actualHeight = Math.max(1, Math.floor(rectHeight * effectiveScale));
 
 			// Double-buffer: render to an offscreen buffer so the old detail
 			// canvas stays visible during the render (no flash to pixelated base)
@@ -205,6 +290,8 @@ export const useDetailCanvasLayer = ({
 
 			const bufferCtx = buffer.getContext("2d");
 			if (!bufferCtx) {
+				buffer.width = 0;
+				buffer.height = 0;
 				return;
 			}
 
@@ -215,8 +302,8 @@ export const useDetailCanvasLayer = ({
 				0,
 				0,
 				1,
-				-pdfOffsetX * effectiveScale,
-				-pdfOffsetY * effectiveScale,
+				-rectLeft * effectiveScale,
+				-rectTop * effectiveScale,
 			];
 			const detailViewport = pdfPageProxy.getViewport({
 				scale: effectiveScale,
@@ -226,14 +313,30 @@ export const useDetailCanvasLayer = ({
 			// original color and is mapped by the wrapped fillRect exactly once.
 			if (recolor) applyContextRecolor(bufferCtx, recolor);
 
-			const currentRenderingTask = pdfPageProxy.render({
-				canvas: buffer,
-				canvasContext: bufferCtx,
-				viewport: detailViewport,
-				background,
-				transform,
-			});
+			const releaseBuffer = () => {
+				buffer.width = 0;
+				buffer.height = 0;
+			};
+
+			let currentRenderingTask: RenderTask;
+			try {
+				currentRenderingTask = pdfPageProxy.render({
+					canvas: buffer,
+					canvasContext: bufferCtx,
+					viewport: detailViewport,
+					background,
+					transform,
+				});
+			} catch (error) {
+				releaseBuffer();
+				throw error;
+			}
 			renderingTask = currentRenderingTask;
+
+			// Derive the on-screen geometry from the floored backing size so the
+			// backing-to-device-pixel ratio stays exact (1:1 at full resolution).
+			const cssWidth = (actualWidth / effectiveScale) * zoom;
+			const cssHeight = (actualHeight / effectiveScale) * zoom;
 
 			currentRenderingTask.promise
 				.then(() => {
@@ -253,14 +356,25 @@ export const useDetailCanvasLayer = ({
 					// Swap: update the visible detail canvas in one go
 					detailCanvas.width = actualWidth;
 					detailCanvas.height = actualHeight;
-					detailCanvas.style.cssText = `${detailBaseStyle};display:block;opacity:1;width:${visibleWidth * zoom}px;height:${visibleHeight * zoom}px;transform-origin:center center;transform:translate(${visibleLeft * zoom}px,${visibleTop * zoom}px)`;
+					detailCanvas.style.cssText = `${detailBaseStyle};display:block;opacity:1;width:${cssWidth}px;height:${cssHeight}px;transform-origin:center center;transform:translate(${rectLeft * zoom}px,${rectTop * zoom}px)`;
 					container.style.cssText = `transform:scale3d(${1 / zoom},${1 / zoom},1);transform-origin:0 0`;
 
 					const ctx = detailCanvas.getContext("2d");
 					if (ctx) {
 						ctx.drawImage(buffer, 0, 0);
 					}
-					paintedKeyRef.current = contentKey;
+					paintedRef.current = {
+						key: contentKey,
+						scale: effectiveScale,
+						left: rectLeft,
+						top: rectTop,
+						width: rectWidth,
+						height: rectHeight,
+					};
+					if (releaseTimerRef.current !== null) {
+						clearTimeout(releaseTimerRef.current);
+						releaseTimerRef.current = null;
+					}
 				})
 				.catch((error) => {
 					if (error.name === "RenderingCancelledException") {
@@ -274,8 +388,7 @@ export const useDetailCanvasLayer = ({
 						renderingTask = null;
 					}
 					// Always release buffer — cancellations and stale tasks leak otherwise
-					buffer.width = 0;
-					buffer.height = 0;
+					releaseBuffer();
 				});
 		};
 
@@ -284,10 +397,11 @@ export const useDetailCanvasLayer = ({
 				clearTimeout(renderTimeoutId);
 			}
 
-			// Cancel any in-progress render but keep the old detail canvas
-			// visible — stale sharpness is better than a flash to pixelated base
-			renderingTask?.cancel();
-
+			// Deliberately do NOT cancel an in-flight render here: it blits at
+			// page-anchored coordinates, so it stays correct after a scroll, and
+			// a 90%-complete sharpening pass is worth keeping. It is replaced
+			// only when a new render actually starts (rect went stale) or the
+			// overlay hides.
 			renderTimeoutId = setTimeout(() => {
 				renderTimeoutId = null;
 				renderDetailCanvas();
@@ -299,7 +413,7 @@ export const useDetailCanvasLayer = ({
 			scheduleRender,
 		);
 
-		if (zoom <= 1 || isPinching) {
+		if (!needsDetail) {
 			// Synchronously hide — runs before paint (useLayoutEffect),
 			// so no stale rectangle flicker on zoom-out
 			hideDetailCanvas();
@@ -309,11 +423,10 @@ export const useDetailCanvasLayer = ({
 			// would show wrong-scheme pixels over a correct base — hide it
 			// before paint and let the scheduled render bring sharpness back.
 			if (
-				paintedKeyRef.current !== null &&
-				paintedKeyRef.current !== contentKey
+				paintedRef.current !== null &&
+				paintedRef.current.key !== contentKey
 			) {
 				hideDetailCanvas();
-				paintedKeyRef.current = null;
 			}
 			scheduleRender(0);
 		}
@@ -332,7 +445,6 @@ export const useDetailCanvasLayer = ({
 	}, [
 		pdfPageProxy,
 		zoom,
-		isPinching,
 		background,
 		dpr,
 		viewportRef,
@@ -347,6 +459,10 @@ export const useDetailCanvasLayer = ({
 	useEffect(() => {
 		const canvas = detailCanvasRef.current;
 		return () => {
+			if (releaseTimerRef.current !== null) {
+				clearTimeout(releaseTimerRef.current);
+				releaseTimerRef.current = null;
+			}
 			if (canvas) {
 				canvas.width = 1;
 				canvas.height = 1;

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -171,8 +171,8 @@ export const useDetailCanvasLayer = ({
 		const renderDetailCanvas = () => {
 			// The viewport-invalidation subscription schedules renders on every
 			// scroll/resize regardless of zoom — when the base canvas already
-			// covers full output resolution there is nothing to sharpen, and an
-			// overlay rendered here could even be SOFTER than the quantized base.
+			// covers full output resolution there is nothing to sharpen and an
+			// overlay would just duplicate it.
 			// Recomputed live rather than trusting the effect-time value: the
 			// pixel budget reads screen dimensions, which can change (monitor
 			// move) without any effect dependency changing.

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -60,9 +60,13 @@ export const useDetailCanvasLayer = ({
 		? `dark:${darkModeColors.background},${darkModeColors.foreground}`
 		: "light";
 
-	// What the visible overlay currently shows: content key, render scale and
-	// the covered page-space rect — or null when the overlay is hidden.
+	// What the visible overlay currently shows: page proxy, content key,
+	// render scale and the covered page-space rect — or null when the overlay
+	// is hidden. The proxy guards against a recycled component (e.g. a
+	// standalone <Page> whose pageNumber prop changes) keeping another page's
+	// pixels on screen.
 	const paintedRef = useRef<{
+		proxy: unknown;
 		key: string;
 		scale: number;
 		left: number;
@@ -128,6 +132,10 @@ export const useDetailCanvasLayer = ({
 
 		const hideDetailCanvas = () => {
 			renderingTask?.cancel();
+			// Null the task too: cancel() is a no-op on an internally-completed
+			// task, and its pending swap must not re-show the overlay after a
+			// hide — the swap's identity guard catches it once this is null.
+			renderingTask = null;
 			detailCanvas.style.cssText = `${detailBaseStyle};display:block;opacity:0`;
 			container.style.cssText = "";
 			paintedRef.current = null;
@@ -152,6 +160,15 @@ export const useDetailCanvasLayer = ({
 		const needsDetail = targetDetailScale - baseScale > 1e-3;
 
 		const renderDetailCanvas = () => {
+			// The viewport-invalidation subscription schedules renders on every
+			// scroll/resize regardless of zoom — when the base canvas already
+			// covers full output resolution there is nothing to sharpen, and an
+			// overlay rendered here could even be SOFTER than the quantized base.
+			if (!needsDetail) {
+				hideDetailCanvas();
+				return;
+			}
+
 			// Don't read layout (getBoundingClientRect below) while the user is
 			// scrolling: the read forces a synchronous reflow of the whole page
 			// tree (catastrophic with text layers present), and the detail
@@ -232,16 +249,20 @@ export const useDetailCanvasLayer = ({
 
 			// Still sharp at the right scale and the visible region is inside
 			// the painted (overscanned) rect — scrolling within the overscan
-			// margin costs zero work.
+			// margin costs zero work. Tolerance is one device pixel (a fixed
+			// page-unit epsilon would scale up to a visible soft seam at high
+			// zoom).
+			const eps = 1 / effectiveScale;
 			const painted = paintedRef.current;
 			if (
 				painted &&
+				painted.proxy === pdfPageProxy &&
 				painted.key === contentKey &&
 				painted.scale === effectiveScale &&
-				visibleLeft >= painted.left - 0.5 &&
-				visibleTop >= painted.top - 0.5 &&
-				visibleRight <= painted.left + painted.width + 0.5 &&
-				visibleBottom <= painted.top + painted.height + 0.5
+				visibleLeft >= painted.left - eps &&
+				visibleTop >= painted.top - eps &&
+				visibleRight <= painted.left + painted.width + eps &&
+				visibleBottom <= painted.top + painted.height + eps
 			) {
 				return;
 			}
@@ -364,17 +385,26 @@ export const useDetailCanvasLayer = ({
 						ctx.drawImage(buffer, 0, 0);
 					}
 					paintedRef.current = {
+						proxy: pdfPageProxy,
 						key: contentKey,
 						scale: effectiveScale,
 						left: rectLeft,
 						top: rectTop,
-						width: rectWidth,
-						height: rectHeight,
+						// The truly painted extent comes from the floored backing,
+						// not the requested rect.
+						width: actualWidth / effectiveScale,
+						height: actualHeight / effectiveScale,
 					};
 					if (releaseTimerRef.current !== null) {
 						clearTimeout(releaseTimerRef.current);
 						releaseTimerRef.current = null;
 					}
+					// Re-validate coverage: if the user scrolled elsewhere while
+					// this render was in flight (the covered-rect check may have
+					// skipped scheduling against the PREVIOUS painted rect), this
+					// schedules a corrective render; when the landed rect still
+					// covers the viewport it's a free no-op.
+					scheduleRender();
 				})
 				.catch((error) => {
 					if (error.name === "RenderingCancelledException") {
@@ -419,12 +449,14 @@ export const useDetailCanvasLayer = ({
 			hideDetailCanvas();
 		} else {
 			// Stale detail is only better than a flash when it matches the
-			// current scheme/background. Across a theme toggle the old overlay
-			// would show wrong-scheme pixels over a correct base — hide it
-			// before paint and let the scheduled render bring sharpness back.
+			// current scheme/background AND page. Across a theme toggle (or a
+			// page-proxy swap on a recycled component) the old overlay would
+			// show wrong pixels over a correct base — hide it before paint and
+			// let the scheduled render bring sharpness back.
 			if (
 				paintedRef.current !== null &&
-				paintedRef.current.key !== contentKey
+				(paintedRef.current.key !== contentKey ||
+					paintedRef.current.proxy !== pdfPageProxy)
 			) {
 				hideDetailCanvas();
 			}
@@ -467,6 +499,10 @@ export const useDetailCanvasLayer = ({
 				canvas.width = 1;
 				canvas.height = 1;
 			}
+			// Keep the "paintedRef non-null implies the canvas holds that
+			// frame" invariant — under StrictMode this cleanup runs on a
+			// simulated unmount and the component lives on with the same refs.
+			paintedRef.current = null;
 		};
 	}, []);
 

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -4,6 +4,7 @@ import { useDebounce } from "use-debounce";
 
 import { PDFStore, usePdf } from "../../internal";
 import {
+	CANVAS_SUPERSAMPLE,
 	clampScaleForPage,
 	computeBaseScale,
 	getCanvasPixelBudget,
@@ -161,10 +162,11 @@ export const useDetailCanvasLayer = ({
 
 		// Decide from cached page dims + zoom only — NO layout reads. The
 		// detail pass is needed exactly when the base canvas could not reach
-		// full output resolution (its budget clamp bound), which the shared
-		// computeBaseScale tells us directly. This also covers oversized pages
-		// (posters, plans) that are clamped below device resolution at zoom <= 1.
-		const targetDetailScale = dpr * zoom;
+		// the full supersampled output scale (its budget clamp bound), which
+		// the shared computeBaseScale tells us directly. This also covers
+		// oversized pages (posters, plans) clamped below device resolution at
+		// zoom <= 1.
+		const targetDetailScale = dpr * zoom * CANVAS_SUPERSAMPLE;
 		const baseScale = computeBaseScale(dpr, zoom, pageWidth, pageHeight);
 		const needsDetail = targetDetailScale - baseScale > 1e-3;
 

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -7,6 +7,7 @@ import {
 	clampScaleForPage,
 	computeBaseScale,
 	getCanvasPixelBudget,
+	MAX_CANVAS_DIMENSION,
 } from "../../lib/canvas-utils";
 import { createDarkModeColorMap } from "../../lib/dark-mode";
 import { applyContextRecolor } from "../../lib/recolor-context";
@@ -240,11 +241,27 @@ export const useDetailCanvasLayer = ({
 			// The budget clamp keeps every allocation under the Safari area
 			// limit even on huge viewports — degrade resolution, never blank.
 			const budget = getCanvasPixelBudget();
-			const effectiveScale = clampScaleForPage(
+			let effectiveScale = clampScaleForPage(
 				targetDetailScale,
 				visibleWidth,
 				visibleHeight,
 				budget,
+			);
+
+			// Overscan padding (page units per side). The rect can grow up to
+			// this much past the visible region, so the per-dimension canvas
+			// limit must be enforced against the padded bounds — and it must
+			// happen BEFORE the covered-rect check so painted.scale compares
+			// against the final scale (otherwise extreme aspect ratios would
+			// re-render forever).
+			const padX = OVERSCAN_X * viewportWidth;
+			const padY = OVERSCAN_Y * viewportHeight;
+			const maxRectWidth = Math.min(pageWidth, visibleWidth + 2 * padX);
+			const maxRectHeight = Math.min(pageHeight, visibleHeight + 2 * padY);
+			effectiveScale = Math.min(
+				effectiveScale,
+				MAX_CANVAS_DIMENSION / Math.max(maxRectWidth, 1),
+				MAX_CANVAS_DIMENSION / Math.max(maxRectHeight, 1),
 			);
 
 			// Still sharp at the right scale and the visible region is inside
@@ -271,8 +288,6 @@ export const useDetailCanvasLayer = ({
 			// overscan, shrinking the padding factor f so that
 			// (w + 2·padX·f)(h + 2·padY·f) <= maxArea.
 			const maxArea = budget / (effectiveScale * effectiveScale);
-			const padX = OVERSCAN_X * viewportWidth;
-			const padY = OVERSCAN_Y * viewportHeight;
 			const a = 4 * padX * padY;
 			const b = 2 * (visibleWidth * padY + visibleHeight * padX);
 			const c = visibleWidth * visibleHeight - maxArea;
@@ -297,8 +312,13 @@ export const useDetailCanvasLayer = ({
 			const rectHeight = rectBottom - rectTop;
 
 			// A new render is starting — the in-flight one (if any) targets an
-			// outdated rect, so replace it.
+			// outdated rect, so replace it. And don't let a release timer from
+			// an earlier hide shrink the canvas out from under this pass.
 			renderingTask?.cancel();
+			if (releaseTimerRef.current !== null) {
+				clearTimeout(releaseTimerRef.current);
+				releaseTimerRef.current = null;
+			}
 
 			const actualWidth = Math.max(1, Math.floor(rectWidth * effectiveScale));
 			const actualHeight = Math.max(1, Math.floor(rectHeight * effectiveScale));
@@ -313,6 +333,10 @@ export const useDetailCanvasLayer = ({
 			if (!bufferCtx) {
 				buffer.width = 0;
 				buffer.height = 0;
+				// Canvas memory pressure: degrade to the base layer and release
+				// our backing (which is exactly what the system needs right now)
+				// instead of keeping a stale, partially-covering overlay.
+				hideDetailCanvas();
 				return;
 			}
 
@@ -381,9 +405,14 @@ export const useDetailCanvasLayer = ({
 					container.style.cssText = `transform:scale3d(${1 / zoom},${1 / zoom},1);transform-origin:0 0`;
 
 					const ctx = detailCanvas.getContext("2d");
-					if (ctx) {
-						ctx.drawImage(buffer, 0, 0);
+					if (!ctx) {
+						// "Painted" must be a postcondition of a successful blit:
+						// recording it here would satisfy future covered-rect
+						// checks and pin the blurry base on screen forever.
+						hideDetailCanvas();
+						return;
 					}
+					ctx.drawImage(buffer, 0, 0);
 					paintedRef.current = {
 						proxy: pdfPageProxy,
 						key: contentKey,

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -449,7 +449,17 @@ export const useDetailCanvasLayer = ({
 						hideDetailCanvas();
 						return;
 					}
-					ctx.drawImage(buffer, 0, 0);
+					try {
+						ctx.drawImage(buffer, 0, 0);
+					} catch (error) {
+						// The width assignment above already cleared the canvas — a
+						// failed blit must not leave paintedRef describing the
+						// previous rect, or covered-rect checks would pin the
+						// blurry base on screen.
+						hideDetailCanvas();
+						console.error("PDF detail canvas blit error:", error);
+						return;
+					}
 					paintedRef.current = {
 						proxy: pdfPageProxy,
 						key: contentKey,

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -356,9 +356,17 @@ export const useDetailCanvasLayer = ({
 				buffer.width = 0;
 				buffer.height = 0;
 				// Canvas memory pressure: degrade to the base layer and release
-				// our backing (which is exactly what the system needs right now)
-				// instead of keeping a stale, partially-covering overlay.
+				// our backing instead of keeping a stale, partially-covering
+				// overlay. Release IMMEDIATELY rather than after the hide grace
+				// period — freeing memory is exactly what the system needs when
+				// an allocation just failed.
 				hideDetailCanvas();
+				if (releaseTimerRef.current !== null) {
+					clearTimeout(releaseTimerRef.current);
+					releaseTimerRef.current = null;
+				}
+				detailCanvas.width = 1;
+				detailCanvas.height = 1;
 				return;
 			}
 

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -149,7 +149,15 @@ export const useDetailCanvasLayer = ({
 			}
 		};
 
-		const { width: pageWidth, height: pageHeight } = pageDimsRef.current!;
+		// Populated during render (above) for the current proxy, so this is
+		// provably non-null — but guard instead of asserting, so a future
+		// reorder degrades to a hidden overlay rather than a throw.
+		const pageDims = pageDimsRef.current;
+		if (!pageDims) {
+			hideDetailCanvas();
+			return;
+		}
+		const { width: pageWidth, height: pageHeight } = pageDims;
 
 		// Decide from cached page dims + zoom only — NO layout reads. The
 		// detail pass is needed exactly when the base canvas could not reach

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -4,9 +4,9 @@ import { useDebounce } from "use-debounce";
 
 import { PDFStore, usePdf } from "../../internal";
 import {
-	CANVAS_SUPERSAMPLE,
 	clampScaleForPage,
 	computeBaseScale,
+	computeTargetScale,
 	getCanvasPixelBudget,
 	MAX_CANVAS_DIMENSION,
 } from "../../lib/canvas-utils";
@@ -162,11 +162,10 @@ export const useDetailCanvasLayer = ({
 
 		// Decide from cached page dims + zoom only — NO layout reads. The
 		// detail pass is needed exactly when the base canvas could not reach
-		// the full supersampled output scale (its budget clamp bound), which
-		// the shared computeBaseScale tells us directly. This also covers
-		// oversized pages (posters, plans) clamped below device resolution at
-		// zoom <= 1.
-		const targetDetailScale = dpr * zoom * CANVAS_SUPERSAMPLE;
+		// the full target output scale (its budget clamp bound), which the
+		// shared helpers tell us directly. This also covers oversized pages
+		// (posters, plans) clamped below device resolution at zoom <= 1.
+		const targetDetailScale = computeTargetScale(dpr, zoom);
 		const baseScale = computeBaseScale(dpr, zoom, pageWidth, pageHeight);
 		const needsDetail = targetDetailScale - baseScale > 1e-3;
 

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -296,6 +296,12 @@ export const useDetailCanvasLayer = ({
 				visibleRight <= painted.left + painted.width + eps &&
 				visibleBottom <= painted.top + painted.height + eps
 			) {
+				// The view is already covered, so any in-flight render targets a
+				// region the user scrolled away from — let it land and it would
+				// MOVE the (single) overlay canvas off the current view. Cancel
+				// it; nulling also blocks a resolved-but-unswapped task's swap.
+				renderingTask?.cancel();
+				renderingTask = null;
 				return;
 			}
 

--- a/packages/lector/src/hooks/useDpr.tsx
+++ b/packages/lector/src/hooks/useDpr.tsx
@@ -1,30 +1,56 @@
 import { useEffect, useState } from "react";
 
+// dpr-3 phones (recent iPhones, most Android flagships) look visibly soft at
+// a cap of 2; the page-area clamp in canvas-utils already bounds the memory
+// cost of rendering at 3.
+const DPR_CAP = 3;
+
+const readDpr = () =>
+	typeof window === "undefined"
+		? 1
+		: Math.min(window.devicePixelRatio || 1, DPR_CAP);
+
 export const useDpr = () => {
-	const [dpr, setDPR] = useState(
-		typeof window === "undefined" ? 1 : Math.min(window.devicePixelRatio, 2),
-	);
+	const [dpr, setDpr] = useState(readDpr);
 
 	useEffect(() => {
 		if (typeof window === "undefined") {
 			return;
 		}
 
-		const handleDPRChange = () => {
-			setDPR(Math.min(window.devicePixelRatio, 2));
+		let mediaQuery: MediaQueryList | null = null;
+		let cancelled = false;
+
+		const handleChange = () => {
+			if (cancelled) {
+				return;
+			}
+			setDpr(readDpr());
+			subscribe();
 		};
 
-		const windowMatch = window.matchMedia(
-			`screen and (min-resolution: ${dpr}dppx)`,
-		);
+		const subscribe = () => {
+			mediaQuery?.removeEventListener("change", handleChange);
+			// Exact-match query built from the live, UNCAPPED devicePixelRatio: it
+			// flips (and fires "change") on any deviation in either direction. A
+			// min-resolution query only fires when the ratio drops below it, so
+			// moving to a denser display or raising browser zoom would never be
+			// observed. The -webkit alternative covers older Safari, which lacks
+			// the standard resolution feature in matchMedia.
+			const ratio = window.devicePixelRatio || 1;
+			mediaQuery = window.matchMedia(
+				`(resolution: ${ratio}dppx), (-webkit-device-pixel-ratio: ${ratio})`,
+			);
+			mediaQuery.addEventListener("change", handleChange, { once: true });
+		};
 
-		windowMatch.addEventListener("change", handleDPRChange);
+		subscribe();
 
 		return () => {
-			windowMatch.removeEventListener("change", handleDPRChange);
+			cancelled = true;
+			mediaQuery?.removeEventListener("change", handleChange);
 		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [dpr]);
+	}, []);
 
 	return dpr;
 };

--- a/packages/lector/src/hooks/useDpr.tsx
+++ b/packages/lector/src/hooks/useDpr.tsx
@@ -29,8 +29,18 @@ export const useDpr = () => {
 			subscribe();
 		};
 
+		// Safari <14 MediaQueryList only has addListener/removeListener.
+		const unlisten = (mql: MediaQueryList | null) => {
+			if (!mql) return;
+			if (typeof mql.removeEventListener === "function") {
+				mql.removeEventListener("change", handleChange);
+			} else {
+				mql.removeListener(handleChange);
+			}
+		};
+
 		const subscribe = () => {
-			mediaQuery?.removeEventListener("change", handleChange);
+			unlisten(mediaQuery);
 			// Exact-match query built from the live, UNCAPPED devicePixelRatio: it
 			// flips (and fires "change") on any deviation in either direction. A
 			// min-resolution query only fires when the ratio drops below it, so
@@ -41,14 +51,18 @@ export const useDpr = () => {
 			mediaQuery = window.matchMedia(
 				`(resolution: ${ratio}dppx), (-webkit-device-pixel-ratio: ${ratio})`,
 			);
-			mediaQuery.addEventListener("change", handleChange, { once: true });
+			if (typeof mediaQuery.addEventListener === "function") {
+				mediaQuery.addEventListener("change", handleChange, { once: true });
+			} else {
+				mediaQuery.addListener(handleChange);
+			}
 		};
 
 		subscribe();
 
 		return () => {
 			cancelled = true;
-			mediaQuery?.removeEventListener("change", handleChange);
+			unlisten(mediaQuery);
 		};
 	}, []);
 

--- a/packages/lector/src/hooks/useDpr.tsx
+++ b/packages/lector/src/hooks/useDpr.tsx
@@ -58,6 +58,11 @@ export const useDpr = () => {
 			}
 		};
 
+		// Re-sync before subscribing: a DPR change between the initial render
+		// and this (passive) effect would otherwise leave the state stale while
+		// the query — built from the already-changed live value — matches and
+		// never fires. setState with an unchanged value is a no-op re-render.
+		setDpr(readDpr());
 		subscribe();
 
 		return () => {

--- a/packages/lector/src/hooks/useThumbnail.tsx
+++ b/packages/lector/src/hooks/useThumbnail.tsx
@@ -36,7 +36,9 @@ export const useThumbnail = (
 	const containerRef = useRef<HTMLDivElement>(null);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const renderTaskRef = useRef<RenderTask | null>(null);
-	const hasRenderedRef = useRef(false);
+	// Which page proxy this thumb has rendered — a recycled component showing
+	// a new page starts lazy again.
+	const renderedProxyRef = useRef<unknown>(null);
 
 	const pageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 	const { visible } = useVisibility({ elementRef: containerRef });
@@ -57,8 +59,8 @@ export const useThumbnail = (
 		// one retained canvas per page). Once a thumb has been on screen it
 		// keeps re-rendering through visibility changes, so leaving the
 		// window still downgrades it to the cheap 0.5x preview below.
-		if (!isVisible && !hasRenderedRef.current) return;
-		hasRenderedRef.current = true;
+		if (!isVisible && renderedProxyRef.current !== pageProxy) return;
+		renderedProxyRef.current = pageProxy;
 
 		const renderThumbnail = async () => {
 			const canvas = canvasRef.current;

--- a/packages/lector/src/hooks/useThumbnail.tsx
+++ b/packages/lector/src/hooks/useThumbnail.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import { useDebounce } from "use-debounce";
 
 import { usePdf } from "../internal";
+import { clampScaleForPage } from "../lib/canvas-utils";
 import { createDarkModeColorMap } from "../lib/dark-mode";
 import {
 	applyContextRecolor,
@@ -35,6 +36,7 @@ export const useThumbnail = (
 	const containerRef = useRef<HTMLDivElement>(null);
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const renderTaskRef = useRef<RenderTask | null>(null);
+	const hasRenderedRef = useRef(false);
 
 	const pageProxy = usePdf((state) => state.getPdfPageProxy(pageNumber));
 	const { visible } = useVisibility({ elementRef: containerRef });
@@ -50,6 +52,14 @@ export const useThumbnail = (
 	const isVisible = isFirstPage || debouncedVisible;
 
 	useEffect(() => {
+		// Never-seen thumbnails skip rendering entirely — a long document
+		// would otherwise render every page eagerly at mount (CPU burst plus
+		// one retained canvas per page). Once a thumb has been on screen it
+		// keeps re-rendering through visibility changes, so leaving the
+		// window still downgrades it to the cheap 0.5x preview below.
+		if (!isVisible && !hasRenderedRef.current) return;
+		hasRenderedRef.current = true;
+
 		const renderThumbnail = async () => {
 			const canvas = canvasRef.current;
 
@@ -61,11 +71,16 @@ export const useThumbnail = (
 					renderTaskRef.current.cancel();
 				}
 
-				// Calculate viewport and scale
+				// Calculate viewport and scale. Clamp like the main layers so an
+				// oversized maxWidth/maxHeight config can't allocate a canvas past
+				// the Safari area limit (which would render blank).
 				const viewport = pageProxy.getViewport({ scale: 1 });
-				const scale =
+				const scale = clampScaleForPage(
 					Math.min(maxWidth / viewport.width, maxHeight / viewport.height) *
-					(isVisible ? dpr : 0.5);
+						(isVisible ? dpr : 0.5),
+					viewport.width,
+					viewport.height,
+				);
 
 				const scaledViewport = pageProxy.getViewport({ scale });
 

--- a/packages/lector/src/hooks/viewport/useViewportContainer.tsx
+++ b/packages/lector/src/hooks/viewport/useViewportContainer.tsx
@@ -45,6 +45,11 @@ export const useViewportContainer = ({
 		viewportRef.current = containerRef.current;
 	}, [containerRef, viewportRef]);
 
+	// Initialized to 1 — the DOM's actual state at mount (no transform yet) —
+	// NOT the store zoom. Initializing to the store zoom made the sync effect
+	// below treat an initial `zoom` prop != 1 as already applied, so the
+	// scale3d was never written: pages rendered for the requested zoom but
+	// displayed at zoom 1 (mis-sized and resampled-blurry canvases).
 	const transformations = useRef<{
 		translateX: number;
 		translateY: number;
@@ -52,7 +57,7 @@ export const useViewportContainer = ({
 	}>({
 		translateX: 0,
 		translateY: 0,
-		zoom,
+		zoom: 1,
 	});
 
 	// rAF handle for debouncing Zustand store updates during pinch.
@@ -65,7 +70,10 @@ export const useViewportContainer = ({
 	// (e.g. zoom slider). Without this, the sync effect sees a mismatch
 	// between the store (stale rAF value) and transformations.current
 	// (already advanced by a newer pinch frame) and snaps back.
-	const lastPushedZoomRef = useRef(zoom);
+	// Initialized to 1 (matching transformations above), not the store zoom:
+	// an initial `zoom` prop != 1 is an external value the sync effect must
+	// apply, not one of our own pushes.
+	const lastPushedZoomRef = useRef(1);
 
 	const updateTransform = useCallback(
 		(zoomUpdate?: boolean) => {

--- a/packages/lector/src/hooks/viewport/useViewportContainer.tsx
+++ b/packages/lector/src/hooks/viewport/useViewportContainer.tsx
@@ -70,10 +70,11 @@ export const useViewportContainer = ({
 	// (e.g. zoom slider). Without this, the sync effect sees a mismatch
 	// between the store (stale rAF value) and transformations.current
 	// (already advanced by a newer pinch frame) and snaps back.
-	// Initialized to 1 (matching transformations above), not the store zoom:
-	// an initial `zoom` prop != 1 is an external value the sync effect must
-	// apply, not one of our own pushes.
-	const lastPushedZoomRef = useRef(1);
+	// null = "no pending self-push": a real zoom value here could mask an
+	// external change to that same number (e.g. init 1 swallowing an external
+	// reset to 1x after mounting with an initial zoom prop). The sentinel is
+	// consumed on match and cleared when an external change is applied.
+	const lastPushedZoomRef = useRef<number | null>(null);
 
 	const updateTransform = useCallback(
 		(zoomUpdate?: boolean) => {
@@ -135,8 +136,16 @@ export const useViewportContainer = ({
 		}
 
 		if (zoom === lastPushedZoomRef.current) {
+			// Consume the sentinel: each self-push produces exactly one store
+			// update, so leaving the value armed could only ever mask a FUTURE
+			// external change to the same number.
+			lastPushedZoomRef.current = null;
 			return;
 		}
+
+		// An external change is being applied — any stale self-push value must
+		// not mask a later external return to that zoom.
+		lastPushedZoomRef.current = null;
 
 		const prevZoom = transformations.current.zoom;
 		if (!prevZoom || !Number.isFinite(prevZoom)) {

--- a/packages/lector/src/hooks/viewport/useViewportContainer.tsx
+++ b/packages/lector/src/hooks/viewport/useViewportContainer.tsx
@@ -144,7 +144,14 @@ export const useViewportContainer = ({
 		}
 
 		// An external change is being applied — any stale self-push value must
-		// not mask a later external return to that zoom.
+		// not mask a later external return to that zoom, and a pending rAF
+		// push must not fire afterwards: it would re-arm the sentinel and
+		// reset isZoomFitWidth even though its zoom write (it reads the live
+		// transform, which we are about to overwrite) is a no-op.
+		if (zoomRafRef.current !== null) {
+			cancelAnimationFrame(zoomRafRef.current);
+			zoomRafRef.current = null;
+		}
 		lastPushedZoomRef.current = null;
 
 		const prevZoom = transformations.current.zoom;

--- a/packages/lector/src/lib/canvas-utils.test.ts
+++ b/packages/lector/src/lib/canvas-utils.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	BASE_ZOOM_STEP,
+	clampScaleForPage,
+	computeBaseScale,
+	getCanvasPixelBudget,
+	MAX_CANVAS_PIXELS,
+} from "./canvas-utils";
+
+const LETTER = { width: 612, height: 792 };
+
+describe("clampScaleForPage", () => {
+	it("passes the target scale through when the page fits the budget", () => {
+		expect(clampScaleForPage(2, LETTER.width, LETTER.height)).toBe(2);
+	});
+
+	it("clamps the scale so width * height * scale^2 never exceeds maxPixels", () => {
+		const scale = clampScaleForPage(100, LETTER.width, LETTER.height);
+		const pixels = LETTER.width * scale * (LETTER.height * scale);
+		expect(pixels).toBeLessThanOrEqual(MAX_CANVAS_PIXELS * (1 + 1e-9));
+		expect(scale).toBeCloseTo(
+			Math.sqrt(MAX_CANVAS_PIXELS / (LETTER.width * LETTER.height)),
+			6,
+		);
+	});
+
+	it("respects a custom maxPixels budget", () => {
+		const budget = 1_000_000;
+		const scale = clampScaleForPage(10, 1000, 1000, budget);
+		expect(scale).toBeCloseTo(1, 6);
+	});
+
+	it("returns 0 for a zero target scale", () => {
+		expect(clampScaleForPage(0, LETTER.width, LETTER.height)).toBe(0);
+	});
+});
+
+describe("getCanvasPixelBudget", () => {
+	it("never exceeds MAX_CANVAS_PIXELS", () => {
+		expect(getCanvasPixelBudget()).toBeLessThanOrEqual(MAX_CANVAS_PIXELS);
+	});
+
+	it("is positive", () => {
+		expect(getCanvasPixelBudget()).toBeGreaterThan(0);
+	});
+});
+
+describe("computeBaseScale", () => {
+	it("quantizes zoom upward so many zoom values share one scale", () => {
+		const low = computeBaseScale(1, 1.0 + 1e-6, LETTER.width, LETTER.height);
+		const high = computeBaseScale(
+			1,
+			1.0 + BASE_ZOOM_STEP - 1e-6,
+			LETTER.width,
+			LETTER.height,
+		);
+		expect(low).toBe(high);
+	});
+
+	it("is never below dpr * zoom until the budget clamps", () => {
+		const budget = getCanvasPixelBudget();
+		for (const zoom of [0.4, 0.75, 1, 1.3, 2, 3.7]) {
+			const scale = computeBaseScale(2, zoom, LETTER.width, LETTER.height);
+			const unclamped =
+				LETTER.width * LETTER.height * (2 * zoom) ** 2 <= budget;
+			if (unclamped) {
+				expect(scale).toBeGreaterThanOrEqual(2 * zoom - 1e-9);
+			}
+		}
+	});
+
+	it("never allocates past the adaptive budget", () => {
+		const budget = getCanvasPixelBudget();
+		for (const zoom of [1, 2, 5, 10]) {
+			const scale = computeBaseScale(3, zoom, LETTER.width, LETTER.height);
+			const pixels = LETTER.width * scale * (LETTER.height * scale);
+			expect(pixels).toBeLessThanOrEqual(budget * (1 + 1e-9));
+		}
+	});
+
+	it("is monotonically non-decreasing in zoom", () => {
+		let prev = 0;
+		for (const zoom of [0.25, 0.5, 1, 1.5, 2, 3, 5, 8]) {
+			const scale = computeBaseScale(2, zoom, LETTER.width, LETTER.height);
+			expect(scale).toBeGreaterThanOrEqual(prev - 1e-9);
+			prev = scale;
+		}
+	});
+
+	it("keeps a floor of half a zoom step for tiny zooms", () => {
+		const scale = computeBaseScale(2, 0.01, LETTER.width, LETTER.height);
+		expect(scale).toBeCloseTo(2 * BASE_ZOOM_STEP, 6);
+	});
+});

--- a/packages/lector/src/lib/canvas-utils.test.ts
+++ b/packages/lector/src/lib/canvas-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	CANVAS_SUPERSAMPLE,
 	clampScaleForPage,
 	computeBaseScale,
 	getCanvasPixelBudget,
@@ -46,14 +47,14 @@ describe("getCanvasPixelBudget", () => {
 });
 
 describe("computeBaseScale", () => {
-	it("is EXACTLY dpr * zoom until the budget clamps — any surplus would be a non-integer downscale at composite time (soft text on Safari)", () => {
+	it("is exactly dpr * zoom * CANVAS_SUPERSAMPLE until the budget clamps", () => {
 		const budget = getCanvasPixelBudget();
 		for (const zoom of [0.4, 0.75, 0.8, 0.9, 1, 1.13, 1.3, 2, 3.7]) {
 			const scale = computeBaseScale(2, zoom, LETTER.width, LETTER.height);
-			const unclamped =
-				LETTER.width * LETTER.height * (2 * zoom) ** 2 <= budget;
+			const target = 2 * zoom * CANVAS_SUPERSAMPLE;
+			const unclamped = LETTER.width * LETTER.height * target ** 2 <= budget;
 			if (unclamped) {
-				expect(scale).toBeCloseTo(2 * zoom, 9);
+				expect(scale).toBeCloseTo(target, 9);
 			}
 		}
 	});
@@ -78,6 +79,6 @@ describe("computeBaseScale", () => {
 
 	it("keeps a small floor for degenerate zooms", () => {
 		const scale = computeBaseScale(2, 0, LETTER.width, LETTER.height);
-		expect(scale).toBeCloseTo(2 * 0.1, 6);
+		expect(scale).toBeCloseTo(2 * 0.1 * CANVAS_SUPERSAMPLE, 6);
 	});
 });

--- a/packages/lector/src/lib/canvas-utils.test.ts
+++ b/packages/lector/src/lib/canvas-utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import {
-	BASE_ZOOM_STEP,
 	clampScaleForPage,
 	computeBaseScale,
 	getCanvasPixelBudget,
@@ -47,25 +46,14 @@ describe("getCanvasPixelBudget", () => {
 });
 
 describe("computeBaseScale", () => {
-	it("quantizes zoom upward so many zoom values share one scale", () => {
-		const low = computeBaseScale(1, 1.0 + 1e-6, LETTER.width, LETTER.height);
-		const high = computeBaseScale(
-			1,
-			1.0 + BASE_ZOOM_STEP - 1e-6,
-			LETTER.width,
-			LETTER.height,
-		);
-		expect(low).toBe(high);
-	});
-
-	it("is never below dpr * zoom until the budget clamps", () => {
+	it("is EXACTLY dpr * zoom until the budget clamps — any surplus would be a non-integer downscale at composite time (soft text on Safari)", () => {
 		const budget = getCanvasPixelBudget();
-		for (const zoom of [0.4, 0.75, 1, 1.3, 2, 3.7]) {
+		for (const zoom of [0.4, 0.75, 0.8, 0.9, 1, 1.13, 1.3, 2, 3.7]) {
 			const scale = computeBaseScale(2, zoom, LETTER.width, LETTER.height);
 			const unclamped =
 				LETTER.width * LETTER.height * (2 * zoom) ** 2 <= budget;
 			if (unclamped) {
-				expect(scale).toBeGreaterThanOrEqual(2 * zoom - 1e-9);
+				expect(scale).toBeCloseTo(2 * zoom, 9);
 			}
 		}
 	});
@@ -88,8 +76,8 @@ describe("computeBaseScale", () => {
 		}
 	});
 
-	it("keeps a floor of half a zoom step for tiny zooms", () => {
-		const scale = computeBaseScale(2, 0.01, LETTER.width, LETTER.height);
-		expect(scale).toBeCloseTo(2 * BASE_ZOOM_STEP, 6);
+	it("keeps a small floor for degenerate zooms", () => {
+		const scale = computeBaseScale(2, 0, LETTER.width, LETTER.height);
+		expect(scale).toBeCloseTo(2 * 0.1, 6);
 	});
 });

--- a/packages/lector/src/lib/canvas-utils.test.ts
+++ b/packages/lector/src/lib/canvas-utils.test.ts
@@ -85,6 +85,9 @@ describe("computeBaseScale", () => {
 
 	it("keeps a small floor for degenerate zooms", () => {
 		const scale = computeBaseScale(2, 0, LETTER.width, LETTER.height);
-		expect(scale).toBeCloseTo(2 * 0.1, 6);
+		expect(scale).toBeCloseTo(2 * 0.01, 6);
+		expect(computeTargetScale(2, Number.NaN)).toBeCloseTo(2 * 0.01, 6);
+		// real low zooms are exact, not floored
+		expect(computeTargetScale(2, 0.05)).toBeCloseTo(0.1, 9);
 	});
 });

--- a/packages/lector/src/lib/canvas-utils.test.ts
+++ b/packages/lector/src/lib/canvas-utils.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
-	CANVAS_SUPERSAMPLE,
 	clampScaleForPage,
 	computeBaseScale,
+	computeTargetScale,
 	getCanvasPixelBudget,
 	MAX_CANVAS_PIXELS,
 } from "./canvas-utils";
@@ -47,16 +47,22 @@ describe("getCanvasPixelBudget", () => {
 });
 
 describe("computeBaseScale", () => {
-	it("is exactly dpr * zoom * CANVAS_SUPERSAMPLE until the budget clamps", () => {
+	it("is exactly the target scale until the budget clamps: native at zoom <= 1, supersampled above", () => {
 		const budget = getCanvasPixelBudget();
 		for (const zoom of [0.4, 0.75, 0.8, 0.9, 1, 1.13, 1.3, 2, 3.7]) {
 			const scale = computeBaseScale(2, zoom, LETTER.width, LETTER.height);
-			const target = 2 * zoom * CANVAS_SUPERSAMPLE;
+			const target = computeTargetScale(2, zoom);
 			const unclamped = LETTER.width * LETTER.height * target ** 2 <= budget;
 			if (unclamped) {
 				expect(scale).toBeCloseTo(target, 9);
 			}
 		}
+	});
+
+	it("renders native 1:1 at zoom <= 1 and supersampled above", () => {
+		expect(computeTargetScale(2, 1)).toBeCloseTo(2, 9);
+		expect(computeTargetScale(2, 0.8)).toBeCloseTo(1.6, 9);
+		expect(computeTargetScale(2, 1.5)).toBeCloseTo(2 * 1.5 * 1.3, 9);
 	});
 
 	it("never allocates past the adaptive budget", () => {
@@ -79,6 +85,6 @@ describe("computeBaseScale", () => {
 
 	it("keeps a small floor for degenerate zooms", () => {
 		const scale = computeBaseScale(2, 0, LETTER.width, LETTER.height);
-		expect(scale).toBeCloseTo(2 * 0.1 * CANVAS_SUPERSAMPLE, 6);
+		expect(scale).toBeCloseTo(2 * 0.1, 6);
 	});
 });

--- a/packages/lector/src/lib/canvas-utils.ts
+++ b/packages/lector/src/lib/canvas-utils.ts
@@ -6,10 +6,23 @@ export const MAX_CANVAS_DIMENSION = 32767;
 // a new full-page render per debounced zoom value.
 export const BASE_ZOOM_STEP = 0.5;
 
+// pdf.js-style platform detection: actual mobile devices only. Generic
+// touch-screen Windows/ChromeOS laptops report maxTouchPoints > 1 too, so
+// the touch heuristic is scoped to iPads pretending to be MacIntel.
+export const IS_MOBILE_DEVICE =
+	typeof navigator !== "undefined" &&
+	(/Android|iPhone|iPad|iPod/i.test(navigator.userAgent) ||
+		(navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1));
+
 // pdf.js-style adaptive pixel budget (capCanvasAreaFactor): a canvas never
-// usefully holds more than ~3x the screen's device-pixel area, so on small
-// screens (phones, tablets) the budget shrinks well below MAX_CANVAS_PIXELS
-// instead of letting every device allocate up to the iOS area limit.
+// usefully holds more than a few times the screen's device-pixel area, so on
+// small screens (phones, tablets) the budget shrinks well below
+// MAX_CANVAS_PIXELS instead of letting every device allocate up to the iOS
+// area limit. Mobile gets a tighter factor: the budget bounds EACH canvas
+// and several pages are mounted at once, all counting toward the page's
+// jetsam memory limit.
+const CANVAS_AREA_FACTOR = IS_MOBILE_DEVICE ? 1.5 : 3;
+
 export function getCanvasPixelBudget(): number {
 	if (typeof window === "undefined" || typeof screen === "undefined") {
 		return MAX_CANVAS_PIXELS;
@@ -19,7 +32,7 @@ export function getCanvasPixelBudget(): number {
 	if (!Number.isFinite(screenArea) || screenArea <= 0) {
 		return MAX_CANVAS_PIXELS;
 	}
-	return Math.min(MAX_CANVAS_PIXELS, screenArea * 3);
+	return Math.min(MAX_CANVAS_PIXELS, screenArea * CANVAS_AREA_FACTOR);
 }
 
 export function clampScaleForPage(

--- a/packages/lector/src/lib/canvas-utils.ts
+++ b/packages/lector/src/lib/canvas-utils.ts
@@ -1,14 +1,27 @@
 export const MAX_CANVAS_PIXELS = 16777216;
 export const MAX_CANVAS_DIMENSION = 32767;
 
-// Canvases render supersampled by this factor and are downscaled at
-// composite time. Empirically (Laplacian edge energy on identical retina
-// screenshots, WebKit and Chromium): pdf.js content rasterized at 1.3x and
-// bilinear-downscaled carries ~25% MORE edge energy than an exact 1:1
-// render — the downscale steepens the antialiasing ramps, which users
-// read as "crisp". Exact 1:1 is NOT the perceptual gold standard for
-// pdf.js output; this matches the long-standing detail-overlay behavior.
+// Canvases at zoom > 1 render supersampled by this factor and are
+// downscaled at composite time. Empirically (Laplacian edge energy on
+// identical retina screenshots in WebKit and Chromium, plus a side-by-side
+// pipeline matrix judged on real Safari): pdf.js content rasterized at
+// 1.3x and compositor-downscaled reads visibly crisper than an exact 1:1
+// render for zoomed-in (large) glyphs — the downscale steepens the
+// antialiasing ramps. At zoom <= 1, however, glyphs are small and the
+// same downscale ALIASES them — there, native 1:1 rendering (the old
+// pipeline's behavior, user-validated as crisp) wins. Hence the factor
+// applies only above zoom 1; this exactly mirrors the legacy pipeline
+// (native base at zoom <= 1, 1.3x-supersampled detail overlay above).
 export const CANVAS_SUPERSAMPLE = 1.3;
+
+// The full output scale a canvas should aim for at a given zoom, before
+// any budget clamping. Shared by the base layer (its render scale) and
+// the detail layer (its gate + render target) so the two always agree on
+// when the base falls short.
+export function computeTargetScale(dpr: number, zoom: number): number {
+	const safeZoom = Math.max(zoom, 0.1);
+	return dpr * safeZoom * (safeZoom > 1 ? CANVAS_SUPERSAMPLE : 1);
+}
 
 // pdf.js-style platform detection: actual mobile devices only. Generic
 // touch-screen Windows/ChromeOS laptops report maxTouchPoints > 1 too, so
@@ -63,14 +76,15 @@ export function clampScaleForPage(
 	return Math.max(safeScale, 0);
 }
 
-// The base canvas renders at dpr * zoom * CANVAS_SUPERSAMPLE (not
-// dpr * min(zoom, 1)) so pages stay sharp while scrolling at moderate
-// zooms; the detail overlay is only needed once the budget clamp binds.
+// The base canvas renders at the full target scale (not dpr * min(zoom, 1))
+// so pages stay sharp while scrolling at moderate zooms; the detail overlay
+// is only needed once the budget clamp binds.
 //
 // Derived from the EXACT zoom — deliberately not quantized to zoom steps:
-// quantization made the supersample factor vary per zoom (inconsistent
-// softness across zoom levels). The bitmap cache absorbs the per-zoom
-// variants via its byte budget and per-page variant cap.
+// quantization composited off-grid zooms at a varying non-integer
+// downscale (inconsistent softness across zoom levels). The bitmap cache
+// absorbs the per-zoom variants via its byte budget and per-page variant
+// cap.
 export function computeBaseScale(
 	dpr: number,
 	zoom: number,
@@ -78,7 +92,7 @@ export function computeBaseScale(
 	pageHeight: number,
 ): number {
 	return clampScaleForPage(
-		dpr * Math.max(zoom, 0.1) * CANVAS_SUPERSAMPLE,
+		computeTargetScale(dpr, zoom),
 		pageWidth,
 		pageHeight,
 		getCanvasPixelBudget(),

--- a/packages/lector/src/lib/canvas-utils.ts
+++ b/packages/lector/src/lib/canvas-utils.ts
@@ -1,6 +1,15 @@
 export const MAX_CANVAS_PIXELS = 16777216;
 export const MAX_CANVAS_DIMENSION = 32767;
 
+// Canvases render supersampled by this factor and are downscaled at
+// composite time. Empirically (Laplacian edge energy on identical retina
+// screenshots, WebKit and Chromium): pdf.js content rasterized at 1.3x and
+// bilinear-downscaled carries ~25% MORE edge energy than an exact 1:1
+// render — the downscale steepens the antialiasing ramps, which users
+// read as "crisp". Exact 1:1 is NOT the perceptual gold standard for
+// pdf.js output; this matches the long-standing detail-overlay behavior.
+export const CANVAS_SUPERSAMPLE = 1.3;
+
 // pdf.js-style platform detection: actual mobile devices only. Generic
 // touch-screen Windows/ChromeOS laptops report maxTouchPoints > 1 too, so
 // the touch heuristic is scoped to iPads pretending to be MacIntel.
@@ -54,19 +63,14 @@ export function clampScaleForPage(
 	return Math.max(safeScale, 0);
 }
 
-// The base canvas renders at EXACTLY dpr * zoom (not dpr * min(zoom, 1))
-// so pages stay sharp while scrolling at moderate zooms; the detail overlay
-// is only needed once the budget clamp binds.
+// The base canvas renders at dpr * zoom * CANVAS_SUPERSAMPLE (not
+// dpr * min(zoom, 1)) so pages stay sharp while scrolling at moderate
+// zooms; the detail overlay is only needed once the budget clamp binds.
 //
-// Exact — deliberately NOT quantized to zoom steps: the canvas composites
-// at dpr * zoom device px per page unit, and any backing scale above that
-// is a non-integer downscale at composite time. Safari's compositor
-// resamples canvases with plain bilinear filtering, so even a 1.1-1.3x
-// downscale reads as visibly soft/aliased text ("crisp at 100%, slightly
-// blurry at fit-width"). Exact 1:1 backing-to-device mapping is the
-// sharpness gold standard, and pdf.js renders at unquantized dpr * zoom
-// for the same reason. The bitmap cache absorbs the per-zoom variants via
-// its byte budget and per-page variant cap.
+// Derived from the EXACT zoom — deliberately not quantized to zoom steps:
+// quantization made the supersample factor vary per zoom (inconsistent
+// softness across zoom levels). The bitmap cache absorbs the per-zoom
+// variants via its byte budget and per-page variant cap.
 export function computeBaseScale(
 	dpr: number,
 	zoom: number,
@@ -74,7 +78,7 @@ export function computeBaseScale(
 	pageHeight: number,
 ): number {
 	return clampScaleForPage(
-		dpr * Math.max(zoom, 0.1),
+		dpr * Math.max(zoom, 0.1) * CANVAS_SUPERSAMPLE,
 		pageWidth,
 		pageHeight,
 		getCanvasPixelBudget(),

--- a/packages/lector/src/lib/canvas-utils.ts
+++ b/packages/lector/src/lib/canvas-utils.ts
@@ -1,11 +1,6 @@
 export const MAX_CANVAS_PIXELS = 16777216;
 export const MAX_CANVAS_DIMENSION = 32767;
 
-// Base-canvas zoom is quantized upward to this step so small zoom changes
-// reuse the same backing scale (and bitmap-cache entry) instead of minting
-// a new full-page render per debounced zoom value.
-export const BASE_ZOOM_STEP = 0.5;
-
 // pdf.js-style platform detection: actual mobile devices only. Generic
 // touch-screen Windows/ChromeOS laptops report maxTouchPoints > 1 too, so
 // the touch heuristic is scoped to iPads pretending to be MacIntel.
@@ -59,22 +54,27 @@ export function clampScaleForPage(
 	return Math.max(safeScale, 0);
 }
 
-// The base canvas renders at dpr * zoom (not dpr * min(zoom, 1)) so pages
-// stay sharp while scrolling at moderate zooms; the detail overlay is only
-// needed once this clamp binds. Quantized upward so the rendered scale is
-// never below the displayed scale until the budget cuts it off.
+// The base canvas renders at EXACTLY dpr * zoom (not dpr * min(zoom, 1))
+// so pages stay sharp while scrolling at moderate zooms; the detail overlay
+// is only needed once the budget clamp binds.
+//
+// Exact — deliberately NOT quantized to zoom steps: the canvas composites
+// at dpr * zoom device px per page unit, and any backing scale above that
+// is a non-integer downscale at composite time. Safari's compositor
+// resamples canvases with plain bilinear filtering, so even a 1.1-1.3x
+// downscale reads as visibly soft/aliased text ("crisp at 100%, slightly
+// blurry at fit-width"). Exact 1:1 backing-to-device mapping is the
+// sharpness gold standard, and pdf.js renders at unquantized dpr * zoom
+// for the same reason. The bitmap cache absorbs the per-zoom variants via
+// its byte budget and per-page variant cap.
 export function computeBaseScale(
 	dpr: number,
 	zoom: number,
 	pageWidth: number,
 	pageHeight: number,
 ): number {
-	const quantizedZoom = Math.max(
-		Math.ceil(Math.max(zoom, 0) / BASE_ZOOM_STEP) * BASE_ZOOM_STEP,
-		BASE_ZOOM_STEP,
-	);
 	return clampScaleForPage(
-		dpr * quantizedZoom,
+		dpr * Math.max(zoom, 0.1),
 		pageWidth,
 		pageHeight,
 		getCanvasPixelBudget(),

--- a/packages/lector/src/lib/canvas-utils.ts
+++ b/packages/lector/src/lib/canvas-utils.ts
@@ -19,7 +19,9 @@ export const CANVAS_SUPERSAMPLE = 1.3;
 // the detail layer (its gate + render target) so the two always agree on
 // when the base falls short.
 export function computeTargetScale(dpr: number, zoom: number): number {
-	const safeZoom = Math.max(zoom, 0.1);
+	// Tiny floor only against degenerate inputs (0/NaN would produce a
+	// zero-size canvas and break pdf.js) — real low zooms render exactly.
+	const safeZoom = Math.max(Number.isFinite(zoom) ? zoom : 0, 0.01);
 	return dpr * safeZoom * (safeZoom > 1 ? CANVAS_SUPERSAMPLE : 1);
 }
 

--- a/packages/lector/src/lib/canvas-utils.ts
+++ b/packages/lector/src/lib/canvas-utils.ts
@@ -1,18 +1,38 @@
 export const MAX_CANVAS_PIXELS = 16777216;
 export const MAX_CANVAS_DIMENSION = 32767;
 
+// Base-canvas zoom is quantized upward to this step so small zoom changes
+// reuse the same backing scale (and bitmap-cache entry) instead of minting
+// a new full-page render per debounced zoom value.
+export const BASE_ZOOM_STEP = 0.5;
+
+// pdf.js-style adaptive pixel budget (capCanvasAreaFactor): a canvas never
+// usefully holds more than ~3x the screen's device-pixel area, so on small
+// screens (phones, tablets) the budget shrinks well below MAX_CANVAS_PIXELS
+// instead of letting every device allocate up to the iOS area limit.
+export function getCanvasPixelBudget(): number {
+	if (typeof window === "undefined" || typeof screen === "undefined") {
+		return MAX_CANVAS_PIXELS;
+	}
+	const dpr = window.devicePixelRatio || 1;
+	const screenArea = (screen.width || 0) * (screen.height || 0) * dpr * dpr;
+	if (!Number.isFinite(screenArea) || screenArea <= 0) {
+		return MAX_CANVAS_PIXELS;
+	}
+	return Math.min(MAX_CANVAS_PIXELS, screenArea * 3);
+}
+
 export function clampScaleForPage(
 	targetScale: number,
 	pageWidth: number,
 	pageHeight: number,
+	maxPixels: number = MAX_CANVAS_PIXELS,
 ): number {
 	if (!targetScale) {
 		return 0;
 	}
 
-	const areaLimit = Math.sqrt(
-		MAX_CANVAS_PIXELS / Math.max(pageWidth * pageHeight, 1),
-	);
+	const areaLimit = Math.sqrt(maxPixels / Math.max(pageWidth * pageHeight, 1));
 	const widthLimit = MAX_CANVAS_DIMENSION / Math.max(pageWidth, 1);
 	const heightLimit = MAX_CANVAS_DIMENSION / Math.max(pageHeight, 1);
 
@@ -24,4 +44,26 @@ export function clampScaleForPage(
 	);
 
 	return Math.max(safeScale, 0);
+}
+
+// The base canvas renders at dpr * zoom (not dpr * min(zoom, 1)) so pages
+// stay sharp while scrolling at moderate zooms; the detail overlay is only
+// needed once this clamp binds. Quantized upward so the rendered scale is
+// never below the displayed scale until the budget cuts it off.
+export function computeBaseScale(
+	dpr: number,
+	zoom: number,
+	pageWidth: number,
+	pageHeight: number,
+): number {
+	const quantizedZoom = Math.max(
+		Math.ceil(Math.max(zoom, 0) / BASE_ZOOM_STEP) * BASE_ZOOM_STEP,
+		BASE_ZOOM_STEP,
+	);
+	return clampScaleForPage(
+		dpr * quantizedZoom,
+		pageWidth,
+		pageHeight,
+		getCanvasPixelBudget(),
+	);
 }


### PR DESCRIPTION
## Why

Users reported blurry PDFs — worst symptom: *the moment you scroll at zoom > 1, the page goes blurry*. A deep multi-agent review plus live browser measurement found the blur was structural, alongside several independent whole-document-blur bugs. The fixes were then calibrated against real-Safari perception (A/B servers, a six-pipeline matrix page, and Laplacian edge-energy measurements in retina WebKit and Chromium).

## The final rendering pipeline

The shape that real-Safari testing validated (`computeTargetScale`):

- **zoom = 1** — native 1:1 render, legacy 2D transform; bit-for-bit the old pipeline (its one validated-crisp state). A `scale3d` — even identity — forces a GPU-sampled layer in WebKit that softens native content, so it's skipped here.
- **zoom < 1** — native 1:1 under a net-identity inverse transform (sharper than old, which sampled the canvas through a raw `scale3d`).
- **zoom > 1** — **1.3× supersample + compositor downscale**, budget-clamped. Measured: supersampled-downscaled pdf.js content carries ~25% more edge energy than exact 1:1 in both WebKit and Chromium (6047 vs 4726 vs old's 5928 at zoom 1.57, dpr 2) and won the user-judged Safari pipeline matrix. Small text at zoom ≤ 1 aliases under the same downscale, hence the conditional.
- Beyond the adaptive pixel budget, the **overscanned detail overlay** (same supersampled pipeline, visible-rect + margin) takes over — scrolling within the overscan is a zero-work no-op, in-flight renders survive scrolling, and the overlay stays page-glued through gestures.

## Everything else fixed

- **`useDpr`**: exact-resolution media query (DPR changes fire in *both* directions — was a one-way downward ratchet), cap raised 2 → 3 for dpr-3 phones, old-Safari `addListener` fallback, render-to-effect race closed.
- **`useScrollendEvent: false`**: a single missed scrollend could pin `isScrolling` forever and permanently stop detail/text rendering.
- **Initial `zoom` prop**: the scale transform was never applied for it (rendered at zoom Z, displayed at 1) — fixed via DOM-truth ref initialization; plus a null self-push sentinel so an external zoom reset to a previously-pushed value can't be swallowed.
- **Memory**: bitmap cache budgeted in bytes (64 MB mobile / 192 MB desktop) with per-page variant caps and LRU; unique cache buckets for fingerprint-less documents; hidden overlay backings released after a grace period; thumbnails render lazily and clamped; adaptive per-canvas pixel budget (pdf.js `capCanvasAreaFactor` pattern: ≤3× screen device-px area desktop, 1.5× mobile) with per-dimension clamps incl. overscan bounds.
- **Failure paths**: canvas/bitmap allocation failures degrade to blur (never an opaque blank rectangle — the old overlay's failure mode), "painted" is a postcondition of a successful blit, buffers released on all paths.
- **No-flash re-renders**: same-scheme frames stay visible while replacements render off-DOM; same-scale re-runs are no-ops; pinch/resize reuse the painted frame.

## Verification

- 22 review threads across seven bot waves: all resolved (≈2/3 fixed in code, the rest refuted with evidence on-thread).
- 34 unit tests (scale math + conditional supersample locked by tests); typecheck, biome, build green.
- Live-measured: backing:device ratios exact in every zoom regime; scroll-within-overscan leaves the overlay byte-identical; detail handoff at budget-clamped zooms intact; zero console errors.
- Final sharpness sign-off by eye on real Safari against the published build, at normal zoom and deep zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Keep `Pages` canvases sharp during scroll and zoom
>
> - Adds shared canvas scale helpers in `canvas-utils`: base/detail canvases now target DPR×zoom, apply 1.3× supersampling only above zoom 1, and clamp allocations to an adaptive pixel budget.
> - Reworks the base canvas layer to render at the exact budgeted scale, inverse-scale its CSS geometry, skip WebKit’s sampled `scale3d` path at zoom 1, and keep the previous matching frame visible while replacements render.
> - Rebuilds the detail overlay around an overscanned visible-page rect, so scrolling within the covered area is a no-op and high-res detail rendering only runs when the base canvas is budget-clamped below target resolution.
> - Hardens canvas memory and failure paths: bitmap caching is now byte-budgeted with per-page variant caps, anonymous document cache buckets are isolated, hidden overlay backings are released, and allocation/render/blit failures fall back to the base layer instead of blank overlays.
> - Fixes related sharpness regressions: `useDpr` now tracks DPR changes in both directions with cap `2→3`, `Pages` keeps the `isScrolling` debounce fallback active, initial `zoom` props apply their transform, thumbnails render lazily with scale clamping, and scale/budget math gains unit coverage.
> - Behavioral change: PDF pages should remain sharp during scrolling/zooming, initial non-1x zoom displays at the requested scale, and never-viewed thumbnails no longer render eagerly.
>
> <sup>[Leo](https://anara.com) summarized `6d06272`</sup>
<!-- leo:summary-end -->