### PR TITLE
feat(dark-mode): invert scanned-page rasters toward the palette poles

### DIFF
--- a/packages/lector/package.json
+++ b/packages/lector/package.json
@@ -1,103 +1,104 @@
 {
-  "name": "@anaralabs/lector",
-  "version": "0.0.0-semantically-released",
-  "description": "A headless PDF viewer for React",
-  "author": "andrewdr (https://github.com/andrewdoro)",
-  "license": "MIT",
-  "type": "module",
-  "sideEffects": false,
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./esm-only.cjs"
-    }
-  },
-  "files": [
-    "dist"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "scripts": {
-    "dev": "tsup --watch --onSuccess 'yalc push'",
-    "prebuild": "rm -rf dist",
-    "build": "tsup",
-    "lint": "biome check .",
-    "format": "biome format --write .",
-    "postbuild": "size-limit --json > size.json",
-    "test": "pnpm run '/^test:/'",
-    "test:unit": "vitest run",
-    "test:size": "size-limit",
-    "prepack": "./scripts/prepack.sh"
-  },
-  "devDependencies": {
-    "@microsoft/api-extractor": "^7.48.1",
-    "@size-limit/preset-small-lib": "^11.1.6",
-    "@testing-library/react": "^16.0.0",
-    "@types/node": "^22.9.0",
-    "@types/react": "^19.0.1",
-    "@types/react-dom": "^19.0.2",
-    "@use-gesture/react": "^10.3.1",
-    "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/browser": "^3.2.6",
-    "clsx": "^2.1.1",
-    "pdfjs-dist": "^5.5.207",
-    "playwright": "^1.45.3",
-    "react": "^19.1.1",
-    "size-limit": "^11.1.6",
-    "tsc-alias": "^1.8.10",
-    "tslib": "^2.6.3",
-    "tsup": "^8.3.5",
-    "typescript": "^5.5.3",
-    "vite": "^6.4.3",
-    "vitest": "^3.2.6",
-    "webdriverio": "^8.39.1"
-  },
-  "peerDependencies": {
-    "pdfjs-dist": "^5.5.207",
-    "react": ">=19"
-  },
-  "dependencies": {
-    "@floating-ui/react": "^0.26.28",
-    "@radix-ui/react-slot": "^1.1.0",
-    "@tanstack/react-virtual": "^3.10.9",
-    "react-dom": "^19.1.1",
-    "use-debounce": "^10.0.4",
-    "uuid": "^11.1.1",
-    "zustand": "^5.0.2"
-  },
-  "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.28.1"
-  },
-  "keywords": [
-    "pdf",
-    "react",
-    "headless",
-    "viewer",
-    "react-pdf",
-    "anaralabs",
-    "typescript"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/anaralabs/lector.git",
-    "directory": "packages/lector"
-  },
-  "bugs": {
-    "url": "https://github.com/anaralabs/lector/issues"
-  },
-  "homepage": "https://github.com/anaralabs/lector",
-  "size-limit": [
-    {
-      "name": "Client",
-      "path": "dist/index.js",
-      "limit": "150 kB",
-      "ignore": [
-        "react"
-      ]
-    }
-  ]
+	"name": "@anaralabs/lector",
+	"version": "0.0.0-semantically-released",
+	"description": "A headless PDF viewer for React",
+	"author": "andrewdr (https://github.com/andrewdoro)",
+	"license": "MIT",
+	"type": "module",
+	"sideEffects": false,
+	"module": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"require": "./esm-only.cjs"
+		}
+	},
+	"files": [
+		"dist"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"scripts": {
+		"dev": "tsup --watch --onSuccess 'yalc push'",
+		"prebuild": "rm -rf dist",
+		"build": "tsup",
+		"lint": "biome check .",
+		"format": "biome format --write .",
+		"postbuild": "size-limit --json > size.json",
+		"test": "pnpm run '/^test:/'",
+		"test:unit": "vitest run",
+		"test:size": "size-limit",
+		"prepack": "./scripts/prepack.sh",
+		"prepare": "tsup"
+	},
+	"devDependencies": {
+		"@microsoft/api-extractor": "^7.48.1",
+		"@size-limit/preset-small-lib": "^11.1.6",
+		"@testing-library/react": "^16.0.0",
+		"@types/node": "^22.9.0",
+		"@types/react": "^19.0.1",
+		"@types/react-dom": "^19.0.2",
+		"@use-gesture/react": "^10.3.1",
+		"@vitejs/plugin-react": "^4.3.4",
+		"@vitest/browser": "^3.2.6",
+		"clsx": "^2.1.1",
+		"pdfjs-dist": "^5.5.207",
+		"playwright": "^1.45.3",
+		"react": "^19.1.1",
+		"size-limit": "^11.1.6",
+		"tsc-alias": "^1.8.10",
+		"tslib": "^2.6.3",
+		"tsup": "^8.3.5",
+		"typescript": "^5.5.3",
+		"vite": "^6.4.3",
+		"vitest": "^3.2.6",
+		"webdriverio": "^8.39.1"
+	},
+	"peerDependencies": {
+		"pdfjs-dist": "^5.5.207",
+		"react": ">=19"
+	},
+	"dependencies": {
+		"@floating-ui/react": "^0.26.28",
+		"@radix-ui/react-slot": "^1.1.0",
+		"@tanstack/react-virtual": "^3.10.9",
+		"react-dom": "^19.1.1",
+		"use-debounce": "^10.0.4",
+		"uuid": "^11.1.1",
+		"zustand": "^5.0.2"
+	},
+	"optionalDependencies": {
+		"@rollup/rollup-linux-x64-gnu": "^4.28.1"
+	},
+	"keywords": [
+		"pdf",
+		"react",
+		"headless",
+		"viewer",
+		"react-pdf",
+		"anaralabs",
+		"typescript"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/anaralabs/lector.git",
+		"directory": "packages/lector"
+	},
+	"bugs": {
+		"url": "https://github.com/anaralabs/lector/issues"
+	},
+	"homepage": "https://github.com/anaralabs/lector",
+	"size-limit": [
+		{
+			"name": "Client",
+			"path": "dist/index.js",
+			"limit": "150 kB",
+			"ignore": [
+				"react"
+			]
+		}
+	]
 }

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -365,7 +365,9 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		// long-lived visible canvas context).
 		let restoreRecolor: (() => void) | null = null;
 		if (recolor) {
-			restoreRecolor = applyContextRecolor(renderCtx, recolor);
+			restoreRecolor = applyContextRecolor(renderCtx, recolor, {
+				pageArea: viewport.width * viewport.height,
+			});
 		} else {
 			removeContextRecolor(renderCtx);
 		}

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -386,7 +386,10 @@ export const useDetailCanvasLayer = ({
 
 			// Native dark mode: recolor at draw time; `background` stays the
 			// original color and is mapped by the wrapped fillRect exactly once.
-			if (recolor) applyContextRecolor(bufferCtx, recolor);
+			if (recolor)
+				applyContextRecolor(bufferCtx, recolor, {
+					pageArea: detailViewport.width * detailViewport.height,
+				});
 
 			const releaseBuffer = () => {
 				buffer.width = 0;

--- a/packages/lector/src/hooks/useThumbnail.tsx
+++ b/packages/lector/src/hooks/useThumbnail.tsx
@@ -100,7 +100,9 @@ export const useThumbnail = (
 				// synchronously, and strip stale wrappers before light renders.
 				let restoreRecolor: (() => void) | null = null;
 				if (recolor) {
-					restoreRecolor = applyContextRecolor(context, recolor);
+					restoreRecolor = applyContextRecolor(context, recolor, {
+						pageArea: scaledViewport.width * scaledViewport.height,
+					});
 				} else {
 					removeContextRecolor(context);
 				}

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -31,8 +31,10 @@ function ntscLuma(r: number, g: number, b: number): number {
 }
 
 function parseHexLuma(color: string): number | null {
-	// toCssColor emits #rrggbb, or #rrggbbaa for translucent palette colors.
-	if (!/^#[0-9a-f]{6}([0-9a-f]{2})?$/i.test(color)) return null;
+	// Opaque poles only: a translucent paper pole is ill-defined for the
+	// difference fill (vector fills composite their alpha; a fill cannot),
+	// so translucent palettes keep scans un-inverted, like mask correction.
+	if (!/^#[0-9a-f]{6}$/i.test(color)) return null;
 	return ntscLuma(
 		Number.parseInt(color.slice(1, 3), 16),
 		Number.parseInt(color.slice(3, 5), 16),
@@ -301,6 +303,8 @@ export function applyContextRecolor(
 		/** Non-overlapping area contributed toward coverage, as a page fraction. */
 		area: number;
 		inked: boolean;
+		/** paintSerial at draw time — tiles older than a foreign paint are unsafe. */
+		serial: number;
 	}
 	const OVERLAP_TOLERANCE = 0.2;
 	let pendingTileArea = 0;
@@ -400,14 +404,38 @@ export function applyContextRecolor(
 		}
 	};
 
+	const pendingTriggerReady = () => {
+		if (pendingTileArea < SCAN_COVERAGE_MIN || !pendingHasInk) return false;
+		const union: DeviceBounds = [
+			Math.min(...pendingTiles.map((t) => t.bounds[0])),
+			Math.min(...pendingTiles.map((t) => t.bounds[1])),
+			Math.max(...pendingTiles.map((t) => t.bounds[2])),
+			Math.max(...pendingTiles.map((t) => t.bounds[3])),
+		];
+		const unionArea = boundsArea(union);
+		if (unionArea <= 0) return false;
+		return (
+			(pendingTileArea * (pageArea ?? 0)) / unionArea >= SCAN_TILE_DENSITY_MIN
+		);
+	};
+
 	const flushPendingTiles = (self: CanvasRenderingContext2D) => {
-		// Vector content painted between strips (annotations, signatures)
-		// would be inverted by a retroactive fill — leave the page as-is.
-		if (paintSerial === pendingBaselineSerial) {
-			for (const pending of pendingTiles) {
-				invertTileRemainder(self, pending, coveredBounds);
-				coveredBounds.push(pending.bounds);
-			}
+		// Content painted between strips (annotations, watermarks, photos)
+		// would be inverted by a retroactive fill — but only tiles OLDER than
+		// the last foreign paint are unsafe. Keep the clean suffix so a scan
+		// painted after a watermark still accumulates and inverts.
+		if (paintSerial !== pendingBaselineSerial) {
+			const kept = pendingTiles.filter((t) => t.serial === paintSerial);
+			pendingTiles.length = 0;
+			pendingTiles.push(...kept);
+			pendingTileArea = kept.reduce((sum, t) => sum + t.area, 0);
+			pendingHasInk = kept.some((t) => t.inked);
+			pendingBaselineSerial = paintSerial;
+			if (pendingTiles.length === 0 || !pendingTriggerReady()) return;
+		}
+		for (const pending of pendingTiles) {
+			invertTileRemainder(self, pending, coveredBounds);
+			coveredBounds.push(pending.bounds);
 		}
 		pendingTiles.length = 0;
 		pendingTileArea = 0;
@@ -555,23 +583,13 @@ export function applyContextRecolor(
 			bounds,
 			area: contributedArea,
 			inked: candidate.inked,
+			serial: paintSerial,
 		});
 		pendingTileArea += contributedArea;
 		pendingHasInk ||= candidate.inked;
-		if (pendingTileArea < SCAN_COVERAGE_MIN) return;
 		// Blank tiles count toward coverage, but a page only inverts when its
 		// strips carry ink somewhere (pure-white stacks are MRC backgrounds).
-		if (!pendingHasInk) return;
-		const union: DeviceBounds = [
-			Math.min(...pendingTiles.map((t) => t.bounds[0])),
-			Math.min(...pendingTiles.map((t) => t.bounds[1])),
-			Math.max(...pendingTiles.map((t) => t.bounds[2])),
-			Math.max(...pendingTiles.map((t) => t.bounds[3])),
-		];
-		const unionArea = boundsArea(union);
-		if (unionArea <= 0) return;
-		const density = (pendingTileArea * (pageArea ?? 0)) / unionArea;
-		if (density < SCAN_TILE_DENSITY_MIN) return;
+		if (!pendingTriggerReady()) return;
 		flushPendingTiles(self);
 	};
 

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -479,7 +479,13 @@ export function applyContextRecolor(
 			flushPendingTiles(self);
 			return;
 		}
-		if (candidate.clipped) return;
+		if (candidate.clipped) {
+			// It painted pixels we can't track (unknown clip footprint): a
+			// later retroactive fill over them would alter content, so it
+			// invalidates pending accumulation like any interleaved paint.
+			paintSerial++;
+			return;
+		}
 		if (candidate.areaFraction >= SCAN_COVERAGE_MIN) {
 			// A page-covering pure-white raster can't invert on its own: its
 			// ink may live in a separate MRC layer that must stay readable, or

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -416,6 +416,24 @@ export function applyContextRecolor(
 	) => {
 		const matrix = self.getTransform();
 		const bounds = tileBounds(matrix, candidate.rect);
+		// An unclipped page-covering draw repaints the canvas beneath it:
+		// covered state that lies (mostly) inside it is stale and must not
+		// bounce it as an "overlay" or block later strips in that area.
+		if (candidate.areaFraction >= SCAN_COVERAGE_MIN && !candidate.clipped) {
+			for (let i = coveredBounds.length - 1; i >= 0; i--) {
+				const covered = coveredBounds[i]!;
+				const intersection: DeviceBounds = [
+					Math.max(bounds[0], covered[0]),
+					Math.max(bounds[1], covered[1]),
+					Math.min(bounds[2], covered[2]),
+					Math.min(bounds[3], covered[3]),
+				];
+				const coveredArea = boundsArea(covered);
+				if (coveredArea > 0 && boundsArea(intersection) >= 0.8 * coveredArea) {
+					coveredBounds.splice(i, 1);
+				}
+			}
+		}
 		// White content landing on already-inverted paper is an overlay
 		// (logo, QR block, restated MRC layer) — inverting it again would
 		// un-invert those pixels.
@@ -536,8 +554,17 @@ export function applyContextRecolor(
 		styleProp: "fillStyle" | "strokeStyle",
 	) =>
 		function (this: CanvasRenderingContext2D, ...args: never[]): unknown {
-			paintSerial++;
 			const style = this[styleProp];
+			// Paints that cannot touch pixels (invisible OCR overlays) must
+			// not invalidate pending scan strips. Canvas normalizes
+			// 'transparent' to 'rgba(0, 0, 0, 0)' on readback.
+			if (
+				this.globalAlpha > 0 &&
+				style !== "transparent" &&
+				style !== "rgba(0, 0, 0, 0)"
+			) {
+				paintSerial++;
+			}
 			if (typeof style === "string") {
 				const mapped = map(style);
 				if (mapped !== style) {
@@ -574,6 +601,15 @@ export function applyContextRecolor(
 	for (const name of GRADIENT_METHODS)
 		record[name] = withMappedStops(target[name] as AnyFn);
 	record.drawImage = withImageHandling(target.drawImage as AnyFn);
+	const pristinePutImageData = target.putImageData as AnyFn;
+	record.putImageData = function (
+		this: CanvasRenderingContext2D,
+		...args: never[]
+	) {
+		// Direct pixel writes invalidate retroactive fills like any paint.
+		paintSerial++;
+		return pristinePutImageData.apply(this, args);
+	};
 	record.save = function (this: CanvasRenderingContext2D) {
 		clipFlags.push(clipFlags[clipFlags.length - 1]!);
 		return pristineSave.call(this);
@@ -595,6 +631,7 @@ export function applyContextRecolor(
 			...STROKE_METHODS,
 			...GRADIENT_METHODS,
 			"drawImage",
+			"putImageData",
 			"save",
 			"restore",
 			"clip",

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -700,6 +700,15 @@ export function applyContextRecolor(
 		paintSerial++;
 		return pristinePutImageData.apply(this, args);
 	};
+	const pristineClearRect = target.clearRect as AnyFn;
+	record.clearRect = function (
+		this: CanvasRenderingContext2D,
+		...args: never[]
+	) {
+		// Erasing pixels invalidates retroactive fills like any paint.
+		paintSerial++;
+		return pristineClearRect.apply(this, args);
+	};
 	record.save = function (this: CanvasRenderingContext2D) {
 		clipFlags.push(clipFlags[clipFlags.length - 1]!);
 		return pristineSave.call(this);
@@ -722,6 +731,7 @@ export function applyContextRecolor(
 			...GRADIENT_METHODS,
 			"drawImage",
 			"putImageData",
+			"clearRect",
 			"save",
 			"restore",
 			"clip",

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -1,6 +1,6 @@
 import type { RenderColorMap } from "./dark-mode";
 import {
-	isScanPaperSource,
+	classifyScanPaper,
 	SCAN_COVERAGE_MIN,
 	SCAN_TILE_DENSITY_MIN,
 	SCAN_TILE_MIN_FRACTION,
@@ -204,7 +204,12 @@ export function applyContextRecolor(
 	const scanCandidate = (
 		self: CanvasRenderingContext2D,
 		args: readonly unknown[],
-	): { rect: DestRect; areaFraction: number; clipped: boolean } | null => {
+	): {
+		rect: DestRect;
+		areaFraction: number;
+		clipped: boolean;
+		inked: boolean;
+	} | null => {
 		if (!scanEnabled || !pageArea) return null;
 		if (self.globalCompositeOperation !== "source-over") return null;
 		if (self.globalAlpha < 0.99) return null;
@@ -227,8 +232,9 @@ export function applyContextRecolor(
 						sh: args[4] as number,
 					}
 				: undefined;
-		if (!isScanPaperSource(args[0] as CanvasImageSource, crop)) return null;
-		return { rect, areaFraction, clipped: clipActive() };
+		const paper = classifyScanPaper(args[0] as CanvasImageSource, crop);
+		if (!paper) return null;
+		return { rect, areaFraction, clipped: clipActive(), inked: paper.inked };
 	};
 
 	const grayCss = (value: number) => `rgb(${value}, ${value}, ${value})`;
@@ -289,8 +295,13 @@ export function applyContextRecolor(
 	}
 	const OVERLAP_TOLERANCE = 0.2;
 	let pendingTileArea = 0;
+	let pendingHasInk = false;
 	const pendingTiles: PendingTile[] = [];
 	const coveredBounds: DeviceBounds[] = [];
+	// Bumped on every vector fill/stroke: a retroactive tile fill is only
+	// safe when nothing vector was painted since the first pending strip.
+	let paintSerial = 0;
+	let pendingBaselineSerial = 0;
 
 	const tileBounds = (matrix: DOMMatrix, rect: DestRect): DeviceBounds => {
 		const corners = [
@@ -325,14 +336,82 @@ export function applyContextRecolor(
 			);
 		});
 
-	const markCovered = (self: CanvasRenderingContext2D, tile: PendingTile) => {
-		invertScanRect(self, tile.rect, tile.matrix);
-		coveredBounds.push(tile.bounds);
+	const AXIS_EPS = 1e-6;
+	const isAxisAligned = (m: DOMMatrix) =>
+		Math.abs(m.b) < AXIS_EPS && Math.abs(m.c) < AXIS_EPS;
+	const IDENTITY_MATRIX =
+		typeof DOMMatrix !== "undefined" ? new DOMMatrix() : null;
+
+	// Subtract a hole from each rect, keeping the up-to-4 remainder pieces.
+	const subtractBounds = (
+		rects: DeviceBounds[],
+		hole: DeviceBounds,
+	): DeviceBounds[] => {
+		const out: DeviceBounds[] = [];
+		for (const r of rects) {
+			const ix0 = Math.max(r[0], hole[0]);
+			const iy0 = Math.max(r[1], hole[1]);
+			const ix1 = Math.min(r[2], hole[2]);
+			const iy1 = Math.min(r[3], hole[3]);
+			if (ix0 >= ix1 || iy0 >= iy1) {
+				out.push(r);
+				continue;
+			}
+			if (r[1] < iy0) out.push([r[0], r[1], r[2], iy0]);
+			if (iy1 < r[3]) out.push([r[0], iy1, r[2], r[3]]);
+			if (r[0] < ix0) out.push([r[0], iy0, ix0, iy1]);
+			if (ix1 < r[2]) out.push([ix1, iy0, r[2], iy1]);
+		}
+		return out;
+	};
+
+	// Invert only the parts of a tile that no earlier fill already inverted —
+	// a second difference fill would flip overlap pixels back. Device-space
+	// remainders need an axis-aligned tile; rotated tiles (rare) fall back to
+	// a full-rect fill and accept the seam.
+	const invertTileRemainder = (
+		self: CanvasRenderingContext2D,
+		tile: PendingTile,
+		holes: DeviceBounds[],
+	) => {
+		if (!isAxisAligned(tile.matrix) || !IDENTITY_MATRIX) {
+			invertScanRect(self, tile.rect, tile.matrix);
+			return;
+		}
+		let pieces: DeviceBounds[] = [tile.bounds];
+		for (const hole of holes) pieces = subtractBounds(pieces, hole);
+		for (const piece of pieces) {
+			if (piece[2] - piece[0] < 0.5 || piece[3] - piece[1] < 0.5) continue;
+			invertScanRect(
+				self,
+				[piece[0], piece[1], piece[2] - piece[0], piece[3] - piece[1]],
+				IDENTITY_MATRIX,
+			);
+		}
+	};
+
+	const flushPendingTiles = (self: CanvasRenderingContext2D) => {
+		// Vector content painted between strips (annotations, signatures)
+		// would be inverted by a retroactive fill — leave the page as-is.
+		if (paintSerial === pendingBaselineSerial) {
+			for (const pending of pendingTiles) {
+				invertTileRemainder(self, pending, coveredBounds);
+				coveredBounds.push(pending.bounds);
+			}
+		}
+		pendingTiles.length = 0;
+		pendingTileArea = 0;
+		pendingHasInk = false;
 	};
 
 	const handleScanCandidate = (
 		self: CanvasRenderingContext2D,
-		candidate: { rect: DestRect; areaFraction: number; clipped: boolean },
+		candidate: {
+			rect: DestRect;
+			areaFraction: number;
+			clipped: boolean;
+			inked: boolean;
+		},
 	) => {
 		const matrix = self.getTransform();
 		const bounds = tileBounds(matrix, candidate.rect);
@@ -341,7 +420,18 @@ export function applyContextRecolor(
 		// un-invert those pixels.
 		if (overlapsAny(bounds, coveredBounds)) return;
 		const tile: PendingTile = { rect: candidate.rect, matrix, bounds };
+		// Disjoint white paper arriving on a page already proven to be a scan
+		// is a continuation strip (blank margins included) — invert in place.
+		if (coveredBounds.length > 0 && !candidate.clipped) {
+			invertTileRemainder(self, tile, coveredBounds);
+			coveredBounds.push(tile.bounds);
+			return;
+		}
 		if (candidate.areaFraction >= SCAN_COVERAGE_MIN) {
+			// A page-covering pure-white raster is an MRC background layer or
+			// a blank page: its ink lives elsewhere (or nowhere) and must
+			// stay readable, so the page keeps its light rendering.
+			if (!candidate.inked) return;
 			// The fills inherit the draw's clip, so a clipped draw inverts
 			// exactly the pixels it painted; its true footprint is unknown,
 			// though, so it never counts as covered/pending geometry.
@@ -349,16 +439,11 @@ export function applyContextRecolor(
 				invertScanRect(self, candidate.rect, matrix);
 				return;
 			}
-			markCovered(self, tile);
-			// Strips that accumulated before a page-covering draw appeared:
-			// invert the ones the new draw doesn't already repaint.
-			for (const pending of pendingTiles) {
-				if (!overlapsAny(pending.bounds, coveredBounds)) {
-					markCovered(self, pending);
-				}
-			}
-			pendingTiles.length = 0;
-			pendingTileArea = 0;
+			invertScanRect(self, tile.rect, tile.matrix);
+			coveredBounds.push(tile.bounds);
+			// Strips that accumulated before the page-covering draw appeared:
+			// invert whatever parts of them it did not repaint.
+			flushPendingTiles(self);
 			return;
 		}
 		if (candidate.clipped) return;
@@ -369,9 +454,14 @@ export function applyContextRecolor(
 			)
 		)
 			return;
+		if (pendingTiles.length === 0) pendingBaselineSerial = paintSerial;
 		pendingTiles.push(tile);
 		pendingTileArea += candidate.areaFraction;
+		pendingHasInk ||= candidate.inked;
 		if (pendingTileArea < SCAN_COVERAGE_MIN) return;
+		// Blank tiles count toward coverage, but a page only inverts when its
+		// strips carry ink somewhere (pure-white stacks are MRC backgrounds).
+		if (!pendingHasInk) return;
 		const union: DeviceBounds = [
 			Math.min(...pendingTiles.map((t) => t.bounds[0])),
 			Math.min(...pendingTiles.map((t) => t.bounds[1])),
@@ -382,11 +472,7 @@ export function applyContextRecolor(
 		if (unionArea <= 0) return;
 		const density = (pendingTileArea * (pageArea ?? 0)) / unionArea;
 		if (density < SCAN_TILE_DENSITY_MIN) return;
-		for (const tile2 of pendingTiles.slice()) {
-			markCovered(self, tile2);
-		}
-		pendingTiles.length = 0;
-		pendingTileArea = 0;
+		flushPendingTiles(self);
 	};
 
 	const withImageHandling = (original: AnyFn) =>
@@ -431,6 +517,7 @@ export function applyContextRecolor(
 		styleProp: "fillStyle" | "strokeStyle",
 	) =>
 		function (this: CanvasRenderingContext2D, ...args: never[]): unknown {
+			paintSerial++;
 			const style = this[styleProp];
 			if (typeof style === "string") {
 				const mapped = map(style);

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -433,8 +433,15 @@ export function applyContextRecolor(
 		if (candidate.areaFraction >= SCAN_COVERAGE_MIN) {
 			// A page-covering pure-white raster is an MRC background layer or
 			// a blank page: its ink lives elsewhere (or nowhere) and must
-			// stay readable, so the page keeps its light rendering.
-			if (!candidate.inked) return;
+			// stay readable, so the page keeps its light rendering. It also
+			// repainted whatever strips had accumulated — abandon them so a
+			// later flush can't difference-fill on top of the fresh layer.
+			if (!candidate.inked) {
+				pendingTiles.length = 0;
+				pendingTileArea = 0;
+				pendingHasInk = false;
+				return;
+			}
 			// The fills inherit the draw's clip, so a clipped draw inverts
 			// exactly the pixels it painted; its true footprint is unknown,
 			// though, so it never counts as covered/pending geometry.

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -204,7 +204,7 @@ export function applyContextRecolor(
 	const scanCandidate = (
 		self: CanvasRenderingContext2D,
 		args: readonly unknown[],
-	): { rect: DestRect; areaFraction: number } | null => {
+	): { rect: DestRect; areaFraction: number; clipped: boolean } | null => {
 		if (!scanEnabled || !pageArea) return null;
 		if (self.globalCompositeOperation !== "source-over") return null;
 		if (self.globalAlpha < 0.99) return null;
@@ -228,10 +228,20 @@ export function applyContextRecolor(
 					}
 				: undefined;
 		if (!isScanPaperSource(args[0] as CanvasImageSource, crop)) return null;
-		return { rect, areaFraction };
+		return { rect, areaFraction, clipped: clipActive() };
 	};
 
 	const grayCss = (value: number) => `rgb(${value}, ${value}, ${value})`;
+
+	// Canvas 2D has no clip readback, so track whether ANY clip is active:
+	// inversion fills inherit a clipped draw's clip (correct by construction),
+	// but clipped geometry can't participate in tile/covered bookkeeping —
+	// its true painted footprint is unknown.
+	const clipFlags: boolean[] = [false];
+	const clipActive = () => clipFlags[clipFlags.length - 1] === true;
+	const pristineSave = target.save;
+	const pristineRestore = target.restore;
+	const pristineClip = target.clip;
 
 	const invertScanRect = (
 		self: CanvasRenderingContext2D,
@@ -268,16 +278,19 @@ export function applyContextRecolor(
 	// the wrapper is re-applied per render) and are inverted retroactively
 	// once they sum to page coverage AND tile densely (summed area ≈ their
 	// union box), which scattered white screenshots on a text page never do.
-	// Overlapping tiles are never accumulated: a second difference fill would
-	// un-invert the overlap (MRC layer stacks land here).
+	// Inverted regions are remembered: a later white draw landing on already
+	// inverted paper (a logo, a QR block, an MRC layer restating the page) is
+	// left alone — a second difference fill would un-invert it. Small strip
+	// overlaps (seam-avoidance in real rasterizers) stay within the tolerance.
 	interface PendingTile {
 		rect: DestRect;
 		matrix: DOMMatrix;
 		bounds: DeviceBounds;
 	}
-	let scanPageDetected = false;
+	const OVERLAP_TOLERANCE = 0.2;
 	let pendingTileArea = 0;
 	const pendingTiles: PendingTile[] = [];
+	const coveredBounds: DeviceBounds[] = [];
 
 	const tileBounds = (matrix: DOMMatrix, rect: DestRect): DeviceBounds => {
 		const corners = [
@@ -294,22 +307,69 @@ export function applyContextRecolor(
 		];
 	};
 
-	const boundsOverlap = (a: DeviceBounds, b: DeviceBounds) =>
-		a[0] < b[2] && b[0] < a[2] && a[1] < b[3] && b[1] < a[3];
+	const boundsArea = (b: DeviceBounds) =>
+		Math.max(0, b[2] - b[0]) * Math.max(0, b[3] - b[1]);
+
+	// Overlap beyond a fraction of the smaller box; 1px seam overlaps pass.
+	const overlapsAny = (bounds: DeviceBounds, others: DeviceBounds[]) =>
+		others.some((other) => {
+			const intersection: DeviceBounds = [
+				Math.max(bounds[0], other[0]),
+				Math.max(bounds[1], other[1]),
+				Math.min(bounds[2], other[2]),
+				Math.min(bounds[3], other[3]),
+			];
+			const smaller = Math.min(boundsArea(bounds), boundsArea(other));
+			return (
+				smaller > 0 && boundsArea(intersection) > OVERLAP_TOLERANCE * smaller
+			);
+		});
+
+	const markCovered = (self: CanvasRenderingContext2D, tile: PendingTile) => {
+		invertScanRect(self, tile.rect, tile.matrix);
+		coveredBounds.push(tile.bounds);
+	};
 
 	const handleScanCandidate = (
 		self: CanvasRenderingContext2D,
-		candidate: { rect: DestRect; areaFraction: number },
+		candidate: { rect: DestRect; areaFraction: number; clipped: boolean },
 	) => {
 		const matrix = self.getTransform();
-		if (scanPageDetected || candidate.areaFraction >= SCAN_COVERAGE_MIN) {
-			scanPageDetected = true;
-			invertScanRect(self, candidate.rect, matrix);
+		const bounds = tileBounds(matrix, candidate.rect);
+		// White content landing on already-inverted paper is an overlay
+		// (logo, QR block, restated MRC layer) — inverting it again would
+		// un-invert those pixels.
+		if (overlapsAny(bounds, coveredBounds)) return;
+		const tile: PendingTile = { rect: candidate.rect, matrix, bounds };
+		if (candidate.areaFraction >= SCAN_COVERAGE_MIN) {
+			// The fills inherit the draw's clip, so a clipped draw inverts
+			// exactly the pixels it painted; its true footprint is unknown,
+			// though, so it never counts as covered/pending geometry.
+			if (candidate.clipped) {
+				invertScanRect(self, candidate.rect, matrix);
+				return;
+			}
+			markCovered(self, tile);
+			// Strips that accumulated before a page-covering draw appeared:
+			// invert the ones the new draw doesn't already repaint.
+			for (const pending of pendingTiles) {
+				if (!overlapsAny(pending.bounds, coveredBounds)) {
+					markCovered(self, pending);
+				}
+			}
+			pendingTiles.length = 0;
+			pendingTileArea = 0;
 			return;
 		}
-		const bounds = tileBounds(matrix, candidate.rect);
-		if (pendingTiles.some((tile) => boundsOverlap(tile.bounds, bounds))) return;
-		pendingTiles.push({ rect: candidate.rect, matrix, bounds });
+		if (candidate.clipped) return;
+		if (
+			overlapsAny(
+				bounds,
+				pendingTiles.map((t) => t.bounds),
+			)
+		)
+			return;
+		pendingTiles.push(tile);
 		pendingTileArea += candidate.areaFraction;
 		if (pendingTileArea < SCAN_COVERAGE_MIN) return;
 		const union: DeviceBounds = [
@@ -318,15 +378,15 @@ export function applyContextRecolor(
 			Math.max(...pendingTiles.map((t) => t.bounds[2])),
 			Math.max(...pendingTiles.map((t) => t.bounds[3])),
 		];
-		const unionArea = (union[2] - union[0]) * (union[3] - union[1]);
+		const unionArea = boundsArea(union);
 		if (unionArea <= 0) return;
 		const density = (pendingTileArea * (pageArea ?? 0)) / unionArea;
 		if (density < SCAN_TILE_DENSITY_MIN) return;
-		scanPageDetected = true;
-		for (const tile of pendingTiles) {
-			invertScanRect(self, tile.rect, tile.matrix);
+		for (const tile2 of pendingTiles.slice()) {
+			markCovered(self, tile2);
 		}
 		pendingTiles.length = 0;
+		pendingTileArea = 0;
 	};
 
 	const withImageHandling = (original: AnyFn) =>
@@ -408,6 +468,18 @@ export function applyContextRecolor(
 	for (const name of GRADIENT_METHODS)
 		record[name] = withMappedStops(target[name] as AnyFn);
 	record.drawImage = withImageHandling(target.drawImage as AnyFn);
+	record.save = function (this: CanvasRenderingContext2D) {
+		clipFlags.push(clipFlags[clipFlags.length - 1]!);
+		return pristineSave.call(this);
+	};
+	record.restore = function (this: CanvasRenderingContext2D) {
+		if (clipFlags.length > 1) clipFlags.pop();
+		return pristineRestore.call(this);
+	};
+	record.clip = function (this: CanvasRenderingContext2D, ...args: never[]) {
+		clipFlags[clipFlags.length - 1] = true;
+		return (pristineClip as AnyFn).apply(this, args);
+	};
 
 	const cleanup = () => {
 		// A later applyContextRecolor call already replaced these wrappers.
@@ -417,6 +489,9 @@ export function applyContextRecolor(
 			...STROKE_METHODS,
 			...GRADIENT_METHODS,
 			"drawImage",
+			"save",
+			"restore",
+			"clip",
 		])
 			delete record[name];
 		delete target[RECOLOR_CLEANUP];

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -459,12 +459,13 @@ export function applyContextRecolor(
 			pendingHasInk = false;
 			return;
 		}
-		// White content mostly inside already-inverted regions is an overlay
-		// (logo, QR block, restated partial layer): its freshly repainted
-		// pixels must stay un-inverted. A strip merely BRUSHING covered area
-		// is a continuation — it repainted its whole rect, so the full-rect
-		// fill below is exact even across the overlap.
-		if (coveredBounds.length > 0) {
+		// SMALL white content mostly inside already-inverted regions is an
+		// overlay (logo, QR block): its freshly repainted pixels must stay
+		// un-inverted. Size disambiguates the rest — a LARGE mostly-inside
+		// draw is a restated scan layer, and any strip merely brushing
+		// covered area is a continuation; both repainted their whole rect, so
+		// the full-rect fill below is exact even across the overlap.
+		if (coveredBounds.length > 0 && candidate.areaFraction <= 0.2) {
 			const candidateArea = boundsArea(bounds);
 			let insideArea = 0;
 			for (const covered of coveredBounds) {

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -458,10 +458,25 @@ export function applyContextRecolor(
 			pendingHasInk = false;
 			return;
 		}
-		// White content landing on already-inverted paper is an overlay
-		// (logo, QR block, restated MRC layer) — inverting it again would
-		// un-invert those pixels.
-		if (overlapsAny(bounds, coveredBounds)) return;
+		// White content mostly inside already-inverted regions is an overlay
+		// (logo, QR block, restated partial layer): its freshly repainted
+		// pixels must stay un-inverted. A strip merely BRUSHING covered area
+		// is a continuation — it repainted its whole rect, so the full-rect
+		// fill below is exact even across the overlap.
+		if (coveredBounds.length > 0) {
+			const candidateArea = boundsArea(bounds);
+			let insideArea = 0;
+			for (const covered of coveredBounds) {
+				const intersection: DeviceBounds = [
+					Math.max(bounds[0], covered[0]),
+					Math.max(bounds[1], covered[1]),
+					Math.min(bounds[2], covered[2]),
+					Math.min(bounds[3], covered[3]),
+				];
+				insideArea += boundsArea(intersection);
+			}
+			if (candidateArea > 0 && insideArea >= 0.8 * candidateArea) return;
+		}
 		// Disjoint white paper arriving on a page already proven to be a scan
 		// is a continuation strip (blank margins included) — invert in place.
 		// The draw just repainted its whole rect, so no earlier fill survives

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -2,6 +2,8 @@ import type { RenderColorMap } from "./dark-mode";
 import {
 	isScanPaperSource,
 	SCAN_COVERAGE_MIN,
+	SCAN_TILE_DENSITY_MIN,
+	SCAN_TILE_MIN_FRACTION,
 	sourceSize,
 } from "./scan-invert";
 
@@ -145,21 +147,40 @@ export function applyContextRecolor(
 	const mappedBlackLuma = parseHexLuma(map("#000000"));
 
 	const pageArea = options?.pageArea;
+	const scanEnabled =
+		!!pageArea &&
+		pageArea > 0 &&
+		mappedWhiteLuma !== null &&
+		mappedBlackLuma !== null;
 	// Difference-filling with this gray sends scan paper (255) exactly to the
-	// mapped white pole's luma; ink lands near the light foreground. A second
-	// color-blend fill then tints the neutral result toward the palette
-	// background, so tinted palettes (e.g. warm or blue darks) match vector
-	// pages instead of landing on plain gray.
-	const scanInvertGray =
-		pageArea && pageArea > 0 && mappedWhiteLuma !== null
-			? 255 - Math.round(mappedWhiteLuma)
-			: null;
-	const scanTintCss = scanInvertGray !== null ? map("#ffffff") : null;
+	// mapped white pole's luma; an affine luma remap then pins ink to the
+	// foreground pole (paper is a fixed point of the remap), and a final
+	// color-blend fill tints the neutral result toward the palette background
+	// so tinted palettes match vector pages instead of landing on plain gray.
+	const scanInvertGray = scanEnabled ? 255 - Math.round(mappedWhiteLuma) : null;
+	const scanTintCss = scanEnabled ? map("#ffffff") : null;
+	let inkScaleGray = 255;
+	let inkOffsetGray = 0;
+	if (scanEnabled) {
+		const inkLuma = 255 - mappedWhiteLuma; // where ink lands post-difference
+		const span = inkLuma - mappedWhiteLuma;
+		if (span > 8) {
+			const scale = Math.min(
+				1,
+				Math.max(0, (mappedBlackLuma - mappedWhiteLuma) / span),
+			);
+			inkScaleGray = Math.round(scale * 255);
+			inkOffsetGray = Math.round(mappedWhiteLuma * (1 - scale));
+		}
+	}
+	const needsInkRemap = inkScaleGray < 253 || inkOffsetGray > 2;
 	// Captured pre-wrap: the inversion fills must not run through the
 	// style-mapping fillRect wrapper installed below.
 	const pristineFillRect = target.fillRect;
 
 	type DestRect = [number, number, number, number];
+	type DeviceBounds = [number, number, number, number];
+
 	const destRect = (args: readonly unknown[]): DestRect | null => {
 		if (args.length >= 9) {
 			return [args[5], args[6], args[7], args[8]] as DestRect;
@@ -177,14 +198,14 @@ export function applyContextRecolor(
 		];
 	};
 
-	// A qualifying draw papers the page under a plain composite. Checks run
+	// A candidate draw paints white paper under a plain composite. Checks run
 	// cheapest-first; pixel sampling (isScanPaperSource) comes last, and for
 	// cropped draws it samples exactly the drawn source region.
-	const scanInvertRect = (
+	const scanCandidate = (
 		self: CanvasRenderingContext2D,
 		args: readonly unknown[],
-	): DestRect | null => {
-		if (scanInvertGray === null || !pageArea) return null;
+	): { rect: DestRect; areaFraction: number } | null => {
+		if (!scanEnabled || !pageArea) return null;
 		if (self.globalCompositeOperation !== "source-over") return null;
 		if (self.globalAlpha < 0.99) return null;
 		const filter = self.filter;
@@ -195,7 +216,8 @@ export function applyContextRecolor(
 		const t = self.getTransform();
 		const painted =
 			Math.abs(t.a * t.d - t.b * t.c) * Math.abs(rect[2] * rect[3]);
-		if (painted < SCAN_COVERAGE_MIN * pageArea) return null;
+		const areaFraction = painted / pageArea;
+		if (areaFraction < SCAN_TILE_MIN_FRACTION) return null;
 		const crop =
 			args.length >= 9
 				? {
@@ -206,7 +228,105 @@ export function applyContextRecolor(
 					}
 				: undefined;
 		if (!isScanPaperSource(args[0] as CanvasImageSource, crop)) return null;
-		return rect;
+		return { rect, areaFraction };
+	};
+
+	const grayCss = (value: number) => `rgb(${value}, ${value}, ${value})`;
+
+	const invertScanRect = (
+		self: CanvasRenderingContext2D,
+		rect: DestRect,
+		matrix: DOMMatrix,
+	) => {
+		self.save();
+		self.setTransform(matrix);
+		self.globalAlpha = 1;
+		self.globalCompositeOperation = "difference";
+		self.fillStyle = grayCss(scanInvertGray ?? 0);
+		pristineFillRect.call(self, rect[0], rect[1], rect[2], rect[3]);
+		if (needsInkRemap) {
+			self.globalCompositeOperation = "multiply";
+			self.fillStyle = grayCss(inkScaleGray);
+			pristineFillRect.call(self, rect[0], rect[1], rect[2], rect[3]);
+			if (inkOffsetGray > 0) {
+				self.globalCompositeOperation = "lighter";
+				self.fillStyle = grayCss(inkOffsetGray);
+				pristineFillRect.call(self, rect[0], rect[1], rect[2], rect[3]);
+			}
+		}
+		if (scanTintCss) {
+			// Keep the inverted luma, adopt the palette's hue/chroma.
+			self.globalCompositeOperation = "color";
+			self.fillStyle = scanTintCss;
+			pristineFillRect.call(self, rect[0], rect[1], rect[2], rect[3]);
+		}
+		self.restore();
+	};
+
+	// Tiled scans: some raster PDFs paint a page as strips whose areas only
+	// paper the page in sum. Pending white tiles accumulate (per render pass —
+	// the wrapper is re-applied per render) and are inverted retroactively
+	// once they sum to page coverage AND tile densely (summed area ≈ their
+	// union box), which scattered white screenshots on a text page never do.
+	// Overlapping tiles are never accumulated: a second difference fill would
+	// un-invert the overlap (MRC layer stacks land here).
+	interface PendingTile {
+		rect: DestRect;
+		matrix: DOMMatrix;
+		bounds: DeviceBounds;
+	}
+	let scanPageDetected = false;
+	let pendingTileArea = 0;
+	const pendingTiles: PendingTile[] = [];
+
+	const tileBounds = (matrix: DOMMatrix, rect: DestRect): DeviceBounds => {
+		const corners = [
+			matrix.transformPoint({ x: rect[0], y: rect[1] }),
+			matrix.transformPoint({ x: rect[0] + rect[2], y: rect[1] }),
+			matrix.transformPoint({ x: rect[0], y: rect[1] + rect[3] }),
+			matrix.transformPoint({ x: rect[0] + rect[2], y: rect[1] + rect[3] }),
+		];
+		return [
+			Math.min(...corners.map((c) => c.x)),
+			Math.min(...corners.map((c) => c.y)),
+			Math.max(...corners.map((c) => c.x)),
+			Math.max(...corners.map((c) => c.y)),
+		];
+	};
+
+	const boundsOverlap = (a: DeviceBounds, b: DeviceBounds) =>
+		a[0] < b[2] && b[0] < a[2] && a[1] < b[3] && b[1] < a[3];
+
+	const handleScanCandidate = (
+		self: CanvasRenderingContext2D,
+		candidate: { rect: DestRect; areaFraction: number },
+	) => {
+		const matrix = self.getTransform();
+		if (scanPageDetected || candidate.areaFraction >= SCAN_COVERAGE_MIN) {
+			scanPageDetected = true;
+			invertScanRect(self, candidate.rect, matrix);
+			return;
+		}
+		const bounds = tileBounds(matrix, candidate.rect);
+		if (pendingTiles.some((tile) => boundsOverlap(tile.bounds, bounds))) return;
+		pendingTiles.push({ rect: candidate.rect, matrix, bounds });
+		pendingTileArea += candidate.areaFraction;
+		if (pendingTileArea < SCAN_COVERAGE_MIN) return;
+		const union: DeviceBounds = [
+			Math.min(...pendingTiles.map((t) => t.bounds[0])),
+			Math.min(...pendingTiles.map((t) => t.bounds[1])),
+			Math.max(...pendingTiles.map((t) => t.bounds[2])),
+			Math.max(...pendingTiles.map((t) => t.bounds[3])),
+		];
+		const unionArea = (union[2] - union[0]) * (union[3] - union[1]);
+		if (unionArea <= 0) return;
+		const density = (pendingTileArea * (pageArea ?? 0)) / unionArea;
+		if (density < SCAN_TILE_DENSITY_MIN) return;
+		scanPageDetected = true;
+		for (const tile of pendingTiles) {
+			invertScanRect(self, tile.rect, tile.matrix);
+		}
+		pendingTiles.length = 0;
 	};
 
 	const withImageHandling = (original: AnyFn) =>
@@ -240,23 +360,9 @@ export function applyContextRecolor(
 				return original.apply(this, args);
 			}
 
-			const scanRect = scanInvertRect(this, args);
+			const candidate = scanCandidate(this, args);
 			const result = original.apply(this, args);
-			if (scanRect) {
-				const [dx, dy, dw, dh] = scanRect;
-				this.save();
-				this.globalAlpha = 1;
-				this.globalCompositeOperation = "difference";
-				this.fillStyle = `rgb(${scanInvertGray}, ${scanInvertGray}, ${scanInvertGray})`;
-				pristineFillRect.call(this, dx, dy, dw, dh);
-				if (scanTintCss) {
-					// Keep the inverted luma, adopt the palette's hue/chroma.
-					this.globalCompositeOperation = "color";
-					this.fillStyle = scanTintCss;
-					pristineFillRect.call(this, dx, dy, dw, dh);
-				}
-				this.restore();
-			}
+			if (candidate) handleScanCandidate(this, candidate);
 			return result;
 		};
 

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -434,6 +434,22 @@ export function applyContextRecolor(
 				}
 			}
 		}
+		// A clipped page-covering draw repaints scan paper under its clip —
+		// possibly over already-inverted regions. The fill inherits the same
+		// live clip, so inverting NOW is exact: inside the clip everything was
+		// just repainted, outside it the fill cannot reach. It must run before
+		// the overlay guard (its bounds overlap covered state by definition on
+		// a rescan) and its unknown footprint never enters covered/pending
+		// geometry; pending strips may lie under it, so abandon them.
+		if (candidate.areaFraction >= SCAN_COVERAGE_MIN && candidate.clipped) {
+			if (candidate.inked) {
+				invertScanRect(self, candidate.rect, matrix);
+			}
+			pendingTiles.length = 0;
+			pendingTileArea = 0;
+			pendingHasInk = false;
+			return;
+		}
 		// White content landing on already-inverted paper is an overlay
 		// (logo, QR block, restated MRC layer) — inverting it again would
 		// un-invert those pixels.
@@ -455,19 +471,6 @@ export function applyContextRecolor(
 			// repainted whatever strips had accumulated — abandon them so a
 			// later flush can't difference-fill on top of the fresh layer.
 			if (!candidate.inked) {
-				pendingTiles.length = 0;
-				pendingTileArea = 0;
-				pendingHasInk = false;
-				return;
-			}
-			// The fills inherit the draw's clip, so a clipped draw inverts
-			// exactly the pixels it painted; its true footprint is unknown,
-			// though, so it never counts as covered/pending geometry.
-			if (candidate.clipped) {
-				invertScanRect(self, candidate.rect, matrix);
-				// Pending strips may partly lie under this clip-inverted
-				// region; a retroactive fill would flip it back. Abandon them
-				// (safe direction: those regions keep their light rendering).
 				pendingTiles.length = 0;
 				pendingTileArea = 0;
 				pendingHasInk = false;

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -298,8 +298,9 @@ export function applyContextRecolor(
 	let pendingHasInk = false;
 	const pendingTiles: PendingTile[] = [];
 	const coveredBounds: DeviceBounds[] = [];
-	// Bumped on every vector fill/stroke: a retroactive tile fill is only
-	// safe when nothing vector was painted since the first pending strip.
+	// Bumped on every paint that is not scan paper (vector fills/strokes,
+	// photos, figures): a retroactive tile fill is only safe when nothing
+	// else was painted since the first pending strip.
 	let paintSerial = 0;
 	let pendingBaselineSerial = 0;
 
@@ -422,8 +423,10 @@ export function applyContextRecolor(
 		const tile: PendingTile = { rect: candidate.rect, matrix, bounds };
 		// Disjoint white paper arriving on a page already proven to be a scan
 		// is a continuation strip (blank margins included) — invert in place.
+		// The draw just repainted its whole rect, so no earlier fill survives
+		// under it and the inversion applies to the full rect.
 		if (coveredBounds.length > 0 && !candidate.clipped) {
-			invertTileRemainder(self, tile, coveredBounds);
+			invertScanRect(self, tile.rect, tile.matrix);
 			coveredBounds.push(tile.bounds);
 			return;
 		}
@@ -437,6 +440,12 @@ export function applyContextRecolor(
 			// though, so it never counts as covered/pending geometry.
 			if (candidate.clipped) {
 				invertScanRect(self, candidate.rect, matrix);
+				// Pending strips may partly lie under this clip-inverted
+				// region; a retroactive fill would flip it back. Abandon them
+				// (safe direction: those regions keep their light rendering).
+				pendingTiles.length = 0;
+				pendingTileArea = 0;
+				pendingHasInk = false;
 				return;
 			}
 			invertScanRect(self, tile.rect, tile.matrix);
@@ -507,6 +516,9 @@ export function applyContextRecolor(
 			}
 
 			const candidate = scanCandidate(this, args);
+			// Non-paper draws (photos, figures) invalidate retroactive fills
+			// the same way vector paints do.
+			if (!candidate) paintSerial++;
 			const result = original.apply(this, args);
 			if (candidate) handleScanCandidate(this, candidate);
 			return result;

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -1,4 +1,9 @@
 import type { RenderColorMap } from "./dark-mode";
+import {
+	isScanPaperSource,
+	SCAN_COVERAGE_MIN,
+	sourceSize,
+} from "./scan-invert";
 
 const RECOLOR_CLEANUP = Symbol("lectorRecolorCleanup");
 const RECOLOR_PAINTED = Symbol("lectorRecolorPainted");
@@ -96,17 +101,31 @@ function correctLuminosityMask(
 	return tmp;
 }
 
+export interface RecolorContextOptions {
+	/**
+	 * Full-page area in the context's device space (viewport.width × height).
+	 * When provided, image draws that paper the page (≥ SCAN_COVERAGE_MIN of
+	 * this area) with near-white pixels — scanned pages — are inverted toward
+	 * the palette poles. Omit on pdf.js scratch canvases, whose device space
+	 * is not the page; a page-covering scan painted through one is still
+	 * caught when the scratch canvas is composed back onto a page context.
+	 */
+	pageArea?: number;
+}
+
 /**
  * Recolors a 2D context at draw time: every fill/stroke whose style is a
  * string is painted with `map(style)` and the original style is restored
  * right after, so pdf.js readbacks (`ctx.fillStyle`, `copyCtxState`,
  * save/restore) always observe original-document colors and nothing is ever
  * mapped twice. Gradients are recolored per stop at creation. `drawImage`
- * and `putImageData` are deliberately untouched — photos keep their pixels —
- * with one exception: a drawImage that composes a luminosity soft mask
+ * and `putImageData` keep image pixels untouched — photos stay photos — with
+ * two exceptions: a drawImage that composes a luminosity soft mask
  * (destination-in through a pdf.js `*_luminosity_map_*` filter) draws a
  * luma-corrected copy of the mask so the recoloring doesn't invert the
- * mask's alpha.
+ * mask's alpha, and a drawImage that papers the page with near-white pixels
+ * (a scanned page) is inverted toward the palette poles right after painting
+ * (policy in ./scan-invert.ts).
  *
  * Wrapping installs own properties on the context instance (the prototype is
  * never modified). Returns a cleanup that restores the pristine context.
@@ -114,6 +133,7 @@ function correctLuminosityMask(
 export function applyContextRecolor(
 	ctx: CanvasRenderingContext2D,
 	map: RenderColorMap,
+	options?: RecolorContextOptions,
 ): () => void {
 	const target = ctx as RecolorableContext;
 	// Re-wrapping replaces the previous map instead of stacking wrappers.
@@ -124,7 +144,58 @@ export function applyContextRecolor(
 	const mappedWhiteLuma = parseHexLuma(map("#ffffff"));
 	const mappedBlackLuma = parseHexLuma(map("#000000"));
 
-	const withMaskCorrection = (original: AnyFn) =>
+	const pageArea = options?.pageArea;
+	// Difference-filling with this gray sends scan paper (255) exactly to the
+	// mapped white pole; ink lands near the light foreground.
+	const scanInvertGray =
+		pageArea && pageArea > 0 && mappedWhiteLuma !== null
+			? 255 - Math.round(mappedWhiteLuma)
+			: null;
+	// Captured pre-wrap: the difference fill must not run through the
+	// style-mapping fillRect wrapper installed below.
+	const pristineFillRect = target.fillRect;
+
+	type DestRect = [number, number, number, number];
+	const destRect = (args: readonly unknown[]): DestRect | null => {
+		if (args.length >= 9) {
+			return [args[5], args[6], args[7], args[8]] as DestRect;
+		}
+		if (args.length >= 5) {
+			return [args[1], args[2], args[3], args[4]] as DestRect;
+		}
+		const size = sourceSize(args[0] as CanvasImageSource);
+		if (!size) return null;
+		return [
+			(args[1] as number) ?? 0,
+			(args[2] as number) ?? 0,
+			size.width,
+			size.height,
+		];
+	};
+
+	// A qualifying draw papers the page under a plain composite. Checks run
+	// cheapest-first; pixel sampling (isScanPaperSource) comes last.
+	const scanInvertRect = (
+		self: CanvasRenderingContext2D,
+		args: readonly unknown[],
+	): DestRect | null => {
+		if (scanInvertGray === null || !pageArea) return null;
+		if (self.globalCompositeOperation !== "source-over") return null;
+		if (self.globalAlpha < 0.99) return null;
+		const filter = self.filter;
+		if (typeof filter === "string" && filter !== "none" && filter !== "")
+			return null;
+		const rect = destRect(args);
+		if (!rect) return null;
+		const t = self.getTransform();
+		const painted =
+			Math.abs(t.a * t.d - t.b * t.c) * Math.abs(rect[2] * rect[3]);
+		if (painted < SCAN_COVERAGE_MIN * pageArea) return null;
+		if (!isScanPaperSource(args[0] as CanvasImageSource)) return null;
+		return rect;
+	};
+
+	const withImageHandling = (original: AnyFn) =>
 		function (this: CanvasRenderingContext2D, ...args: never[]): unknown {
 			if (
 				mappedWhiteLuma !== null &&
@@ -152,8 +223,21 @@ export function applyContextRecolor(
 					const next = [corrected, ...args.slice(1)] as never[];
 					return original.apply(this, next);
 				}
+				return original.apply(this, args);
 			}
-			return original.apply(this, args);
+
+			const scanRect = scanInvertRect(this, args);
+			const result = original.apply(this, args);
+			if (scanRect) {
+				const [dx, dy, dw, dh] = scanRect;
+				this.save();
+				this.globalCompositeOperation = "difference";
+				this.globalAlpha = 1;
+				this.fillStyle = `rgb(${scanInvertGray}, ${scanInvertGray}, ${scanInvertGray})`;
+				pristineFillRect.call(this, dx, dy, dw, dh);
+				this.restore();
+			}
+			return result;
 		};
 
 	const withMappedStyle = (
@@ -197,7 +281,7 @@ export function applyContextRecolor(
 		record[name] = withMappedStyle(target[name] as AnyFn, "strokeStyle");
 	for (const name of GRADIENT_METHODS)
 		record[name] = withMappedStops(target[name] as AnyFn);
-	record.drawImage = withMaskCorrection(target.drawImage as AnyFn);
+	record.drawImage = withImageHandling(target.drawImage as AnyFn);
 
 	const cleanup = () => {
 		// A later applyContextRecolor call already replaced these wrappers.

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -31,7 +31,8 @@ function ntscLuma(r: number, g: number, b: number): number {
 }
 
 function parseHexLuma(color: string): number | null {
-	if (!/^#[0-9a-f]{6}$/i.test(color)) return null;
+	// toCssColor emits #rrggbb, or #rrggbbaa for translucent palette colors.
+	if (!/^#[0-9a-f]{6}([0-9a-f]{2})?$/i.test(color)) return null;
 	return ntscLuma(
 		Number.parseInt(color.slice(1, 3), 16),
 		Number.parseInt(color.slice(3, 5), 16),

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -257,6 +257,11 @@ export function applyContextRecolor(
 		self.save();
 		self.setTransform(matrix);
 		self.globalAlpha = 1;
+		// Shadow state from the image draw must not smear the fills.
+		self.shadowColor = "rgba(0, 0, 0, 0)";
+		self.shadowBlur = 0;
+		self.shadowOffsetX = 0;
+		self.shadowOffsetY = 0;
 		self.globalCompositeOperation = "difference";
 		self.fillStyle = grayCss(scanInvertGray ?? 0);
 		pristineFillRect.call(self, rect[0], rect[1], rect[2], rect[3]);
@@ -292,6 +297,9 @@ export function applyContextRecolor(
 		rect: DestRect;
 		matrix: DOMMatrix;
 		bounds: DeviceBounds;
+		/** Non-overlapping area contributed toward coverage, as a page fraction. */
+		area: number;
+		inked: boolean;
 	}
 	const OVERLAP_TOLERANCE = 0.2;
 	let pendingTileArea = 0;
@@ -454,40 +462,49 @@ export function applyContextRecolor(
 		// (logo, QR block, restated MRC layer) — inverting it again would
 		// un-invert those pixels.
 		if (overlapsAny(bounds, coveredBounds)) return;
-		const tile: PendingTile = { rect: candidate.rect, matrix, bounds };
 		// Disjoint white paper arriving on a page already proven to be a scan
 		// is a continuation strip (blank margins included) — invert in place.
 		// The draw just repainted its whole rect, so no earlier fill survives
 		// under it and the inversion applies to the full rect.
 		if (coveredBounds.length > 0 && !candidate.clipped) {
-			invertScanRect(self, tile.rect, tile.matrix);
-			coveredBounds.push(tile.bounds);
+			invertScanRect(self, candidate.rect, matrix);
+			coveredBounds.push(bounds);
 			return;
 		}
-		if (candidate.areaFraction >= SCAN_COVERAGE_MIN) {
-			// A page-covering pure-white raster can't invert on its own: its
-			// ink may live in a separate MRC layer that must stay readable, or
-			// the page may simply be blank. It repainted whatever strips had
-			// accumulated, so it REPLACES them as one big blank pending tile —
-			// a later inked tile completes the page (large blank tile + inked
-			// tile scans), while a dark MRC ink layer is a non-paper draw that
-			// bumps the paint serial and discards it.
-			if (!candidate.inked) {
-				pendingTiles.length = 0;
-				pendingHasInk = false;
-				pendingBaselineSerial = paintSerial;
-				pendingTiles.push(tile);
-				pendingTileArea = candidate.areaFraction;
-				return;
-			}
-			invertScanRect(self, tile.rect, tile.matrix);
-			coveredBounds.push(tile.bounds);
+		if (candidate.areaFraction >= SCAN_COVERAGE_MIN && candidate.inked) {
+			invertScanRect(self, candidate.rect, matrix);
+			coveredBounds.push(bounds);
 			// Strips that accumulated before the page-covering draw appeared:
 			// invert whatever parts of them it did not repaint.
 			flushPendingTiles(self);
 			return;
 		}
 		if (candidate.clipped) return;
+		if (candidate.areaFraction >= SCAN_COVERAGE_MIN) {
+			// A page-covering pure-white raster can't invert on its own: its
+			// ink may live in a separate MRC layer that must stay readable, or
+			// the page may simply be blank. It joins the tiling as a blank
+			// tile after pruning only the pending strips it actually repainted
+			// — disjoint inked strips keep their evidence ('inked strip + big
+			// blank band' scans complete), while a dark MRC ink layer is a
+			// non-paper draw that bumps the paint serial and discards the
+			// accumulation.
+			for (let i = pendingTiles.length - 1; i >= 0; i--) {
+				const pending = pendingTiles[i]!;
+				const intersection: DeviceBounds = [
+					Math.max(bounds[0], pending.bounds[0]),
+					Math.max(bounds[1], pending.bounds[1]),
+					Math.min(bounds[2], pending.bounds[2]),
+					Math.min(bounds[3], pending.bounds[3]),
+				];
+				const pendingArea = boundsArea(pending.bounds);
+				if (pendingArea > 0 && boundsArea(intersection) >= 0.8 * pendingArea) {
+					pendingTiles.splice(i, 1);
+				}
+			}
+			pendingTileArea = pendingTiles.reduce((sum, t) => sum + t.area, 0);
+			pendingHasInk = pendingTiles.some((t) => t.inked);
+		}
 		// Overlapping tiles are fine — the fills subtract already-filled
 		// regions — but only the non-overlapping remainder counts toward
 		// coverage, so restated layers can't inflate the sum.
@@ -509,7 +526,13 @@ export function applyContextRecolor(
 			return;
 		}
 		if (pendingTiles.length === 0) pendingBaselineSerial = paintSerial;
-		pendingTiles.push(tile);
+		pendingTiles.push({
+			rect: candidate.rect,
+			matrix,
+			bounds,
+			area: contributedArea,
+			inked: candidate.inked,
+		});
 		pendingTileArea += contributedArea;
 		pendingHasInk ||= candidate.inked;
 		if (pendingTileArea < SCAN_COVERAGE_MIN) return;

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -465,15 +465,19 @@ export function applyContextRecolor(
 			return;
 		}
 		if (candidate.areaFraction >= SCAN_COVERAGE_MIN) {
-			// A page-covering pure-white raster is an MRC background layer or
-			// a blank page: its ink lives elsewhere (or nowhere) and must
-			// stay readable, so the page keeps its light rendering. It also
-			// repainted whatever strips had accumulated — abandon them so a
-			// later flush can't difference-fill on top of the fresh layer.
+			// A page-covering pure-white raster can't invert on its own: its
+			// ink may live in a separate MRC layer that must stay readable, or
+			// the page may simply be blank. It repainted whatever strips had
+			// accumulated, so it REPLACES them as one big blank pending tile —
+			// a later inked tile completes the page (large blank tile + inked
+			// tile scans), while a dark MRC ink layer is a non-paper draw that
+			// bumps the paint serial and discards it.
 			if (!candidate.inked) {
 				pendingTiles.length = 0;
-				pendingTileArea = 0;
 				pendingHasInk = false;
+				pendingBaselineSerial = paintSerial;
+				pendingTiles.push(tile);
+				pendingTileArea = candidate.areaFraction;
 				return;
 			}
 			invertScanRect(self, tile.rect, tile.matrix);
@@ -484,16 +488,29 @@ export function applyContextRecolor(
 			return;
 		}
 		if (candidate.clipped) return;
-		if (
+		// Overlapping tiles are fine — the fills subtract already-filled
+		// regions — but only the non-overlapping remainder counts toward
+		// coverage, so restated layers can't inflate the sum.
+		let contributedArea = candidate.areaFraction;
+		if (isAxisAligned(matrix) && pageArea) {
+			let pieces: DeviceBounds[] = [bounds];
+			for (const pending of pendingTiles) {
+				pieces = subtractBounds(pieces, pending.bounds);
+			}
+			contributedArea =
+				pieces.reduce((sum, piece) => sum + boundsArea(piece), 0) / pageArea;
+		} else if (
 			overlapsAny(
 				bounds,
 				pendingTiles.map((t) => t.bounds),
 			)
-		)
+		) {
+			// Rotated tiles can't be subtracted exactly — keep the reject.
 			return;
+		}
 		if (pendingTiles.length === 0) pendingBaselineSerial = paintSerial;
 		pendingTiles.push(tile);
-		pendingTileArea += candidate.areaFraction;
+		pendingTileArea += contributedArea;
 		pendingHasInk ||= candidate.inked;
 		if (pendingTileArea < SCAN_COVERAGE_MIN) return;
 		// Blank tiles count toward coverage, but a page only inverts when its

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -146,12 +146,16 @@ export function applyContextRecolor(
 
 	const pageArea = options?.pageArea;
 	// Difference-filling with this gray sends scan paper (255) exactly to the
-	// mapped white pole; ink lands near the light foreground.
+	// mapped white pole's luma; ink lands near the light foreground. A second
+	// color-blend fill then tints the neutral result toward the palette
+	// background, so tinted palettes (e.g. warm or blue darks) match vector
+	// pages instead of landing on plain gray.
 	const scanInvertGray =
 		pageArea && pageArea > 0 && mappedWhiteLuma !== null
 			? 255 - Math.round(mappedWhiteLuma)
 			: null;
-	// Captured pre-wrap: the difference fill must not run through the
+	const scanTintCss = scanInvertGray !== null ? map("#ffffff") : null;
+	// Captured pre-wrap: the inversion fills must not run through the
 	// style-mapping fillRect wrapper installed below.
 	const pristineFillRect = target.fillRect;
 
@@ -174,7 +178,8 @@ export function applyContextRecolor(
 	};
 
 	// A qualifying draw papers the page under a plain composite. Checks run
-	// cheapest-first; pixel sampling (isScanPaperSource) comes last.
+	// cheapest-first; pixel sampling (isScanPaperSource) comes last, and for
+	// cropped draws it samples exactly the drawn source region.
 	const scanInvertRect = (
 		self: CanvasRenderingContext2D,
 		args: readonly unknown[],
@@ -191,7 +196,16 @@ export function applyContextRecolor(
 		const painted =
 			Math.abs(t.a * t.d - t.b * t.c) * Math.abs(rect[2] * rect[3]);
 		if (painted < SCAN_COVERAGE_MIN * pageArea) return null;
-		if (!isScanPaperSource(args[0] as CanvasImageSource)) return null;
+		const crop =
+			args.length >= 9
+				? {
+						sx: args[1] as number,
+						sy: args[2] as number,
+						sw: args[3] as number,
+						sh: args[4] as number,
+					}
+				: undefined;
+		if (!isScanPaperSource(args[0] as CanvasImageSource, crop)) return null;
 		return rect;
 	};
 
@@ -231,10 +245,16 @@ export function applyContextRecolor(
 			if (scanRect) {
 				const [dx, dy, dw, dh] = scanRect;
 				this.save();
-				this.globalCompositeOperation = "difference";
 				this.globalAlpha = 1;
+				this.globalCompositeOperation = "difference";
 				this.fillStyle = `rgb(${scanInvertGray}, ${scanInvertGray}, ${scanInvertGray})`;
 				pristineFillRect.call(this, dx, dy, dw, dh);
+				if (scanTintCss) {
+					// Keep the inverted luma, adopt the palette's hue/chroma.
+					this.globalCompositeOperation = "color";
+					this.fillStyle = scanTintCss;
+					pristineFillRect.call(this, dx, dy, dw, dh);
+				}
 				this.restore();
 			}
 			return result;

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -599,6 +599,9 @@ export function applyContextRecolor(
 				const corrected = sourcePainted
 					? correctLuminosityMask(source, mappedWhiteLuma, mappedBlackLuma)
 					: null;
+				// A destination-in compose mutates pixels under pending strips
+				// — it invalidates retroactive fills like any paint.
+				paintSerial++;
 				if (corrected) {
 					const next = [corrected, ...args.slice(1)] as never[];
 					return original.apply(this, next);
@@ -622,15 +625,18 @@ export function applyContextRecolor(
 		function (this: CanvasRenderingContext2D, ...args: never[]): unknown {
 			const style = this[styleProp];
 			// Paints that cannot touch pixels (invisible OCR overlays) must
-			// not invalidate pending scan strips. Canvas normalizes
-			// 'transparent' to 'rgba(0, 0, 0, 0)' on readback.
-			if (
-				this.globalAlpha > 0 &&
-				style !== "transparent" &&
-				style !== "rgba(0, 0, 0, 0)"
-			) {
-				paintSerial++;
-			}
+			// not invalidate pending scan strips: zero global alpha or any
+			// zero-alpha color (canvas readback normalizes to 'rgba(r, g, b,
+			// 0)', keeping the channels). Only source-over is harmless —
+			// zero-alpha ERASES under composites like destination-in.
+			const invisible =
+				this.globalCompositeOperation === "source-over" &&
+				(this.globalAlpha === 0 ||
+					style === "transparent" ||
+					(typeof style === "string" &&
+						style.startsWith("rgba(") &&
+						style.endsWith(", 0)")));
+			if (!invisible) paintSerial++;
 			if (typeof style === "string") {
 				const mapped = map(style);
 				if (mapped !== style) {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -299,6 +299,74 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(isScanPaperSource(source)).toBe(false);
 	});
 
+	it("rejects pure-white rasters (MRC background layers, blank pages)", () => {
+		const source = document.createElement("canvas");
+		source.width = 100;
+		source.height = 100;
+		const sctx = source.getContext("2d")!;
+		sctx.fillStyle = "#ffffff";
+		sctx.fillRect(0, 0, 100, 100);
+		expect(isScanPaperSource(source)).toBe(false);
+		// with ink present it qualifies again
+		expect(isScanPaperSource(makeScanSource())).toBe(true);
+	});
+
+	it("leaves white overlays on already-inverted paper alone", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100); // inverted
+		ctx.drawImage(makeScanSource(), 10, 60, 30, 30); // logo/QR overlay
+		const [r, g, b] = rgbAt(ctx, 15, 65); // inside the overlay
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+
+	it("tolerates seam-avoidance overlap between strips", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		// strips overlap by 2px — real rasterizers do this to avoid seams
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 52, 0, 0, 100, 52);
+		ctx.drawImage(makeScanSource(), 0, 50, 100, 50, 0, 50, 100, 50);
+		for (const y of [10, 90]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
+	});
+
+	it("flushes accumulated strips when a page-covering draw arrives", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		// a strip that only covers the top 30% accumulates… (its source crop
+		// straddles the ink bar so it reads as inked scan paper)
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		// …then a draw covering the remaining 70% triggers the immediate path
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 70, 0, 30, 100, 70);
+		for (const y of [10, 90]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
+	});
+
+	it("keeps clipped draws inside their clip when inverting", () => {
+		const ctx = makeCtx(100);
+		// pre-fill white before wrapping so the fill isn't recolored
+		ctx.fillStyle = "#ffffff";
+		ctx.fillRect(0, 0, 100, 100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.save();
+		ctx.beginPath();
+		ctx.rect(0, 0, 40, 40);
+		ctx.clip();
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		ctx.restore();
+		const [ir, ig, ib] = rgbAt(ctx, 10, 10); // inside clip: inverted
+		const insideLuma = 0.3 * ir + 0.59 * ig + 0.11 * ib;
+		expect(Math.abs(insideLuma - POLE_LUMA)).toBeLessThan(4);
+		const [or_, og, ob] = rgbAt(ctx, 80, 80); // outside clip: untouched
+		expect(Math.min(or_, og, ob)).toBeGreaterThan(240);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -448,6 +448,30 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.abs(clippedLuma - POLE_LUMA)).toBeLessThan(6);
 	});
 
+	it("abandons strips repainted by an MRC white layer", () => {
+		const white = document.createElement("canvas");
+		white.width = 100;
+		white.height = 100;
+		const wctx = white.getContext("2d")!;
+		wctx.fillStyle = "#ffffff";
+		wctx.fillRect(0, 0, 100, 100);
+
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		// a strip accumulates, then a pure-white page-covering layer repaints
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		ctx.drawImage(white, 0, 0);
+		// fresh inked strips cover the lower 70% and invert normally
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		// the white layer's region must NOT be retro-filled from stale strips
+		const [r, g, b] = rgbAt(ctx, 10, 10);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+		const [pr, pg, pb] = rgbAt(ctx, 10, 90);
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -715,6 +715,20 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
 	});
 
+	it("re-inverts large restated layers mostly inside covered area", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100); // inverted scan
+		// a 60%-page restated layer repaints mostly-covered area white —
+		// too large to be an overlay, so it re-inverts
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 48, 0, 10, 100, 60);
+		for (const y of [15, 65, 90]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -60,6 +60,31 @@ function makeColorfulSource(size = 100): HTMLCanvasElement {
 	return canvas;
 }
 
+/** White page with a saturated chart block covering ~30%. */
+function makeChartSlideSource(size = 100): HTMLCanvasElement {
+	const canvas = document.createElement("canvas");
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext("2d")!;
+	ctx.fillStyle = "#ffffff";
+	ctx.fillRect(0, 0, size, size);
+	ctx.fillStyle = "#e04010";
+	ctx.fillRect(size * 0.1, size * 0.1, size * 0.6, size * 0.5);
+	return canvas;
+}
+
+/** Mostly-white source with a transparent cut-out covering ~20%. */
+function makeCutOutSource(size = 100): HTMLCanvasElement {
+	const canvas = document.createElement("canvas");
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext("2d")!;
+	ctx.fillStyle = "#ffffff";
+	ctx.fillRect(0, 0, size, size);
+	ctx.clearRect(size * 0.3, size * 0.3, size * 0.45, size * 0.45);
+	return canvas;
+}
+
 describe("isScanPaperSource", () => {
 	it("accepts white paper with ink", () => {
 		expect(isScanPaperSource(makeScanSource())).toBe(true);
@@ -74,6 +99,32 @@ describe("isScanPaperSource", () => {
 		canvas.width = 50;
 		canvas.height = 50;
 		expect(isScanPaperSource(canvas)).toBe(false);
+	});
+
+	it("rejects white pages with a saturated chart block", () => {
+		expect(isScanPaperSource(makeChartSlideSource())).toBe(false);
+	});
+
+	it("rejects sources with transparent cut-outs", () => {
+		expect(isScanPaperSource(makeCutOutSource())).toBe(false);
+	});
+
+	it("samples only the cropped region when a crop is given", () => {
+		// left half scan paper, right half saturated color
+		const canvas = document.createElement("canvas");
+		canvas.width = 200;
+		canvas.height = 100;
+		const ctx = canvas.getContext("2d")!;
+		ctx.drawImage(makeScanSource(100), 0, 0);
+		ctx.fillStyle = "#c03020";
+		ctx.fillRect(100, 0, 100, 100);
+		expect(isScanPaperSource(canvas)).toBe(false);
+		expect(
+			isScanPaperSource(canvas, { sx: 0, sy: 0, sw: 100, sh: 100 }),
+		).toBe(true);
+		expect(
+			isScanPaperSource(canvas, { sx: 100, sy: 0, sw: 100, sh: 100 }),
+		).toBe(false);
 	});
 });
 
@@ -149,6 +200,47 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(ctx.fillStyle).toBe("#123456");
 		expect(ctx.globalCompositeOperation).toBe("source-over");
 		expect(ctx.globalAlpha).toBe(1);
+	});
+
+	it("inverts a cropped scan drawn from a mixed scratch canvas", () => {
+		const mixed = document.createElement("canvas");
+		mixed.width = 200;
+		mixed.height = 100;
+		const mctx = mixed.getContext("2d")!;
+		mctx.drawImage(makeScanSource(100), 0, 0);
+		mctx.fillStyle = "#c03020";
+		mctx.fillRect(100, 0, 100, 100);
+
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(mixed, 0, 0, 100, 100, 0, 0, 100, 100);
+		const [pr, pg, pb] = rgbAt(ctx, 10, 10);
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
+	it("does not invert white pages carrying a saturated chart", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeChartSlideSource(), 0, 0, 100, 100);
+		const [r, g, b] = rgbAt(ctx, 95, 95);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+
+	it("tints inverted paper toward a colored palette background", () => {
+		const BLUE_DARK = "#001b33";
+		const blueMap = (color: string) =>
+			color === "#ffffff" || color === "white"
+				? BLUE_DARK
+				: color === "#000000" || color === "black"
+					? LIGHT
+					: color;
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, blueMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		const [r, , b] = rgbAt(ctx, 10, 10);
+		// paper must carry the palette's blue hue, not neutral gray
+		expect(b).toBeGreaterThan(r + 8);
 	});
 
 	it("restores pristine drawImage on cleanup", () => {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -326,11 +326,56 @@ describe("scan inversion via applyContextRecolor", () => {
 		// strips overlap by 2px — real rasterizers do this to avoid seams
 		ctx.drawImage(makeScanSource(), 0, 0, 100, 52, 0, 0, 100, 52);
 		ctx.drawImage(makeScanSource(), 0, 50, 100, 50, 0, 50, 100, 50);
+		// paper on both strips lands on the pole
 		for (const y of [10, 90]) {
 			const [pr, pg, pb] = rgbAt(ctx, 10, y);
 			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
 			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
 		}
+		// the seam row lands on the source's ink bar: inverted once it reads
+		// light (~230); a double inversion would flip it back to dark
+		const [ir, ig, ib] = rgbAt(ctx, 10, 51);
+		expect(Math.min(ir, ig, ib)).toBeGreaterThan(200);
+	});
+
+	it("counts blank margin strips toward tiled coverage", () => {
+		const blank = document.createElement("canvas");
+		blank.width = 100;
+		blank.height = 30;
+		const bctx = blank.getContext("2d")!;
+		bctx.fillStyle = "#ffffff";
+		bctx.fillRect(0, 0, 100, 30);
+
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(blank, 0, 0); // blank top margin, 30%
+		// inked strips carrying the rest of the page
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		// paper samples avoid the source ink bar (rows 48-52 land at y≈50)
+		for (const y of [10, 45, 90]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
+	});
+
+	it("abandons retroactive inversion when vector content interleaves strips", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		// a vector annotation lands on the first strip…
+		ctx.fillStyle = "#ff0000";
+		ctx.fillRect(10, 10, 20, 5);
+		// …then the remaining strips arrive
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		// retro inversion would have flipped the annotation — page stays light
+		const [r, g, b] = rgbAt(ctx, 50, 5);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+		const [ar, ag, ab] = rgbAt(ctx, 15, 12); // annotation untouched
+		expect(ar).toBeGreaterThan(150);
+		expect(Math.max(ag, ab)).toBeLessThan(100);
 	});
 
 	it("flushes accumulated strips when a page-covering draw arrives", () => {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -685,6 +685,21 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.min(ir, ig, ib)).toBeGreaterThan(200);
 	});
 
+	it("inverts continuation strips that partially overlap covered area", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		// top 70% proves the page is a scan…
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 48, 0, 0, 100, 70);
+		// …then a continuation strip overlaps it by ~30% of its own area
+		// while extending into still-light page area
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 55, 100, 45);
+		for (const y of [10, 60, 95]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -119,9 +119,9 @@ describe("isScanPaperSource", () => {
 		ctx.fillStyle = "#c03020";
 		ctx.fillRect(100, 0, 100, 100);
 		expect(isScanPaperSource(canvas)).toBe(false);
-		expect(
-			isScanPaperSource(canvas, { sx: 0, sy: 0, sw: 100, sh: 100 }),
-		).toBe(true);
+		expect(isScanPaperSource(canvas, { sx: 0, sy: 0, sw: 100, sh: 100 })).toBe(
+			true,
+		);
 		expect(
 			isScanPaperSource(canvas, { sx: 100, sy: 0, sw: 100, sh: 100 }),
 		).toBe(false);

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -412,6 +412,42 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.min(or_, og, ob)).toBeGreaterThan(240);
 	});
 
+	it("abandons retroactive inversion when a photo interleaves strips", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		// a small photo lands between strips — retro fill would invert it
+		ctx.drawImage(makeColorfulSource(), 40, 5, 20, 15);
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		const [r, g, b] = rgbAt(ctx, 10, 5); // paper stays light
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+		const [pr, pg, pb] = rgbAt(ctx, 45, 8); // photo untouched
+		expect(pr).toBeGreaterThan(150);
+		expect(pg).toBeLessThan(100);
+	});
+
+	it("keeps retroactive fills out of clip-inverted regions", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		// a pending strip accumulates…
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		// …then a clipped page-covering scan inverts part of that strip
+		ctx.save();
+		ctx.beginPath();
+		ctx.rect(0, 0, 100, 20);
+		ctx.clip();
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		ctx.restore();
+		// …then the rest of the page arrives and triggers the retro fill
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		// the clip-inverted region must not be difference-filled again
+		const [cr, cg, cb] = rgbAt(ctx, 10, 10);
+		const clippedLuma = 0.3 * cr + 0.59 * cg + 0.11 * cb;
+		expect(Math.abs(clippedLuma - POLE_LUMA)).toBeLessThan(6);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -448,7 +448,7 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.abs(clippedLuma - POLE_LUMA)).toBeLessThan(6);
 	});
 
-	it("abandons strips repainted by an MRC white layer", () => {
+	it("completes a blank covering layer with later inked tiles", () => {
 		const white = document.createElement("canvas");
 		white.width = 100;
 		white.height = 100;
@@ -458,18 +458,47 @@ describe("scan inversion via applyContextRecolor", () => {
 
 		const ctx = makeCtx(100);
 		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
-		// a strip accumulates, then a pure-white page-covering layer repaints
-		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
-		ctx.drawImage(white, 0, 0);
-		// fresh inked strips cover the lower 70% and invert normally
-		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
-		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
-		// the white layer's region must NOT be retro-filled from stale strips
-		const [r, g, b] = rgbAt(ctx, 10, 10);
+		// a large blank layer alone must not invert…
+		ctx.drawImage(white, 0, 0, 100, 70);
+		const [wr, wg, wb] = rgbAt(ctx, 10, 10);
+		expect(Math.min(wr, wg, wb)).toBeGreaterThan(240);
+		// …but an inked tile completes the scanned page
+		// (paper samples avoid the ink bar, which lands at y≈84-87)
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 70, 100, 30);
+		for (const y of [10, 75]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
+	});
+
+	it("keeps true MRC pages light (white layer + dark ink layer)", () => {
+		const white = document.createElement("canvas");
+		white.width = 100;
+		white.height = 100;
+		const wctx = white.getContext("2d")!;
+		wctx.fillStyle = "#ffffff";
+		wctx.fillRect(0, 0, 100, 100);
+
+		// MRC ink layer: transparent background, dark glyph blobs
+		const inkLayer = document.createElement("canvas");
+		inkLayer.width = 100;
+		inkLayer.height = 100;
+		const ictx = inkLayer.getContext("2d")!;
+		ictx.fillStyle = "#000000";
+		ictx.fillRect(10, 20, 60, 4);
+		ictx.fillRect(10, 40, 70, 4);
+
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(white, 0, 0); // white background layer
+		ctx.drawImage(inkLayer, 0, 0); // dark ink layer (non-paper draw)
+		// even a later inked paper tile must not retro-invert the MRC page
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 60, 100, 40);
+		const [r, g, b] = rgbAt(ctx, 5, 5);
 		expect(Math.min(r, g, b)).toBeGreaterThan(240);
-		const [pr, pg, pb] = rgbAt(ctx, 10, 90);
-		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
-		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		const [ir, ig, ib] = rgbAt(ctx, 15, 22); // ink stays black
+		expect(Math.max(ir, ig, ib)).toBeLessThan(60);
 	});
 
 	it("classifies sparse scans (signature-only pages) as inked", () => {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -472,6 +472,71 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
 	});
 
+	it("classifies sparse scans (signature-only pages) as inked", () => {
+		const source = document.createElement("canvas");
+		source.width = 200;
+		source.height = 200;
+		const sctx = source.getContext("2d")!;
+		sctx.fillStyle = "#ffffff";
+		sctx.fillRect(0, 0, 200, 200);
+		sctx.fillStyle = "#000000";
+		sctx.fillRect(60, 150, 40, 8); // one short signature stroke
+		expect(isScanPaperSource(source)).toBe(true);
+	});
+
+	it("re-evaluates the page after a white layer repaints an inverted scan", () => {
+		const white = document.createElement("canvas");
+		white.width = 100;
+		white.height = 100;
+		const wctx = white.getContext("2d")!;
+		wctx.fillStyle = "#ffffff";
+		wctx.fillRect(0, 0, 100, 100);
+
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100); // inverted scan
+		ctx.drawImage(white, 0, 0); // MRC white layer repaints the page
+		const [wr, wg, wb] = rgbAt(ctx, 10, 10); // page is white again
+		expect(Math.min(wr, wg, wb)).toBeGreaterThan(240);
+		// strips after the repaint must not be blocked by stale covered state
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 40, 0, 0, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 40, 100, 40);
+		const [pr, pg, pb] = rgbAt(ctx, 10, 10);
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
+	it("aborts retroactive inversion when putImageData interleaves strips", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		const photo = new ImageData(20, 10);
+		photo.data.fill(180);
+		ctx.putImageData(photo, 40, 5);
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		const [r, g, b] = rgbAt(ctx, 10, 5); // page stays light
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+
+	it("ignores invisible paints between strips", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		// invisible OCR-style text ops must not invalidate the strips
+		ctx.globalAlpha = 0;
+		ctx.fillStyle = "#000000";
+		ctx.fillRect(10, 10, 30, 5);
+		ctx.globalAlpha = 1;
+		ctx.fillStyle = "transparent";
+		ctx.fillRect(10, 18, 30, 5);
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		const [pr, pg, pb] = rgbAt(ctx, 10, 5); // strips inverted normally
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -548,6 +548,41 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.min(r, g, b)).toBeGreaterThan(240);
 	});
 
+	it("treats luminosity mask composes between strips as interleaved content", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		// a luminosity soft-mask compose lands between strips
+		const mask = document.createElement("canvas");
+		mask.width = 100;
+		mask.height = 100;
+		mask.getContext("2d")!.fillStyle = "#ffffff";
+		mask.getContext("2d")!.fillRect(0, 0, 100, 100);
+		ctx.save();
+		ctx.globalCompositeOperation = "destination-in";
+		ctx.filter = "url(#pdf_luminosity_map_1)";
+		ctx.drawImage(mask, 0, 0);
+		ctx.restore();
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		// retroactive inversion abandoned — the page stays light
+		const [r, g, b] = rgbAt(ctx, 10, 5);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+
+	it("ignores zero-alpha colored paints between strips", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		ctx.fillStyle = "rgba(255, 255, 255, 0)"; // invisible non-black overlay
+		ctx.fillRect(10, 10, 30, 5);
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		const [pr, pg, pb] = rgbAt(ctx, 10, 5); // strips inverted normally
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
 	it("ignores invisible paints between strips", () => {
 		const ctx = makeCtx(100);
 		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -537,6 +537,25 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
 	});
 
+	it("re-inverts a clipped rescan over already-inverted paper", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100); // inverted scan
+		// a clipped page-covering redraw repaints the top region white…
+		ctx.save();
+		ctx.beginPath();
+		ctx.rect(0, 0, 100, 40);
+		ctx.clip();
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		ctx.restore();
+		// …and must be re-inverted within the clip; the rest stays inverted
+		for (const y of [10, 90]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(6);
+		}
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -576,6 +576,21 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.min(r, g, b)).toBeGreaterThan(240);
 	});
 
+	it("aborts retroactive inversion when clearRect interleaves strips", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		ctx.clearRect(40, 5, 20, 10); // erases part of the first strip
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		// the erased strip stays un-inverted; later clean strips invert
+		const [r, g, b] = rgbAt(ctx, 10, 5);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+		const [pr, pg, pb] = rgbAt(ctx, 10, 40);
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
 	it("ignores zero-alpha colored paints between strips", () => {
 		const ctx = makeCtx(100);
 		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -360,22 +360,28 @@ describe("scan inversion via applyContextRecolor", () => {
 		}
 	});
 
-	it("abandons retroactive inversion when vector content interleaves strips", () => {
+	it("protects annotated strips but inverts clean ones painted after", () => {
 		const ctx = makeCtx(100);
 		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
 		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
 		// a vector annotation lands on the first strip…
 		ctx.fillStyle = "#ff0000";
 		ctx.fillRect(10, 10, 20, 5);
-		// …then the remaining strips arrive
+		// …then strips covering the rest of the page arrive clean
 		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
 		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
-		// retro inversion would have flipped the annotation — page stays light
+		// the annotated strip stays light with the annotation untouched…
 		const [r, g, b] = rgbAt(ctx, 50, 5);
 		expect(Math.min(r, g, b)).toBeGreaterThan(240);
-		const [ar, ag, ab] = rgbAt(ctx, 15, 12); // annotation untouched
+		const [ar, ag, ab] = rgbAt(ctx, 15, 12);
 		expect(ar).toBeGreaterThan(150);
 		expect(Math.max(ag, ab)).toBeLessThan(100);
+		// …while the clean post-annotation strips invert
+		for (const y of [40, 90]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
 	});
 
 	it("flushes accumulated strips when a page-covering draw arrives", () => {
@@ -733,21 +739,6 @@ describe("scan inversion via applyContextRecolor", () => {
 			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
 			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
 		}
-	});
-
-	it("stays enabled for 8-digit hex palette poles", () => {
-		const alphaMap = (color: string) =>
-			color === "#ffffff" || color === "white"
-				? "#181a1bff"
-				: color === "#000000" || color === "black"
-					? "#e8e6e3ff"
-					: color;
-		const ctx = makeCtx(100);
-		applyContextRecolor(ctx, alphaMap, { pageArea: 100 * 100 });
-		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
-		const [pr, pg, pb] = rgbAt(ctx, 10, 10);
-		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
-		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
 	});
 
 	it("re-inverts large restated layers mostly inside covered area", () => {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -637,6 +637,24 @@ describe("scan inversion via applyContextRecolor", () => {
 		).toBe(true);
 	});
 
+	it("treats clipped white draws between strips as interleaved content", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 22, 100, 30, 0, 0, 100, 30);
+		// a clipped white paint lands on the first strip…
+		ctx.save();
+		ctx.beginPath();
+		ctx.rect(10, 5, 20, 10);
+		ctx.clip();
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		ctx.restore();
+		// …so retroactive inversion must be abandoned
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 30, 100, 40);
+		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
+		const [r, g, b] = rgbAt(ctx, 50, 5);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -655,6 +655,36 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.min(r, g, b)).toBeGreaterThan(240);
 	});
 
+	it("inverts scans encoded as a fine tile grid", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		const source = makeScanSource(100);
+		// 5×5 grid: 4% per tile, far below the old 5% floor
+		for (let row = 0; row < 5; row++) {
+			for (let col = 0; col < 5; col++) {
+				ctx.drawImage(
+					source,
+					col * 20,
+					row * 20,
+					20,
+					20,
+					col * 20,
+					row * 20,
+					20,
+					20,
+				);
+			}
+		}
+		for (const y of [10, 90]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
+		// the ink bar row survives as light ink
+		const [ir, ig, ib] = rgbAt(ctx, 50, 50);
+		expect(Math.min(ir, ig, ib)).toBeGreaterThan(200);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -700,6 +700,21 @@ describe("scan inversion via applyContextRecolor", () => {
 		}
 	});
 
+	it("stays enabled for 8-digit hex palette poles", () => {
+		const alphaMap = (color: string) =>
+			color === "#ffffff" || color === "white"
+				? "#181a1bff"
+				: color === "#000000" || color === "black"
+					? "#e8e6e3ff"
+					: color;
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, alphaMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		const [pr, pg, pb] = rgbAt(ctx, 10, 10);
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import { applyContextRecolor } from "./recolor-context";
+import { isScanPaperSource } from "./scan-invert";
+
+const DARK = "#181a1b";
+const LIGHT = "#e8e6e3";
+
+/** Test map mirroring the dark scheme's poles. */
+const testMap = (color: string) =>
+	color === "#ffffff" || color === "white"
+		? DARK
+		: color === "#000000" || color === "black"
+			? LIGHT
+			: color;
+
+// NTSC luma of the mapped white pole (#181a1b): where scan paper must land.
+const POLE_LUMA = 0.3 * 0x18 + 0.59 * 0x1a + 0.11 * 0x1b;
+
+function makeCtx(size = 100): CanvasRenderingContext2D {
+	const canvas = document.createElement("canvas");
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) throw new Error("no 2d context");
+	return ctx;
+}
+
+function rgbAt(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	y: number,
+): [number, number, number] {
+	const [r, g, b] = ctx.getImageData(x, y, 1, 1).data;
+	return [r!, g!, b!];
+}
+
+/** White "scan paper" with a black ink bar across the middle. */
+function makeScanSource(size = 100): HTMLCanvasElement {
+	const canvas = document.createElement("canvas");
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext("2d")!;
+	ctx.fillStyle = "#ffffff";
+	ctx.fillRect(0, 0, size, size);
+	ctx.fillStyle = "#000000";
+	ctx.fillRect(0, Math.floor(size / 2) - 2, size, 4);
+	return canvas;
+}
+
+function makeColorfulSource(size = 100): HTMLCanvasElement {
+	const canvas = document.createElement("canvas");
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext("2d")!;
+	ctx.fillStyle = "#c03020";
+	ctx.fillRect(0, 0, size, size);
+	ctx.fillStyle = "#2040c0";
+	ctx.fillRect(0, size / 2, size, size / 2);
+	return canvas;
+}
+
+describe("isScanPaperSource", () => {
+	it("accepts white paper with ink", () => {
+		expect(isScanPaperSource(makeScanSource())).toBe(true);
+	});
+
+	it("rejects colorful sources", () => {
+		expect(isScanPaperSource(makeColorfulSource())).toBe(false);
+	});
+
+	it("rejects transparent sources", () => {
+		const canvas = document.createElement("canvas");
+		canvas.width = 50;
+		canvas.height = 50;
+		expect(isScanPaperSource(canvas)).toBe(false);
+	});
+});
+
+describe("scan inversion via applyContextRecolor", () => {
+	it("inverts a page-covering scan toward the palette poles", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+
+		const [pr, pg, pb] = rgbAt(ctx, 10, 10); // paper
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+
+		const [ir, ig, ib] = rgbAt(ctx, 50, 50); // ink bar
+		expect(Math.min(ir, ig, ib)).toBeGreaterThan(200);
+	});
+
+	it("keeps colorful full-page images untouched (photos stay photos)", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeColorfulSource(), 0, 0, 100, 100);
+		const [r, g, b] = rgbAt(ctx, 10, 10);
+		expect(r).toBeGreaterThan(150);
+		expect(g).toBeLessThan(100);
+		expect(b).toBeLessThan(100);
+	});
+
+	it("keeps small white images untouched (figures, screenshots)", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 0, 30, 30);
+		const [r, g, b] = rgbAt(ctx, 10, 10);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+
+	it("does nothing without pageArea (scratch canvases)", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap);
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		const [r, g, b] = rgbAt(ctx, 10, 10);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+
+	it("counts coverage through the current transform", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.save();
+		ctx.scale(2, 2);
+		// 50x50 draw × 2x scale = full page
+		ctx.drawImage(makeScanSource(), 0, 0, 50, 50);
+		ctx.restore();
+		const [pr, pg, pb] = rgbAt(ctx, 10, 10);
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
+	it("skips non-source-over composites and translucent draws", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.globalAlpha = 0.5;
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		ctx.globalAlpha = 1;
+		const [r, g, b] = rgbAt(ctx, 10, 10);
+		expect(Math.min(r, g, b)).toBeGreaterThan(200);
+	});
+
+	it("leaves the context state untouched after inverting", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.fillStyle = "#123456";
+		ctx.globalCompositeOperation = "source-over";
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		expect(ctx.fillStyle).toBe("#123456");
+		expect(ctx.globalCompositeOperation).toBe("source-over");
+		expect(ctx.globalAlpha).toBe(1);
+	});
+
+	it("restores pristine drawImage on cleanup", () => {
+		const ctx = makeCtx(100);
+		const cleanup = applyContextRecolor(ctx, testMap, {
+			pageArea: 100 * 100,
+		});
+		cleanup();
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		const [r, g, b] = rgbAt(ctx, 10, 10);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+});

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -243,6 +243,62 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(b).toBeGreaterThan(r + 8);
 	});
 
+	it("pins ink to the foreground pole on asymmetric palettes", () => {
+		// black background, mid-gray foreground: without the remap, ink would
+		// land at 255 instead of the configured 200.
+		const asymmetricMap = (color: string) =>
+			color === "#ffffff" || color === "white"
+				? "#000000"
+				: color === "#000000" || color === "black"
+					? "#c8c8c8"
+					: color;
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, asymmetricMap, { pageArea: 100 * 100 });
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		const [pr, pg, pb] = rgbAt(ctx, 10, 10); // paper → background pole (0)
+		expect(Math.max(pr, pg, pb)).toBeLessThan(12);
+		const [ir, ig, ib] = rgbAt(ctx, 50, 50); // ink → foreground pole (200)
+		const inkLuma = 0.3 * ir + 0.59 * ig + 0.11 * ib;
+		expect(Math.abs(inkLuma - 200)).toBeLessThan(12);
+	});
+
+	it("inverts tiled scans once the strips paper the page", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		// two half-page strips, neither passes the per-draw coverage gate
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 50, 0, 0, 100, 50);
+		ctx.drawImage(makeScanSource(), 0, 50, 100, 50, 0, 50, 100, 50);
+		for (const y of [10, 90]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
+	});
+
+	it("does not invert scattered white figures on a text page", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		// four white screenshots totalling ~81% of the page, but separated by
+		// gutters — the density guard must keep them un-inverted
+		ctx.drawImage(makeScanSource(), 0, 0, 45, 45);
+		ctx.drawImage(makeScanSource(), 55, 0, 45, 45);
+		ctx.drawImage(makeScanSource(), 0, 55, 45, 45);
+		ctx.drawImage(makeScanSource(), 55, 55, 45, 45);
+		const [r, g, b] = rgbAt(ctx, 10, 10);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+
+	it("rejects semi-transparent white overlays", () => {
+		const source = document.createElement("canvas");
+		source.width = 100;
+		source.height = 100;
+		const sctx = source.getContext("2d")!;
+		sctx.globalAlpha = 0.8;
+		sctx.fillStyle = "#ffffff";
+		sctx.fillRect(0, 0, 100, 100);
+		expect(isScanPaperSource(source)).toBe(false);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -585,6 +585,58 @@ describe("scan inversion via applyContextRecolor", () => {
 		}
 	});
 
+	it("keeps ink evidence from strips a blank band did not repaint", () => {
+		const blank = document.createElement("canvas");
+		blank.width = 100;
+		blank.height = 70;
+		const bctx = blank.getContext("2d")!;
+		bctx.fillStyle = "#ffffff";
+		bctx.fillRect(0, 0, 100, 70);
+
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		// small inked strip first…
+		ctx.drawImage(makeScanSource(), 0, 30, 100, 40, 0, 0, 100, 30);
+		// …then a large blank band that does NOT repaint it
+		ctx.drawImage(blank, 0, 30);
+		for (const y of [10, 80]) {
+			const [pr, pg, pb] = rgbAt(ctx, 10, y);
+			const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+			expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+		}
+	});
+
+	it("ignores active shadow state when inverting", () => {
+		const ctx = makeCtx(100);
+		applyContextRecolor(ctx, testMap, { pageArea: 100 * 100 });
+		ctx.shadowColor = "#ff0000";
+		ctx.shadowBlur = 12;
+		ctx.shadowOffsetX = 25;
+		ctx.shadowOffsetY = 25;
+		ctx.drawImage(makeScanSource(), 0, 0, 100, 100);
+		// paper lands on the pole with no red shadow smear anywhere
+		for (const [x, y] of [
+			[10, 10],
+			[90, 90],
+		] as const) {
+			const [r, g, b] = rgbAt(ctx, x, y);
+			const luma = 0.3 * r + 0.59 * g + 0.11 * b;
+			expect(Math.abs(luma - POLE_LUMA)).toBeLessThan(6);
+			expect(Math.abs(r - g)).toBeLessThan(12);
+		}
+	});
+
+	it("classifies crops with negative source dimensions", () => {
+		expect(
+			isScanPaperSource(makeScanSource(), {
+				sx: 100,
+				sy: 100,
+				sw: -100,
+				sh: -100,
+			}),
+		).toBe(true);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -422,7 +422,7 @@ describe("scan inversion via applyContextRecolor", () => {
 		ctx.drawImage(makeScanSource(), 0, 62, 100, 30, 0, 70, 100, 30);
 		const [r, g, b] = rgbAt(ctx, 10, 5); // paper stays light
 		expect(Math.min(r, g, b)).toBeGreaterThan(240);
-		const [pr, pg, pb] = rgbAt(ctx, 45, 8); // photo untouched
+		const [pr, pg] = rgbAt(ctx, 45, 8); // photo untouched
 		expect(pr).toBeGreaterThan(150);
 		expect(pg).toBeLessThan(100);
 	});

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -11,11 +11,30 @@
 export const SCAN_COVERAGE_MIN = 0.7;
 /** Fraction of near-white opaque pixels above which a source is scan paper. */
 export const SCAN_WHITE_MIN_FRACTION = 0.6;
+/**
+ * Minimum opaque fraction: scans are fully opaque; a cut-out PNG would let
+ * the inversion fill bleed into its transparent holes.
+ */
+export const SCAN_OPAQUE_MIN_FRACTION = 0.99;
+/**
+ * Maximum saturated fraction. Stamps and seals on real scans measure a few
+ * percent saturated; a rasterized slide with a colored chart measures far
+ * more — inverting it would render the chart as a negative.
+ */
+export const SCAN_SATURATED_MAX_FRACTION = 0.15;
 
 const SAMPLE_TARGET_PX = 48;
 
-// ImageBitmaps are immutable — one verdict per bitmap. Canvas sources get
-// repainted (pdf.js reuses scratch canvases), so they are re-sampled per draw.
+export interface SourceCrop {
+	sx: number;
+	sy: number;
+	sw: number;
+	sh: number;
+}
+
+// ImageBitmaps are immutable — one whole-source verdict per bitmap. Canvas
+// sources get repainted (pdf.js reuses scratch canvases) and cropped draws
+// vary per call, so those are re-sampled per draw.
 const bitmapVerdicts = new WeakMap<ImageBitmap, boolean>();
 
 export function sourceSize(
@@ -45,53 +64,70 @@ export function sourceSize(
 	return null;
 }
 
-function sampleWhiteFraction(
+function isScanPaperSample(
 	source: CanvasImageSource,
-	width: number,
-	height: number,
-): number | null {
-	if (typeof document === "undefined") return null;
-	const scale = Math.min(1, SAMPLE_TARGET_PX / Math.max(width, height));
-	const w = Math.max(1, Math.round(width * scale));
-	const h = Math.max(1, Math.round(height * scale));
+	crop: SourceCrop,
+): boolean {
+	if (typeof document === "undefined") return false;
+	const scale = Math.min(1, SAMPLE_TARGET_PX / Math.max(crop.sw, crop.sh));
+	const w = Math.max(1, Math.round(crop.sw * scale));
+	const h = Math.max(1, Math.round(crop.sh * scale));
 	const tmp = document.createElement("canvas");
 	tmp.width = w;
 	tmp.height = h;
 	const ctx = tmp.getContext("2d", { willReadFrequently: true });
-	if (!ctx) return null;
+	if (!ctx) return false;
 	try {
-		ctx.drawImage(source, 0, 0, w, h);
+		ctx.drawImage(source, crop.sx, crop.sy, crop.sw, crop.sh, 0, 0, w, h);
 		const { data } = ctx.getImageData(0, 0, w, h);
+		const total = data.length / 4;
 		let white = 0;
+		let opaque = 0;
+		let saturated = 0;
 		for (let i = 0; i < data.length; i += 4) {
+			if (data[i + 3]! <= 200) continue;
+			opaque++;
 			const max = Math.max(data[i]!, data[i + 1]!, data[i + 2]!);
 			const min = Math.min(data[i]!, data[i + 1]!, data[i + 2]!);
-			// Transparent pixels count against: image masks and cut-out art
-			// are not paper, and inverting them would fill their holes.
-			if (data[i + 3]! > 200 && min > 200 && max - min < 32) white++;
+			if (min > 200 && max - min < 32) white++;
+			else if (max > 60 && (max - min) / max > 0.35) saturated++;
 		}
-		return white / (data.length / 4);
+		return (
+			opaque / total >= SCAN_OPAQUE_MIN_FRACTION &&
+			white / total >= SCAN_WHITE_MIN_FRACTION &&
+			saturated / total <= SCAN_SATURATED_MAX_FRACTION
+		);
 	} catch {
 		// Tainted or detached sources never qualify.
-		return null;
+		return false;
 	}
 }
 
-export function isScanPaperSource(source: CanvasImageSource): boolean {
+export function isScanPaperSource(
+	source: CanvasImageSource,
+	crop?: SourceCrop,
+): boolean {
+	const size = sourceSize(source);
+	if (!size || size.width <= 0 || size.height <= 0) return false;
+	const fullSource =
+		!crop ||
+		(crop.sx === 0 &&
+			crop.sy === 0 &&
+			crop.sw === size.width &&
+			crop.sh === size.height);
 	const bitmap =
-		typeof ImageBitmap !== "undefined" && source instanceof ImageBitmap
+		fullSource &&
+		typeof ImageBitmap !== "undefined" &&
+		source instanceof ImageBitmap
 			? source
 			: null;
 	if (bitmap) {
 		const cached = bitmapVerdicts.get(bitmap);
 		if (cached !== undefined) return cached;
 	}
-	const size = sourceSize(source);
-	const fraction =
-		size && size.width > 0 && size.height > 0
-			? sampleWhiteFraction(source, size.width, size.height)
-			: null;
-	const verdict = fraction !== null && fraction >= SCAN_WHITE_MIN_FRACTION;
+	const region = crop ?? { sx: 0, sy: 0, sw: size.width, sh: size.height };
+	if (region.sw <= 0 || region.sh <= 0) return false;
+	const verdict = isScanPaperSample(source, region);
 	if (bitmap) bitmapVerdicts.set(bitmap, verdict);
 	return verdict;
 }

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -49,10 +49,20 @@ export interface SourceCrop {
 	sh: number;
 }
 
+export interface ScanPaperClass {
+	/**
+	 * Whether the paper carries dark ink pixels. A pure-white raster is an
+	 * MRC background layer (its ink lives in a separate dark layer that must
+	 * stay readable) or a blank margin tile — pages only invert when ink is
+	 * present somewhere, but blank tiles still count toward tiled coverage.
+	 */
+	inked: boolean;
+}
+
 // ImageBitmaps are immutable — one whole-source verdict per bitmap. Canvas
 // sources get repainted (pdf.js reuses scratch canvases) and cropped draws
 // vary per call, so those are re-sampled per draw.
-const bitmapVerdicts = new WeakMap<ImageBitmap, boolean>();
+const bitmapVerdicts = new WeakMap<ImageBitmap, ScanPaperClass | null>();
 
 export function sourceSize(
 	source: CanvasImageSource,
@@ -81,11 +91,11 @@ export function sourceSize(
 	return null;
 }
 
-function isScanPaperSample(
+function sampleScanPaper(
 	source: CanvasImageSource,
 	crop: SourceCrop,
-): boolean {
-	if (typeof document === "undefined") return false;
+): ScanPaperClass | null {
+	if (typeof document === "undefined") return null;
 	const scale = Math.min(1, SAMPLE_TARGET_PX / Math.max(crop.sw, crop.sh));
 	const w = Math.max(1, Math.round(crop.sw * scale));
 	const h = Math.max(1, Math.round(crop.sh * scale));
@@ -93,7 +103,7 @@ function isScanPaperSample(
 	tmp.width = w;
 	tmp.height = h;
 	const ctx = tmp.getContext("2d", { willReadFrequently: true });
-	if (!ctx) return false;
+	if (!ctx) return null;
 	try {
 		ctx.drawImage(source, crop.sx, crop.sy, crop.sw, crop.sh, 0, 0, w, h);
 		const { data } = ctx.getImageData(0, 0, w, h);
@@ -111,24 +121,24 @@ function isScanPaperSample(
 			else if (max > 60 && (max - min) / max > 0.35) saturated++;
 			if (max < 100) ink++;
 		}
-		return (
+		const isPaper =
 			opaque / total >= SCAN_OPAQUE_MIN_FRACTION &&
 			white / total >= SCAN_WHITE_MIN_FRACTION &&
-			saturated / total <= SCAN_SATURATED_MAX_FRACTION &&
-			ink / total >= SCAN_INK_MIN_FRACTION
-		);
+			saturated / total <= SCAN_SATURATED_MAX_FRACTION;
+		if (!isPaper) return null;
+		return { inked: ink / total >= SCAN_INK_MIN_FRACTION };
 	} catch {
 		// Tainted or detached sources never qualify.
-		return false;
+		return null;
 	}
 }
 
-export function isScanPaperSource(
+export function classifyScanPaper(
 	source: CanvasImageSource,
 	crop?: SourceCrop,
-): boolean {
+): ScanPaperClass | null {
 	const size = sourceSize(source);
-	if (!size || size.width <= 0 || size.height <= 0) return false;
+	if (!size || size.width <= 0 || size.height <= 0) return null;
 	const fullSource =
 		!crop ||
 		(crop.sx === 0 &&
@@ -146,8 +156,16 @@ export function isScanPaperSource(
 		if (cached !== undefined) return cached;
 	}
 	const region = crop ?? { sx: 0, sy: 0, sw: size.width, sh: size.height };
-	if (region.sw <= 0 || region.sh <= 0) return false;
-	const verdict = isScanPaperSample(source, region);
+	if (region.sw <= 0 || region.sh <= 0) return null;
+	const verdict = sampleScanPaper(source, region);
 	if (bitmap) bitmapVerdicts.set(bitmap, verdict);
 	return verdict;
+}
+
+export function isScanPaperSource(
+	source: CanvasImageSource,
+	crop?: SourceCrop,
+): boolean {
+	const paper = classifyScanPaper(source, crop);
+	return paper !== null && paper.inked;
 }

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -66,6 +66,21 @@ export interface ScanPaperClass {
 // vary per call, so those are re-sampled per draw.
 const bitmapVerdicts = new WeakMap<ImageBitmap, ScanPaperClass | null>();
 
+// One reusable scratch canvas: sampling is synchronous and strip-encoded
+// pages can classify many draws per render — no per-draw allocations.
+let scratchCanvas: HTMLCanvasElement | null = null;
+function getScratchContext(
+	width: number,
+	height: number,
+): CanvasRenderingContext2D | null {
+	if (typeof document === "undefined") return null;
+	scratchCanvas ??= document.createElement("canvas");
+	// Resizing also clears the previous sample.
+	scratchCanvas.width = width;
+	scratchCanvas.height = height;
+	return scratchCanvas.getContext("2d", { willReadFrequently: true });
+}
+
 export function sourceSize(
 	source: CanvasImageSource,
 ): { width: number; height: number } | null {
@@ -97,14 +112,10 @@ function sampleScanPaper(
 	source: CanvasImageSource,
 	crop: SourceCrop,
 ): ScanPaperClass | null {
-	if (typeof document === "undefined") return null;
 	const scale = Math.min(1, SAMPLE_TARGET_PX / Math.max(crop.sw, crop.sh));
 	const w = Math.max(1, Math.round(crop.sw * scale));
 	const h = Math.max(1, Math.round(crop.sh * scale));
-	const tmp = document.createElement("canvas");
-	tmp.width = w;
-	tmp.height = h;
-	const ctx = tmp.getContext("2d", { willReadFrequently: true });
+	const ctx = getScratchContext(w, h);
 	if (!ctx) return null;
 	try {
 		ctx.drawImage(source, crop.sx, crop.sy, crop.sw, crop.sh, 0, 0, w, h);

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -166,6 +166,5 @@ export function isScanPaperSource(
 	source: CanvasImageSource,
 	crop?: SourceCrop,
 ): boolean {
-	const paper = classifyScanPaper(source, crop);
-	return paper !== null && paper.inked;
+	return classifyScanPaper(source, crop)?.inked === true;
 }

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -23,11 +23,13 @@ export const SCAN_TILE_DENSITY_MIN = 0.85;
 /** Fraction of near-white opaque pixels above which a source is scan paper. */
 export const SCAN_WHITE_MIN_FRACTION = 0.6;
 /**
- * Minimum fraction of dark "ink" pixels. A pure-white raster is an MRC
- * background layer (its ink lives in a separate dark layer that must stay
- * un-inverted to remain readable) or a blank page — skip both.
+ * Minimum count of dark "ink" pixels in the downsample. A pure-white raster
+ * is an MRC background layer (its ink lives in a separate dark layer that
+ * must stay un-inverted to remain readable) or a blank page — skip both.
+ * A single genuine dark sample suffices so sparse pages (a signature, a few
+ * lines) still qualify; downsample averaging already erases isolated noise.
  */
-export const SCAN_INK_MIN_FRACTION = 0.005;
+export const SCAN_INK_MIN_PIXELS = 1;
 /**
  * Minimum opaque fraction: scans are fully opaque; a cut-out PNG would let
  * the inversion fill bleed into its transparent holes.
@@ -40,7 +42,7 @@ export const SCAN_OPAQUE_MIN_FRACTION = 0.99;
  */
 export const SCAN_SATURATED_MAX_FRACTION = 0.15;
 
-const SAMPLE_TARGET_PX = 48;
+const SAMPLE_TARGET_PX = 64;
 
 export interface SourceCrop {
 	sx: number;
@@ -126,7 +128,7 @@ function sampleScanPaper(
 			white / total >= SCAN_WHITE_MIN_FRACTION &&
 			saturated / total <= SCAN_SATURATED_MAX_FRACTION;
 		if (!isPaper) return null;
-		return { inked: ink / total >= SCAN_INK_MIN_FRACTION };
+		return { inked: ink >= SCAN_INK_MIN_PIXELS };
 	} catch {
 		// Tainted or detached sources never qualify.
 		return null;

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -11,9 +11,12 @@
 export const SCAN_COVERAGE_MIN = 0.7;
 /**
  * Minimum painted fraction for a draw to count as a scan tile: some raster
- * PDFs encode a page as strips/tiles whose areas only paper the page in sum.
+ * PDFs encode a page as strips or grids (8×8 grids put single tiles under
+ * 2%) whose areas only paper the page in sum. The floor only excludes
+ * degenerate sliver spam — the density, saturation, page-level ink and
+ * paint-serial guards do the real false-positive filtering.
  */
-export const SCAN_TILE_MIN_FRACTION = 0.05;
+export const SCAN_TILE_MIN_FRACTION = 0.005;
 /**
  * Minimum density (summed tile area / union bounding box area) for pending
  * tiles to read as one contiguous scan: strips partitioning a page are dense,

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -1,0 +1,97 @@
+/**
+ * Scanned pages keep their white raster pixels under the dark-scheme recolor:
+ * the color map only touches vector fills/strokes, never image data. The
+ * policy here decides which image draws are scan paper — painted large enough
+ * to cover the page AND dominated by near-white pixels — so the recolor layer
+ * can invert them toward the palette poles. Photos, embedded figures and
+ * colorful scans (color certificates, palette sheets) never qualify.
+ */
+
+/** Painted area relative to the page above which a draw "papers the page". */
+export const SCAN_COVERAGE_MIN = 0.7;
+/** Fraction of near-white opaque pixels above which a source is scan paper. */
+export const SCAN_WHITE_MIN_FRACTION = 0.6;
+
+const SAMPLE_TARGET_PX = 48;
+
+// ImageBitmaps are immutable — one verdict per bitmap. Canvas sources get
+// repainted (pdf.js reuses scratch canvases), so they are re-sampled per draw.
+const bitmapVerdicts = new WeakMap<ImageBitmap, boolean>();
+
+export function sourceSize(
+	source: CanvasImageSource,
+): { width: number; height: number } | null {
+	if (typeof ImageBitmap !== "undefined" && source instanceof ImageBitmap) {
+		return { width: source.width, height: source.height };
+	}
+	if (
+		typeof HTMLCanvasElement !== "undefined" &&
+		source instanceof HTMLCanvasElement
+	) {
+		return { width: source.width, height: source.height };
+	}
+	if (
+		typeof OffscreenCanvas !== "undefined" &&
+		source instanceof OffscreenCanvas
+	) {
+		return { width: source.width, height: source.height };
+	}
+	if (
+		typeof HTMLImageElement !== "undefined" &&
+		source instanceof HTMLImageElement
+	) {
+		return { width: source.naturalWidth, height: source.naturalHeight };
+	}
+	return null;
+}
+
+function sampleWhiteFraction(
+	source: CanvasImageSource,
+	width: number,
+	height: number,
+): number | null {
+	if (typeof document === "undefined") return null;
+	const scale = Math.min(1, SAMPLE_TARGET_PX / Math.max(width, height));
+	const w = Math.max(1, Math.round(width * scale));
+	const h = Math.max(1, Math.round(height * scale));
+	const tmp = document.createElement("canvas");
+	tmp.width = w;
+	tmp.height = h;
+	const ctx = tmp.getContext("2d", { willReadFrequently: true });
+	if (!ctx) return null;
+	try {
+		ctx.drawImage(source, 0, 0, w, h);
+		const { data } = ctx.getImageData(0, 0, w, h);
+		let white = 0;
+		for (let i = 0; i < data.length; i += 4) {
+			const max = Math.max(data[i]!, data[i + 1]!, data[i + 2]!);
+			const min = Math.min(data[i]!, data[i + 1]!, data[i + 2]!);
+			// Transparent pixels count against: image masks and cut-out art
+			// are not paper, and inverting them would fill their holes.
+			if (data[i + 3]! > 200 && min > 200 && max - min < 32) white++;
+		}
+		return white / (data.length / 4);
+	} catch {
+		// Tainted or detached sources never qualify.
+		return null;
+	}
+}
+
+export function isScanPaperSource(source: CanvasImageSource): boolean {
+	const bitmap =
+		typeof ImageBitmap !== "undefined" && source instanceof ImageBitmap
+			? source
+			: null;
+	if (bitmap) {
+		const cached = bitmapVerdicts.get(bitmap);
+		if (cached !== undefined) return cached;
+	}
+	const size = sourceSize(source);
+	const fraction =
+		size && size.width > 0 && size.height > 0
+			? sampleWhiteFraction(source, size.width, size.height)
+			: null;
+	const verdict = fraction !== null && fraction >= SCAN_WHITE_MIN_FRACTION;
+	if (bitmap) bitmapVerdicts.set(bitmap, verdict);
+	return verdict;
+}

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -9,6 +9,17 @@
 
 /** Painted area relative to the page above which a draw "papers the page". */
 export const SCAN_COVERAGE_MIN = 0.7;
+/**
+ * Minimum painted fraction for a draw to count as a scan tile: some raster
+ * PDFs encode a page as strips/tiles whose areas only paper the page in sum.
+ */
+export const SCAN_TILE_MIN_FRACTION = 0.05;
+/**
+ * Minimum density (summed tile area / union bounding box area) for pending
+ * tiles to read as one contiguous scan: strips partitioning a page are dense,
+ * scattered white screenshots on a text page are not.
+ */
+export const SCAN_TILE_DENSITY_MIN = 0.85;
 /** Fraction of near-white opaque pixels above which a source is scan paper. */
 export const SCAN_WHITE_MIN_FRACTION = 0.6;
 /**
@@ -85,7 +96,7 @@ function isScanPaperSample(
 		let opaque = 0;
 		let saturated = 0;
 		for (let i = 0; i < data.length; i += 4) {
-			if (data[i + 3]! <= 200) continue;
+			if (data[i + 3]! < 250) continue;
 			opaque++;
 			const max = Math.max(data[i]!, data[i + 1]!, data[i + 2]!);
 			const min = Math.min(data[i]!, data[i + 1]!, data[i + 2]!);

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -23,6 +23,12 @@ export const SCAN_TILE_DENSITY_MIN = 0.85;
 /** Fraction of near-white opaque pixels above which a source is scan paper. */
 export const SCAN_WHITE_MIN_FRACTION = 0.6;
 /**
+ * Minimum fraction of dark "ink" pixels. A pure-white raster is an MRC
+ * background layer (its ink lives in a separate dark layer that must stay
+ * un-inverted to remain readable) or a blank page — skip both.
+ */
+export const SCAN_INK_MIN_FRACTION = 0.005;
+/**
  * Minimum opaque fraction: scans are fully opaque; a cut-out PNG would let
  * the inversion fill bleed into its transparent holes.
  */
@@ -95,6 +101,7 @@ function isScanPaperSample(
 		let white = 0;
 		let opaque = 0;
 		let saturated = 0;
+		let ink = 0;
 		for (let i = 0; i < data.length; i += 4) {
 			if (data[i + 3]! < 250) continue;
 			opaque++;
@@ -102,11 +109,13 @@ function isScanPaperSample(
 			const min = Math.min(data[i]!, data[i + 1]!, data[i + 2]!);
 			if (min > 200 && max - min < 32) white++;
 			else if (max > 60 && (max - min) / max > 0.35) saturated++;
+			if (max < 100) ink++;
 		}
 		return (
 			opaque / total >= SCAN_OPAQUE_MIN_FRACTION &&
 			white / total >= SCAN_WHITE_MIN_FRACTION &&
-			saturated / total <= SCAN_SATURATED_MAX_FRACTION
+			saturated / total <= SCAN_SATURATED_MAX_FRACTION &&
+			ink / total >= SCAN_INK_MIN_FRACTION
 		);
 	} catch {
 		// Tainted or detached sources never qualify.

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -111,15 +111,17 @@ export function sourceSize(
 	return null;
 }
 
+// `undefined` = sampling itself failed (canvas pressure, tainted source) and
+// the verdict must not be cached; `null` = definitively not scan paper.
 function sampleScanPaper(
 	source: CanvasImageSource,
 	crop: SourceCrop,
-): ScanPaperClass | null {
+): ScanPaperClass | null | undefined {
 	const scale = Math.min(1, SAMPLE_TARGET_PX / Math.max(crop.sw, crop.sh));
 	const w = Math.max(1, Math.round(crop.sw * scale));
 	const h = Math.max(1, Math.round(crop.sh * scale));
 	const ctx = getScratchContext(w, h);
-	if (!ctx) return null;
+	if (!ctx) return undefined;
 	try {
 		ctx.drawImage(source, crop.sx, crop.sy, crop.sw, crop.sh, 0, 0, w, h);
 		const { data } = ctx.getImageData(0, 0, w, h);
@@ -144,8 +146,7 @@ function sampleScanPaper(
 		if (!isPaper) return null;
 		return { inked: ink >= SCAN_INK_MIN_PIXELS };
 	} catch {
-		// Tainted or detached sources never qualify.
-		return null;
+		return undefined;
 	}
 }
 
@@ -185,6 +186,8 @@ export function classifyScanPaper(
 	}
 	if (region.sw === 0 || region.sh === 0) return null;
 	const verdict = sampleScanPaper(source, region);
+	// Transient failures are not verdicts — retry on the next draw.
+	if (verdict === undefined) return null;
 	if (bitmap) bitmapVerdicts.set(bitmap, verdict);
 	return verdict;
 }

--- a/packages/lector/src/lib/scan-invert.ts
+++ b/packages/lector/src/lib/scan-invert.ts
@@ -157,8 +157,19 @@ export function classifyScanPaper(
 		const cached = bitmapVerdicts.get(bitmap);
 		if (cached !== undefined) return cached;
 	}
-	const region = crop ?? { sx: 0, sy: 0, sw: size.width, sh: size.height };
-	if (region.sw <= 0 || region.sh <= 0) return null;
+	const region = {
+		...(crop ?? { sx: 0, sy: 0, sw: size.width, sh: size.height }),
+	};
+	// drawImage accepts negative source dimensions (normalized rectangles).
+	if (region.sw < 0) {
+		region.sx += region.sw;
+		region.sw = -region.sw;
+	}
+	if (region.sh < 0) {
+		region.sy += region.sh;
+		region.sh = -region.sh;
+	}
+	if (region.sw === 0 || region.sh === 0) return null;
 	const verdict = sampleScanPaper(source, region);
 	if (bitmap) bitmapVerdicts.set(bitmap, verdict);
 	return verdict;


### PR DESCRIPTION
## Problem

The dark-scheme recolor maps vector fills/strokes only — `drawImage` deliberately keeps image pixels untouched so photos stay photos. But scanned pages *are* images: a full-page raster keeps its white paper in dark mode while every vector page around it goes dark. Consumers can't fix this well from outside: a CSS filter over the canvas double-inverts recolored vector content on mixed pages and needs fragile document-level detection.

## Approach

Extend the existing `drawImage` wrap (the luminosity-mask correction already lives there) with a per-draw scan policy, decided at paint time where the information is exact:

- **Coverage**: the draw must paper the page — ≥70% of `pageArea` through the live CTM (`ctx.getTransform()`), so a retina screenshot placed small never counts, and tiled/strip scans count per stripe draw.
- **Content**: the source must sample as white paper — ≥60% near-white opaque pixels on a ≤48px downsample, verdict cached per `ImageBitmap` (immutable); canvas sources re-sample per draw since pdf.js reuses scratch canvases.
- **Inversion**: a `difference` fill with gray `255 − mappedWhiteLuma` over the dest rect, so paper lands **exactly on the palette background** and ink near the light foreground. GPU-composited, no second bitmap, no `ctx.filter` (Safari 16 lacks it).

Skipped whenever the draw isn't a plain paint: non-`source-over` composites, translucent draws, active filters (the luminosity-mask path is untouched), and contexts without a `pageArea` — scratch canvases from the recolor CanvasFactory don't get one, and a scan painted through a transparency group is caught when the group is composed back onto the page context.

`applyContextRecolor` gains an optional `options: { pageArea }` — the three call sites (base canvas, detail canvas, thumbnails) pass their viewport area, so all layers invert consistently, including the zoomed detail layer (coverage is measured against the page, not the canvas).

## What qualifies / what never does

Inverts: pure scans, OCR-backed scans (an invisible text layer changes nothing — the policy never looks at text), tiled/strip scans, scans inset in margins.
Never inverts: photos and embedded figures (coverage), colorful full-page scans like color certificates and photo pages (white-dominance — inverting those would render negatives), blank/vector-only pages (no raster; the recolor map already handles them), translucent/masked/filtered draws.

Thresholds were tuned and validated against a corpus of 450+ real-world PDFs (pure scans, OCR-backed scans, tiled scans, born-digital documents with high-resolution embedded screenshots, color certificates, photo documents): zero false positives on born-digital text documents.

## Tests

11 new browser-mode tests (`scan-invert.test.ts`) assert real pixels: paper lands within 4 luma of the mapped pole, ink goes light, photos/small draws/translucent draws untouched, transform-aware coverage, state restoration, cleanup. Existing recolor/dark-mode suites pass (46 total; `useTextLayer.test.tsx` fails to import on clean main, pre-existing).

Verified in the example app against a real 12-page JBIG2 scan and a tesseract-OCR'd copy: dark mode renders dark paper/light ink natively; light mode and text PDFs behave identically to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Invert scanned-page rasters in `applyContextRecolor`
>
> - Adds [scan-invert.ts](https://github.com/anaralabs/lector/pull/147/files#diff-b672921bbfd57a8b7314c8e1aab8000b3c2963a2a46548ca2e0521e197b5b8f0) to classify scan-paper image draws by sampled source/crop content, requiring opaque near-white paper with ink while rejecting colorful, saturated, transparent, or non-readable sources.
> - Extends `applyContextRecolor` with optional `RecolorContextOptions.pageArea`; qualifying page-covering `drawImage` calls now invert raster paper/ink toward the mapped dark-mode palette poles while preserving the existing luminosity-mask path.
> - Handles tiled and strip-encoded scans by accumulating dense page coverage, avoiding double-inversion over already-covered regions, and abandoning retroactive fills when interleaved paints like photos, `putImageData`, `clearRect`, clips, or mask composes make the fill unsafe.
> - Passes `pageArea` from the base canvas, detail canvas, and thumbnail render paths so scan inversion is applied consistently across visible PDF layers.
> - Adds [scan-invert.test.ts](https://github.com/anaralabs/lector/pull/147/files#diff-8d503183a46b304b3b0ad120f150b08edd0072b8431641def1fa013a20593e32) browser coverage for scan classification, palette targeting, tiled scans, clips, overlays, interleaved paints, cleanup, and state restoration; adds a `prepare` script that runs `tsup`.
> - Behavioral change: In dark mode, qualifying scanned raster pages render with dark paper and light ink instead of leaving the original white image pixels unchanged.
>
> <sup>[Leo](https://anara.com) summarized `c005388`</sup>
<!-- leo:summary-end -->