### PR TITLE
fix(dark-mode): invert genuinely blank scanned pages at end of render

### DIFF
--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -363,7 +363,7 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		// strip any wrapper a still-pending dark render may have left on the
 		// context (matters in the no-buffer fallback, where renderCtx is the
 		// long-lived visible canvas context).
-		let restoreRecolor: (() => void) | null = null;
+		let restoreRecolor: ((finalizeRender?: boolean) => void) | null = null;
 		if (recolor) {
 			restoreRecolor = applyContextRecolor(renderCtx, recolor, {
 				pageArea: viewport.width * viewport.height,
@@ -389,11 +389,20 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		}
 
 		renderingTask.promise
-			.finally(() => {
-				// Matters for the no-buffer fallback, where renderCtx is the
-				// long-lived visible canvas context.
-				restoreRecolor?.();
-			})
+			.then(
+				() => {
+					// Natural completion: lets an inkless papered page finalize
+					// as a blank scanned page.
+					restoreRecolor?.(true);
+				},
+				(error) => {
+					// Matters for the no-buffer fallback, where renderCtx is the
+					// long-lived visible canvas context. No finalize: a cancelled
+					// render proves nothing about pending blank tiles.
+					restoreRecolor?.();
+					throw error;
+				},
+			)
 			.then(() => {
 				if (cancelled) {
 					releaseBuffer();

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -391,9 +391,12 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		renderingTask.promise
 			.then(
 				() => {
-					// Natural completion: lets an inkless papered page finalize
-					// as a blank scanned page.
-					restoreRecolor?.(true);
+					// Natural completion lets an inkless papered page finalize as
+					// a blank scanned page — but pdf.js can fulfill even after a
+					// supersede/scheme-change cancel, and in the no-buffer
+					// fallback these fills would land on the visible canvas:
+					// never finalize a cancelled render.
+					restoreRecolor?.(!cancelled);
 				},
 				(error) => {
 					// Matters for the no-buffer fallback, where renderCtx is the

--- a/packages/lector/src/hooks/layers/useCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useCanvasLayer.tsx
@@ -389,25 +389,12 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 		}
 
 		renderingTask.promise
-			.then(
-				() => {
-					// Natural completion lets an inkless papered page finalize as
-					// a blank scanned page — but pdf.js can fulfill even after a
-					// supersede/scheme-change cancel, and in the no-buffer
-					// fallback these fills would land on the visible canvas:
-					// never finalize a cancelled render.
-					restoreRecolor?.(!cancelled);
-				},
-				(error) => {
-					// Matters for the no-buffer fallback, where renderCtx is the
-					// long-lived visible canvas context. No finalize: a cancelled
-					// render proves nothing about pending blank tiles.
-					restoreRecolor?.();
-					throw error;
-				},
-			)
 			.then(() => {
 				if (cancelled) {
+					// Restore-without-finalize: matters for the no-buffer
+					// fallback, where renderCtx is the long-lived visible canvas
+					// context and stale fills would be user-visible.
+					restoreRecolor?.();
 					releaseBuffer();
 					return;
 				}
@@ -423,9 +410,13 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 						? `dark:${state.darkModeColors.background},${state.darkModeColors.foreground}`
 						: undefined;
 				if (currentRecolorKey !== recolorKey) {
+					restoreRecolor?.();
 					releaseBuffer();
 					return;
 				}
+				// The frame WILL be used: finalize under exactly the conditions
+				// it is blitted, so a blank scanned page's fills are part of it.
+				restoreRecolor?.(true);
 				if (useBuffer) {
 					// Swap: size (which clears) and blit in one go — the previous
 					// frame stays on screen up to this exact paint.
@@ -465,6 +456,8 @@ export const useCanvasLayer = ({ background }: { background?: string }) => {
 				}
 			})
 			.catch((error) => {
+				// Idempotent: a no-op when the fulfilled path already restored.
+				restoreRecolor?.();
 				releaseBuffer();
 				if (cancelled) return;
 				if (error?.name === "RenderingCancelledException") return;

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -555,6 +555,10 @@ export const useDetailCanvasLayer = ({
 			}
 
 			void renderingTask?.cancel();
+			// Null the task too (same as hideDetailCanvas): cancel() no-ops on
+			// an internally-completed task, and the swap's identity guard must
+			// catch it so a fulfill-after-teardown can't finalize or blit.
+			renderingTask = null;
 			// Don't destroy canvas content — stale detail is better than a
 			// white flash. The next effect run will hide or replace it.
 		};

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -426,9 +426,6 @@ export const useDetailCanvasLayer = ({
 
 			currentRenderingTask.promise
 				.then(() => {
-					// Natural completion — finalize before any blit so a blank
-					// scanned page's fills land on the buffer.
-					restoreRecolor?.(true);
 					if (renderingTask !== currentRenderingTask) return;
 
 					// Same guard as the base canvas: a render finishing inside the
@@ -441,6 +438,10 @@ export const useDetailCanvasLayer = ({
 							? `dark:${state.darkModeColors.background},${state.darkModeColors.foreground}`
 							: "light";
 					if (currentRecolorKey !== recolorKey) return;
+
+					// Natural, still-current completion — finalize before the
+					// blit so a blank scanned page's fills land on the buffer.
+					restoreRecolor?.(true);
 
 					// Swap: update the visible detail canvas in one go
 					detailCanvas.width = actualWidth;

--- a/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
+++ b/packages/lector/src/hooks/layers/useDetailCanvasLayer.tsx
@@ -386,10 +386,11 @@ export const useDetailCanvasLayer = ({
 
 			// Native dark mode: recolor at draw time; `background` stays the
 			// original color and is mapped by the wrapped fillRect exactly once.
-			if (recolor)
-				applyContextRecolor(bufferCtx, recolor, {
-					pageArea: detailViewport.width * detailViewport.height,
-				});
+			const restoreRecolor = recolor
+				? applyContextRecolor(bufferCtx, recolor, {
+						pageArea: detailViewport.width * detailViewport.height,
+					})
+				: null;
 
 			const releaseBuffer = () => {
 				buffer.width = 0;
@@ -425,6 +426,9 @@ export const useDetailCanvasLayer = ({
 
 			currentRenderingTask.promise
 				.then(() => {
+					// Natural completion — finalize before any blit so a blank
+					// scanned page's fills land on the buffer.
+					restoreRecolor?.(true);
 					if (renderingTask !== currentRenderingTask) return;
 
 					// Same guard as the base canvas: a render finishing inside the

--- a/packages/lector/src/hooks/useThumbnail.tsx
+++ b/packages/lector/src/hooks/useThumbnail.tsx
@@ -62,6 +62,11 @@ export const useThumbnail = (
 		if (!isVisible && renderedProxyRef.current !== pageProxy) return;
 		renderedProxyRef.current = pageProxy;
 
+		// Set on effect teardown (scheme change, unmount): a render fulfilling
+		// after cancel() must not finalize blank-page fills on the visible
+		// thumbnail canvas.
+		let stale = false;
+
 		const renderThumbnail = async () => {
 			const canvas = canvasRef.current;
 
@@ -117,8 +122,8 @@ export const useThumbnail = (
 					renderTaskRef.current = renderTask;
 					await renderTask.promise;
 					// Natural completion (cleanup is idempotent; the finally
-					// below is then a no-op).
-					restoreRecolor?.(true);
+					// below is then a no-op). Never finalize once stale.
+					restoreRecolor?.(!stale);
 				} finally {
 					restoreRecolor?.();
 				}
@@ -139,6 +144,7 @@ export const useThumbnail = (
 		// Capture ref — React clears refs before passive cleanup runs on unmount
 		const canvas = canvasRef.current;
 		return () => {
+			stale = true;
 			renderTaskRef.current?.cancel();
 			// Release canvas memory for Safari (384 MB total canvas limit on iOS)
 			if (canvas) {

--- a/packages/lector/src/hooks/useThumbnail.tsx
+++ b/packages/lector/src/hooks/useThumbnail.tsx
@@ -98,7 +98,7 @@ export const useThumbnail = (
 				// background fill is mapped by the wrapped fillRect). The context
 				// is long-lived, so restore even when render() throws
 				// synchronously, and strip stale wrappers before light renders.
-				let restoreRecolor: (() => void) | null = null;
+				let restoreRecolor: ((finalizeRender?: boolean) => void) | null = null;
 				if (recolor) {
 					restoreRecolor = applyContextRecolor(context, recolor, {
 						pageArea: scaledViewport.width * scaledViewport.height,
@@ -116,6 +116,9 @@ export const useThumbnail = (
 
 					renderTaskRef.current = renderTask;
 					await renderTask.promise;
+					// Natural completion (cleanup is idempotent; the finally
+					// below is then a no-op).
+					restoreRecolor?.(true);
 				} finally {
 					restoreRecolor?.();
 				}

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -404,8 +404,9 @@ export function applyContextRecolor(
 		}
 	};
 
-	const pendingTriggerReady = () => {
-		if (pendingTileArea < SCAN_COVERAGE_MIN || !pendingHasInk) return false;
+	const pendingTriggerReady = (requireInk = true) => {
+		if (pendingTileArea < SCAN_COVERAGE_MIN) return false;
+		if (requireInk && !pendingHasInk) return false;
 		const union: DeviceBounds = [
 			Math.min(...pendingTiles.map((t) => t.bounds[0])),
 			Math.min(...pendingTiles.map((t) => t.bounds[1])),
@@ -722,9 +723,27 @@ export function applyContextRecolor(
 		return (pristineClip as AnyFn).apply(this, args);
 	};
 
+	const finalizeBlankScanPage = () => {
+		// The render is over: pending white tiles that paper the page with no
+		// foreign paint since (paint serial unchanged) are a genuinely BLANK
+		// scanned page — no MRC ink layer ever arrived — so it goes dark like
+		// its sibling pages. The ink requirement existed only to wait for one.
+		if (pendingTiles.length === 0) return;
+		if (paintSerial !== pendingBaselineSerial) return;
+		if (!pendingTriggerReady(false)) return;
+		for (const pending of pendingTiles) {
+			invertTileRemainder(target, pending, coveredBounds);
+			coveredBounds.push(pending.bounds);
+		}
+		pendingTiles.length = 0;
+		pendingTileArea = 0;
+		pendingHasInk = false;
+	};
+
 	const cleanup = () => {
 		// A later applyContextRecolor call already replaced these wrappers.
 		if (target[RECOLOR_CLEANUP] !== cleanup) return;
+		finalizeBlankScanPage();
 		for (const name of [
 			...FILL_METHODS,
 			...STROKE_METHODS,

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -133,13 +133,15 @@ export interface RecolorContextOptions {
  * (policy in ./scan-invert.ts).
  *
  * Wrapping installs own properties on the context instance (the prototype is
- * never modified). Returns a cleanup that restores the pristine context.
+ * never modified). Returns a cleanup that restores the pristine context; pass
+ * finalizeRender=true only when the render completed naturally, which lets a
+ * papered-but-inkless page finalize as a genuinely blank scanned page.
  */
 export function applyContextRecolor(
 	ctx: CanvasRenderingContext2D,
 	map: RenderColorMap,
 	options?: RecolorContextOptions,
-): () => void {
+): (finalizeRender?: boolean) => void {
 	const target = ctx as RecolorableContext;
 	// Re-wrapping replaces the previous map instead of stacking wrappers.
 	target[RECOLOR_CLEANUP]?.();
@@ -740,10 +742,13 @@ export function applyContextRecolor(
 		pendingHasInk = false;
 	};
 
-	const cleanup = () => {
+	// finalizeRender must be true only on NATURAL render completion: rewraps,
+	// teardown and cancelled renders prove nothing about a pending blank page
+	// (its ink layer may simply not have been drawn yet).
+	const cleanup = (finalizeRender = false) => {
 		// A later applyContextRecolor call already replaced these wrappers.
 		if (target[RECOLOR_CLEANUP] !== cleanup) return;
-		finalizeBlankScanPage();
+		if (finalizeRender) finalizeBlankScanPage();
 		for (const name of [
 			...FILL_METHODS,
 			...STROKE_METHODS,

--- a/packages/lector/src/lib/recolor-context.ts
+++ b/packages/lector/src/lib/recolor-context.ts
@@ -422,18 +422,23 @@ export function applyContextRecolor(
 		);
 	};
 
+	// Content painted between strips (annotations, watermarks, photos) would
+	// be inverted by a retroactive fill — but only tiles OLDER than the last
+	// foreign paint are unsafe. Keep the clean suffix so a scan painted after
+	// a watermark still accumulates and inverts.
+	const prunePendingToCleanSuffix = () => {
+		if (paintSerial === pendingBaselineSerial) return;
+		const kept = pendingTiles.filter((t) => t.serial === paintSerial);
+		pendingTiles.length = 0;
+		pendingTiles.push(...kept);
+		pendingTileArea = kept.reduce((sum, t) => sum + t.area, 0);
+		pendingHasInk = kept.some((t) => t.inked);
+		pendingBaselineSerial = paintSerial;
+	};
+
 	const flushPendingTiles = (self: CanvasRenderingContext2D) => {
-		// Content painted between strips (annotations, watermarks, photos)
-		// would be inverted by a retroactive fill — but only tiles OLDER than
-		// the last foreign paint are unsafe. Keep the clean suffix so a scan
-		// painted after a watermark still accumulates and inverts.
 		if (paintSerial !== pendingBaselineSerial) {
-			const kept = pendingTiles.filter((t) => t.serial === paintSerial);
-			pendingTiles.length = 0;
-			pendingTiles.push(...kept);
-			pendingTileArea = kept.reduce((sum, t) => sum + t.area, 0);
-			pendingHasInk = kept.some((t) => t.inked);
-			pendingBaselineSerial = paintSerial;
+			prunePendingToCleanSuffix();
 			if (pendingTiles.length === 0 || !pendingTriggerReady()) return;
 		}
 		for (const pending of pendingTiles) {
@@ -731,7 +736,10 @@ export function applyContextRecolor(
 		// scanned page — no MRC ink layer ever arrived — so it goes dark like
 		// its sibling pages. The ink requirement existed only to wait for one.
 		if (pendingTiles.length === 0) return;
-		if (paintSerial !== pendingBaselineSerial) return;
+		// Same clean-suffix rule as the flush path: tiles drawn after the last
+		// foreign paint are safe to consider.
+		prunePendingToCleanSuffix();
+		if (pendingTiles.length === 0) return;
 		if (!pendingTriggerReady(false)) return;
 		for (const pending of pendingTiles) {
 			invertTileRemainder(target, pending, coveredBounds);

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -793,6 +793,30 @@ describe("scan inversion via applyContextRecolor", () => {
 		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
 	});
 
+	it("finalizes clean blank tiles painted after a foreign paint", () => {
+		const white = document.createElement("canvas");
+		white.width = 100;
+		white.height = 100;
+		const wctx = white.getContext("2d")!;
+		wctx.fillStyle = "#ffffff";
+		wctx.fillRect(0, 0, 100, 100);
+
+		const ctx = makeCtx(100);
+		const cleanup = applyContextRecolor(ctx, testMap, {
+			pageArea: 100 * 100,
+		});
+		// an early blank strip, then a foreign paint…
+		ctx.drawImage(white, 0, 0, 100, 20);
+		ctx.fillStyle = "#ff0000";
+		ctx.fillRect(10, 5, 20, 5);
+		// …then the real blank page repaints everything, clean
+		ctx.drawImage(white, 0, 0);
+		cleanup(true);
+		const [pr, pg, pb] = rgbAt(ctx, 50, 50);
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
 	it("does not finalize blank pages on teardown or cancelled renders", () => {
 		const white = document.createElement("canvas");
 		white.width = 100;

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -770,6 +770,54 @@ describe("scan inversion via applyContextRecolor", () => {
 		}
 	});
 
+	it("inverts genuinely blank scanned pages at end of render", () => {
+		const white = document.createElement("canvas");
+		white.width = 100;
+		white.height = 100;
+		const wctx = white.getContext("2d")!;
+		wctx.fillStyle = "#ffffff";
+		wctx.fillRect(0, 0, 100, 100);
+
+		const ctx = makeCtx(100);
+		const cleanup = applyContextRecolor(ctx, testMap, {
+			pageArea: 100 * 100,
+		});
+		ctx.drawImage(white, 0, 0); // an all-white scanned page
+		// still light mid-render: an MRC ink layer could yet arrive…
+		const [mr, mg, mb] = rgbAt(ctx, 10, 10);
+		expect(Math.min(mr, mg, mb)).toBeGreaterThan(240);
+		// …but at end of render nothing came: it is a blank scan page
+		cleanup();
+		const [pr, pg, pb] = rgbAt(ctx, 10, 10);
+		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
+		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
+	it("keeps true MRC pages light through end of render", () => {
+		const white = document.createElement("canvas");
+		white.width = 100;
+		white.height = 100;
+		const wctx = white.getContext("2d")!;
+		wctx.fillStyle = "#ffffff";
+		wctx.fillRect(0, 0, 100, 100);
+		const inkLayer = document.createElement("canvas");
+		inkLayer.width = 100;
+		inkLayer.height = 100;
+		const ictx = inkLayer.getContext("2d")!;
+		ictx.fillStyle = "#000000";
+		ictx.fillRect(10, 20, 60, 4);
+
+		const ctx = makeCtx(100);
+		const cleanup = applyContextRecolor(ctx, testMap, {
+			pageArea: 100 * 100,
+		});
+		ctx.drawImage(white, 0, 0);
+		ctx.drawImage(inkLayer, 0, 0); // non-paper draw bumps the serial
+		cleanup();
+		const [r, g, b] = rgbAt(ctx, 10, 10); // stays light — real MRC page
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
+	});
+
 	it("restores pristine drawImage on cleanup", () => {
 		const ctx = makeCtx(100);
 		const cleanup = applyContextRecolor(ctx, testMap, {

--- a/packages/lector/src/lib/scan-invert.test.ts
+++ b/packages/lector/src/lib/scan-invert.test.ts
@@ -786,11 +786,31 @@ describe("scan inversion via applyContextRecolor", () => {
 		// still light mid-render: an MRC ink layer could yet arrive…
 		const [mr, mg, mb] = rgbAt(ctx, 10, 10);
 		expect(Math.min(mr, mg, mb)).toBeGreaterThan(240);
-		// …but at end of render nothing came: it is a blank scan page
-		cleanup();
+		// …but at natural end of render nothing came: a blank scan page
+		cleanup(true);
 		const [pr, pg, pb] = rgbAt(ctx, 10, 10);
 		const paperLuma = 0.3 * pr + 0.59 * pg + 0.11 * pb;
 		expect(Math.abs(paperLuma - POLE_LUMA)).toBeLessThan(4);
+	});
+
+	it("does not finalize blank pages on teardown or cancelled renders", () => {
+		const white = document.createElement("canvas");
+		white.width = 100;
+		white.height = 100;
+		const wctx = white.getContext("2d")!;
+		wctx.fillStyle = "#ffffff";
+		wctx.fillRect(0, 0, 100, 100);
+
+		const ctx = makeCtx(100);
+		const cleanup = applyContextRecolor(ctx, testMap, {
+			pageArea: 100 * 100,
+		});
+		ctx.drawImage(white, 0, 0);
+		// plain cleanup = rewrap/teardown/cancel: the ink layer may simply
+		// not have been drawn yet, so the page must stay light
+		cleanup();
+		const [r, g, b] = rgbAt(ctx, 10, 10);
+		expect(Math.min(r, g, b)).toBeGreaterThan(240);
 	});
 
 	it("keeps true MRC pages light through end of render", () => {
@@ -813,7 +833,7 @@ describe("scan inversion via applyContextRecolor", () => {
 		});
 		ctx.drawImage(white, 0, 0);
 		ctx.drawImage(inkLayer, 0, 0); // non-paper draw bumps the serial
-		cleanup();
+		cleanup(true);
 		const [r, g, b] = rgbAt(ctx, 10, 10); // stays light — real MRC page
 		expect(Math.min(r, g, b)).toBeGreaterThan(240);
 	});


### PR DESCRIPTION
Follow-up to #147, found testing real documents: a scanned exam containing an **all-white page** kept that page glaring white in dark mode while every sibling page inverted.

The ink gate keeps pure-white page-covering rasters light because their ink might live in a separate MRC layer — but that wait is only meaningful while the render is in flight. This adds a final check in the recolor cleanup (invoked when the render task settles): pending white tiles that paper the page, with the paint serial unchanged since they were drawn, mean **no ink layer or any other content ever arrived** — a genuinely blank scanned page — so it inverts like its siblings. True MRC pages remain protected: their dark ink layer is a non-paper draw that bumps the serial before cleanup runs.

Tests assert the full lifecycle: the blank page stays light mid-render and goes dark at settle; an MRC page (white layer + dark ink layer) stays light through settle. 83 browser-mode tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Invert genuinely blank scanned pages after completed dark-mode renders
>
> - Updates `applyContextRecolor` cleanup to accept `finalizeRender`, allowing page-covering white scan tiles to invert only after a natural render completion confirms no ink layer arrived.
> - Finalizes recolor cleanup only for frames that will actually be displayed in `useCanvasLayer`, `useDetailCanvasLayer`, and `useThumbnail`; cancelled, stale, scheme-changed, or torn-down renders restore without finalizing.
> - Reuses the clean-suffix pruning rule so blank tiles repainted after foreign content can still finalize while true MRC pages with separate ink remain protected.
> - Adds 4 `scan-invert` tests covering blank-page finalization, cancellation/teardown, clean repaint after foreign paint, and MRC protection.
> - Behavioral change: In dark mode, all-white scanned pages now darken after render completion instead of remaining bright white; true MRC pages still keep light paper.
>
> <sup>[Leo](https://anara.com) summarized `e371d87`</sup>
<!-- leo:summary-end -->