### PR TITLE
doc: add production PDF.js asset guidance

### DIFF
--- a/packages/docs/content/docs/installation.mdx
+++ b/packages/docs/content/docs/installation.mdx
@@ -91,6 +91,16 @@ export function PDFViewer() {
 import "pdfjs-dist/web/pdf_viewer.css";
 ```
 
+## Production Assets and CSP
+
+For production deployments, especially applications with a strict Content Security Policy, make sure
+the PDF.js worker and auxiliary assets are available from URLs your app is allowed to load.
+
+Some scanned PDFs and image-heavy documents require PDF.js WASM, CMaps, standard fonts, or ICC
+profiles. If those assets are blocked, pages may load but render blank or partially blank.
+
+See [Production PDF.js Assets](/docs/production-assets) for a recommended setup.
+
 ## Verifying Installation
 
 To verify that Lector is properly installed, create a basic PDF viewer component:

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -5,6 +5,7 @@
 	"pages": [
 		"---Getting Started---",
 		"installation",
+		"production-assets",
 		"basic-usage",
 		"---Components---",
 		"code/basic",

--- a/packages/docs/content/docs/production-assets.mdx
+++ b/packages/docs/content/docs/production-assets.mdx
@@ -1,0 +1,70 @@
+---
+title: Production PDF.js Assets
+description: Configure PDF.js worker, CMaps, fonts, ICC profiles, and WASM assets for production deployments
+---
+
+PDF.js may need additional runtime assets beyond the worker file when rendering some PDFs.
+For example, scanned documents, JPEG2000 images, non-standard fonts, CMaps, or color profiles
+can require assets from `pdfjs-dist/wasm`, `pdfjs-dist/cmaps`, `pdfjs-dist/standard_fonts`,
+or `pdfjs-dist/iccs`.
+
+If those assets are not reachable in production, pages may load but render as blank or partially
+blank. Browser consoles can show warnings such as:
+
+```txt
+JpxError: OpenJPEG failed to initialize
+Unable to decode image
+Dependent image isn't ready yet
+```
+
+This is especially common in applications with a strict Content Security Policy (CSP), because
+PDF.js can otherwise try to load some assets from a CDN URL that your CSP does not allow.
+
+## Recommended Setup
+
+Copy the PDF.js runtime assets into your app's public/static directory and point PDF.js at
+same-origin URLs:
+
+```tsx
+import { Root } from "@anaralabs/lector";
+import { GlobalWorkerOptions } from "pdfjs-dist/legacy/build/pdf.mjs";
+import "pdfjs-dist/web/pdf_viewer.css";
+
+GlobalWorkerOptions.workerSrc = "/pdfjs/pdf.worker.mjs";
+
+const documentOptions = {
+  wasmUrl: "/pdfjs/wasm/",
+  cMapUrl: "/pdfjs/cmaps/",
+  cMapPacked: true,
+  standardFontDataUrl: "/pdfjs/standard_fonts/",
+  iccUrl: "/pdfjs/iccs/",
+};
+
+export function PDFViewer() {
+  return <Root source="/sample.pdf" documentOptions={documentOptions}>{/* ... */}</Root>;
+}
+```
+
+For a Next.js app, one simple approach is to copy the files during install or build:
+
+```json
+{
+  "scripts": {
+    "postinstall": "mkdir -p public/pdfjs && cp node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs public/pdfjs/pdf.worker.mjs && cp -R node_modules/pdfjs-dist/wasm public/pdfjs/wasm && cp -R node_modules/pdfjs-dist/cmaps public/pdfjs/cmaps && cp -R node_modules/pdfjs-dist/standard_fonts public/pdfjs/standard_fonts && cp -R node_modules/pdfjs-dist/iccs public/pdfjs/iccs"
+  }
+}
+```
+
+## CSP Notes
+
+When self-hosting the assets above, your CSP can usually stay same-origin focused. If your browser
+blocks PDF.js WASM compilation, add the narrow directive needed by your application, for example:
+
+```txt
+script-src 'self' 'wasm-unsafe-eval'
+font-src 'self' data:
+```
+
+Avoid relying on third-party CDN asset URLs unless your CSP explicitly permits those script, worker,
+font, and fetch destinations.
+


### PR DESCRIPTION
## Summary

Adds production deployment guidance for PDF.js auxiliary assets used by Lector/PDF.js:

- worker file
- WASM assets, including OpenJPEG support
- CMaps
- standard fonts
- ICC profiles
- CSP notes for same-origin deployments

This documents a failure mode where PDFs load and page counts resolve, but scanned/image-heavy pages render blank or partially blank because PDF.js cannot load blocked auxiliary assets.

Closes #140.

## Validation

- `git diff --check`
- Docs-only change; full docs build was not run because the scratch clone did not have monorepo dependencies installed.

<!-- leo:summary-start -->
> [!NOTE]
> ### Document production `PDF.js` asset deployment
>
> - Adds a `production-assets` docs page for deploying `PDF.js` auxiliary assets in production, including workers, WASM/OpenJPEG, CMaps, standard fonts, ICC profiles, and same-origin CSP notes.
> - Documents the blank or partially blank scanned-page failure mode that can occur when `PDF.js` loads the PDF metadata but cannot fetch required rendering assets.
> - Surfaces the new page from the docs navigation and installation flow via [meta.json](https://github.com/anaralabs/lector/pull/141/files#diff-e6419501bac43ac1b5d29af358f9775d98f67d08705bae47ab00c1bbb8e33484) and [installation.mdx](https://github.com/anaralabs/lector/pull/141/files#diff-facc0f9d1edabae4de43bd667e946b17808af754d4cebdc384b43200b4395dac).
>
> <sup>[Leo](https://anara.com) summarized `040b7e8`</sup>
<!-- leo:summary-end -->