### PR TITLE
fix(annotations): reliable internal link navigation with destination scroll

### DIFF
--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 47361,
+    "size": 47387,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 47460,
+    "size": 47400,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 47474,
+    "size": 47471,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 47400,
+    "size": 47474,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 47431,
+    "size": 47460,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 47387,
+    "size": 47431,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/size.json
+++ b/packages/lector/size.json
@@ -2,7 +2,7 @@
   {
     "name": "Client",
     "passed": true,
-    "size": 43577,
+    "size": 47361,
     "sizeLimit": 150000
   }
 ]

--- a/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
+++ b/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
@@ -1,3 +1,4 @@
+import type { PageViewport } from "pdfjs-dist";
 import { useEffect, useMemo, useRef } from "react";
 
 import { usePdf } from "../../internal";
@@ -27,6 +28,54 @@ export interface AnnotationLayerParams {
 	 */
 	jumpOptions?: Parameters<ReturnType<typeof usePdfJump>["jumpToPage"]>[1];
 }
+
+// Distance of an explicit destination from the top of its page, in scale-1
+// viewport pixels (the coordinate space the virtualizer scrolls in). Returns
+// null when the destination carries no usable position, so callers can fall
+// back to a whole-page jump.
+const getDestinationScrollTop = (
+	viewport: PageViewport | undefined,
+	explicitDest?: unknown[],
+): number | null => {
+	if (!viewport || !explicitDest) return null;
+
+	const destType = explicitDest[1];
+	const destName =
+		destType && typeof destType === "object" && "name" in destType
+			? (destType as { name?: unknown }).name
+			: null;
+
+	// PDF destination syntax: [pageRef, {name}, ...args] with args in PDF
+	// user-space units (origin at the bottom-left of the page).
+	let x: unknown = null;
+	let y: unknown = null;
+	switch (destName) {
+		case "XYZ":
+			x = explicitDest[2];
+			y = explicitDest[3];
+			break;
+		case "FitH":
+		case "FitBH":
+			y = explicitDest[2];
+			break;
+		case "FitR":
+			x = explicitDest[2];
+			y = explicitDest[5];
+			break;
+		default:
+			return null;
+	}
+
+	if (typeof y !== "number") return null;
+
+	const [, top] = viewport.convertToViewportPoint(
+		typeof x === "number" ? x : 0,
+		y,
+	);
+	if (typeof top !== "number" || Number.isNaN(top)) return null;
+
+	return Math.min(Math.max(top, 0), viewport.height);
+};
 
 const defaultAnnotationLayerParams = {
 	renderForms: true,
@@ -66,25 +115,48 @@ export const useAnnotationLayer = (params: AnnotationLayerParams) => {
 		linkService.externalLinkEnabled = mergedParams.externalLinksEnabled;
 	}, [linkService, mergedParams.externalLinksEnabled]);
 
-	const { jumpToPage } = usePdfJump();
+	const { jumpToPage, scrollToHighlightRects } = usePdfJump();
+	const viewports = usePdf((state) => state.viewports);
 
-	// Connect the LinkService to the jumpToPage function to enable PDF navigation through links
+	// Connect the LinkService to the viewer's scrolling so link annotations
+	// navigate. When the destination carries a position, scroll to it within
+	// the target page; otherwise fall back to a whole-page jump.
 	useEffect(() => {
 		if (!jumpToPage) return;
 
-		// Define a callback function to handle page navigation
-		const handlePageNavigation = (pageNumber: number) => {
-			jumpToPage(pageNumber, mergedParams.jumpOptions);
+		const handlePageNavigation = (
+			targetPageNumber: number,
+			explicitDest?: unknown[],
+		) => {
+			const top = getDestinationScrollTop(
+				viewports?.[targetPageNumber - 1],
+				explicitDest,
+			);
+			if (top !== null) {
+				scrollToHighlightRects(
+					[{ pageNumber: targetPageNumber, top, left: 0, width: 0, height: 0 }],
+					"pixels",
+					mergedParams.jumpOptions?.align === "center" ? "center" : "start",
+				);
+			} else {
+				jumpToPage(targetPageNumber, mergedParams.jumpOptions);
+			}
 		};
 
-		// Register our callback with the LinkService
 		linkService.registerPageNavigationCallback(handlePageNavigation);
 
-		// Clean up the callback when the component unmounts
+		// Unregister only this layer's callback: pages mount/unmount constantly
+		// under virtualization and must not clobber each other's registration.
 		return () => {
-			linkService.unregisterPageNavigationCallback();
+			linkService.unregisterPageNavigationCallback(handlePageNavigation);
 		};
-	}, [jumpToPage, linkService, mergedParams.jumpOptions]);
+	}, [
+		jumpToPage,
+		scrollToHighlightRects,
+		viewports,
+		linkService,
+		mergedParams.jumpOptions,
+	]);
 
 	useEffect(() => {
 		ensureAnnotationLayerStyles();

--- a/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
+++ b/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
@@ -58,6 +58,10 @@ export const getDestinationScrollTop = (
 		case "FitBH":
 			y = explicitDest[2];
 			break;
+		case "FitV":
+		case "FitBV":
+			x = explicitDest[2];
+			break;
 		case "FitR":
 			x = explicitDest[2];
 			y = explicitDest[5];
@@ -66,15 +70,15 @@ export const getDestinationScrollTop = (
 			return null;
 	}
 
-	if (typeof y !== "number") return null;
-
-	// On sideways-rotated pages the viewport Y axis maps to PDF x, so a
-	// destination without a real x coordinate cannot be positioned.
-	if (typeof x !== "number" && viewport.rotation % 180 !== 0) return null;
+	// Viewport Y comes from PDF y on upright pages and from PDF x on
+	// sideways-rotated ones; without that coordinate the destination cannot
+	// be positioned vertically.
+	const sideways = viewport.rotation % 180 !== 0;
+	if (typeof (sideways ? x : y) !== "number") return null;
 
 	const [, top] = viewport.convertToViewportPoint(
 		typeof x === "number" ? x : 0,
-		y,
+		typeof y === "number" ? y : 0,
 	);
 	if (typeof top !== "number" || Number.isNaN(top)) return null;
 

--- a/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
+++ b/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
@@ -32,8 +32,8 @@ export interface AnnotationLayerParams {
 // Distance of an explicit destination from the top of its page, in scale-1
 // viewport pixels (the coordinate space the virtualizer scrolls in). Returns
 // null when the destination carries no usable position, so callers can fall
-// back to a whole-page jump.
-const getDestinationScrollTop = (
+// back to a whole-page jump. Exported for tests.
+export const getDestinationScrollTop = (
 	viewport: PageViewport | undefined,
 	explicitDest?: unknown[],
 ): number | null => {
@@ -67,6 +67,10 @@ const getDestinationScrollTop = (
 	}
 
 	if (typeof y !== "number") return null;
+
+	// On sideways-rotated pages the viewport Y axis maps to PDF x, so a
+	// destination without a real x coordinate cannot be positioned.
+	if (typeof x !== "number" && viewport.rotation % 180 !== 0) return null;
 
 	const [, top] = viewport.convertToViewportPoint(
 		typeof x === "number" ? x : 0,
@@ -132,7 +136,8 @@ export const useAnnotationLayer = (params: AnnotationLayerParams) => {
 				viewports?.[targetPageNumber - 1],
 				explicitDest,
 			);
-			if (top !== null) {
+			const scrolled =
+				top !== null &&
 				scrollToHighlightRects(
 					[{ pageNumber: targetPageNumber, top, left: 0, width: 0, height: 0 }],
 					"pixels",
@@ -140,7 +145,7 @@ export const useAnnotationLayer = (params: AnnotationLayerParams) => {
 					0,
 					mergedParams.jumpOptions?.behavior ?? "smooth",
 				);
-			} else {
+			if (!scrolled) {
 				jumpToPage(targetPageNumber, mergedParams.jumpOptions);
 			}
 		};
@@ -178,13 +183,19 @@ export const useAnnotationLayer = (params: AnnotationLayerParams) => {
 			const target = e.target as HTMLAnchorElement;
 			const href = target.getAttribute("href") || "";
 
-			// Internal links navigate via pdf.js's own click handler, which calls
-			// linkService.goToDestination with the real destination. Only stop the
-			// browser's default hash navigation here — dispatching goToPage as well
-			// would double-navigate, and the href's page number comes from the PDF
-			// object number, which is not a page index.
 			if (href.startsWith("#page=")) {
 				e.preventDefault();
+				// pdf.js destination links (marked data-internal-link) navigate via
+				// their own click handler calling goToDestination — dispatching here
+				// too would double-navigate, and their href's page number comes from
+				// the PDF object number, not a page index. Only URI annotations with
+				// a literal #page=N hash need the goToPage fallback.
+				if (!target.closest("[data-internal-link]")) {
+					const pageNumber = parseInt(href.substring(6), 10);
+					if (!Number.isNaN(pageNumber)) {
+						linkService.goToPage(pageNumber);
+					}
+				}
 			}
 			// External links will be handled by browser
 		};
@@ -194,7 +205,7 @@ export const useAnnotationLayer = (params: AnnotationLayerParams) => {
 		return () => {
 			element.removeEventListener("click", handleLinkClick as EventListener);
 		};
-	}, []);
+	}, [linkService]);
 
 	useEffect(() => {
 		if (!annotationLayerRef.current) {

--- a/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
+++ b/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
@@ -47,6 +47,25 @@ export const getDestinationScrollTop = (
 
 	// PDF destination syntax: [pageRef, {name}, ...args] with args in PDF
 	// user-space units (origin at the bottom-left of the page).
+	// FitR carries a full rectangle; whichever corner is visually topmost
+	// depends on rotation, so convert both corners and take the smaller top.
+	if (destName === "FitR") {
+		const [x1, y1, x2, y2] = explicitDest.slice(2, 6);
+		if (
+			typeof x1 !== "number" ||
+			typeof y1 !== "number" ||
+			typeof x2 !== "number" ||
+			typeof y2 !== "number"
+		) {
+			return null;
+		}
+		const [, t1] = viewport.convertToViewportPoint(x1, y1);
+		const [, t2] = viewport.convertToViewportPoint(x2, y2);
+		const top = Math.min(t1, t2);
+		if (typeof top !== "number" || Number.isNaN(top)) return null;
+		return Math.min(Math.max(top, 0), viewport.height);
+	}
+
 	let x: unknown = null;
 	let y: unknown = null;
 	switch (destName) {
@@ -61,10 +80,6 @@ export const getDestinationScrollTop = (
 		case "FitV":
 		case "FitBV":
 			x = explicitDest[2];
-			break;
-		case "FitR":
-			x = explicitDest[2];
-			y = explicitDest[5];
 			break;
 		default:
 			return null;

--- a/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
+++ b/packages/lector/src/hooks/layers/useAnnotationLayer.tsx
@@ -137,6 +137,8 @@ export const useAnnotationLayer = (params: AnnotationLayerParams) => {
 					[{ pageNumber: targetPageNumber, top, left: 0, width: 0, height: 0 }],
 					"pixels",
 					mergedParams.jumpOptions?.align === "center" ? "center" : "start",
+					0,
+					mergedParams.jumpOptions?.behavior ?? "smooth",
 				);
 			} else {
 				jumpToPage(targetPageNumber, mergedParams.jumpOptions);
@@ -176,13 +178,13 @@ export const useAnnotationLayer = (params: AnnotationLayerParams) => {
 			const target = e.target as HTMLAnchorElement;
 			const href = target.getAttribute("href") || "";
 
-			// Handle internal page links
+			// Internal links navigate via pdf.js's own click handler, which calls
+			// linkService.goToDestination with the real destination. Only stop the
+			// browser's default hash navigation here — dispatching goToPage as well
+			// would double-navigate, and the href's page number comes from the PDF
+			// object number, which is not a page index.
 			if (href.startsWith("#page=")) {
 				e.preventDefault();
-				const pageNumber = parseInt(href.substring(6), 10);
-				if (!Number.isNaN(pageNumber)) {
-					linkService.goToPage(pageNumber);
-				}
 			}
 			// External links will be handled by browser
 		};
@@ -192,7 +194,7 @@ export const useAnnotationLayer = (params: AnnotationLayerParams) => {
 		return () => {
 			element.removeEventListener("click", handleLinkClick as EventListener);
 		};
-	}, [linkService]);
+	}, []);
 
 	useEffect(() => {
 		if (!annotationLayerRef.current) {

--- a/packages/lector/src/hooks/pages/usePdfJump.tsx
+++ b/packages/lector/src/hooks/pages/usePdfJump.tsx
@@ -49,7 +49,7 @@ export const usePdfJump = () => {
 			additionalOffset: number = 0,
 			behavior: "auto" | "smooth" = "smooth",
 		): boolean => {
-			if (!virtualizer) return false;
+			if (!virtualizer || rects.length === 0) return false;
 
 			const firstPage = Math.min(...rects.map((rect) => rect.pageNumber));
 

--- a/packages/lector/src/hooks/pages/usePdfJump.tsx
+++ b/packages/lector/src/hooks/pages/usePdfJump.tsx
@@ -48,23 +48,23 @@ export const usePdfJump = () => {
 			align: "start" | "center" = "start",
 			additionalOffset: number = 0,
 			behavior: "auto" | "smooth" = "smooth",
-		) => {
-			if (!virtualizer) return;
+		): boolean => {
+			if (!virtualizer) return false;
 
 			const firstPage = Math.min(...rects.map((rect) => rect.pageNumber));
 
 			// Get the start offset of the page in the viewport
 			const pageOffset = virtualizer.getOffsetForIndex(firstPage - 1, "start");
 
-			if (pageOffset === null) return;
+			if (pageOffset === null) return false;
 
 			// Find the target highlight rect (usually the first one)
 			const targetRect = rects.find((rect) => rect.pageNumber === firstPage);
 
-			if (!targetRect) return;
+			if (!targetRect) return false;
 
 			const isNumber = pageOffset?.[0] != null;
-			if (!isNumber) return;
+			if (!isNumber) return false;
 
 			const pageStart = pageOffset[0] ?? 0;
 
@@ -109,6 +109,7 @@ export const usePdfJump = () => {
 				align: "start", // Always use start when we've calculated our own centering
 				behavior,
 			});
+			return true;
 		},
 		[virtualizer],
 	);

--- a/packages/lector/src/hooks/pages/usePdfJump.tsx
+++ b/packages/lector/src/hooks/pages/usePdfJump.tsx
@@ -47,6 +47,7 @@ export const usePdfJump = () => {
 			type: "pixels" | "percent",
 			align: "start" | "center" = "start",
 			additionalOffset: number = 0,
+			behavior: "auto" | "smooth" = "smooth",
 		) => {
 			if (!virtualizer) return;
 
@@ -106,7 +107,7 @@ export const usePdfJump = () => {
 
 			virtualizer.scrollToOffset(adjustedOffset, {
 				align: "start", // Always use start when we've calculated our own centering
-				behavior: "smooth",
+				behavior,
 			});
 		},
 		[virtualizer],

--- a/packages/lector/src/hooks/usePDFLinkService.test.ts
+++ b/packages/lector/src/hooks/usePDFLinkService.test.ts
@@ -153,6 +153,18 @@ describe("getDestinationScrollTop", () => {
 		expect(getDestinationScrollTop(viewport(0), dest)).toBeNull();
 	});
 
+	it("uses the visually topmost FitR corner", () => {
+		// Corners (0, 607) and (596, 597) convert to tops 193 and 203 on an
+		// upright page; the rect's visual top is the smaller viewport offset.
+		const dest = [{ num: 1, gen: 0 }, { name: "FitR" }, 0, 607, 596, 597];
+		expect(getDestinationScrollTop(viewport(0), dest)).toBe(193);
+	});
+
+	it("falls back to a page jump for incomplete FitR rectangles", () => {
+		const dest = [{ num: 1, gen: 0 }, { name: "FitR" }, 0, 607];
+		expect(getDestinationScrollTop(viewport(0), dest)).toBeNull();
+	});
+
 	it("ignores destinations without a position", () => {
 		const dest = [{ num: 1, gen: 0 }, { name: "Fit" }];
 		expect(getDestinationScrollTop(viewport(0), dest)).toBeNull();

--- a/packages/lector/src/hooks/usePDFLinkService.test.ts
+++ b/packages/lector/src/hooks/usePDFLinkService.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { getDestinationScrollTop } from "./layers/useAnnotationLayer";
 import { LinkService } from "./usePDFLinkService";
 
 const xyzDest = (num: number) => [
@@ -96,5 +97,40 @@ describe("LinkService page navigation callbacks", () => {
 		await service.goToDestination(explicitDest);
 
 		expect(callback).toHaveBeenCalledWith(3, explicitDest);
+	});
+});
+
+describe("getDestinationScrollTop", () => {
+	const viewport = (rotation: number) =>
+		({
+			rotation,
+			height: 800,
+			convertToViewportPoint: (x: number, y: number) =>
+				rotation % 180 === 0 ? [x, 800 - y] : [y, x],
+		}) as never;
+
+	it("converts XYZ destinations to a top offset", () => {
+		const dest = [{ num: 1, gen: 0 }, { name: "XYZ" }, 50, 600, null];
+		expect(getDestinationScrollTop(viewport(0), dest)).toBe(200);
+	});
+
+	it("converts FitH destinations on unrotated pages", () => {
+		const dest = [{ num: 1, gen: 0 }, { name: "FitH" }, 600];
+		expect(getDestinationScrollTop(viewport(0), dest)).toBe(200);
+	});
+
+	it("falls back to a page jump for x-less destinations on sideways pages", () => {
+		const dest = [{ num: 1, gen: 0 }, { name: "FitH" }, 600];
+		expect(getDestinationScrollTop(viewport(90), dest)).toBeNull();
+	});
+
+	it("still positions XYZ destinations on sideways pages", () => {
+		const dest = [{ num: 1, gen: 0 }, { name: "XYZ" }, 50, 600, null];
+		expect(getDestinationScrollTop(viewport(90), dest)).toBe(50);
+	});
+
+	it("ignores destinations without a position", () => {
+		const dest = [{ num: 1, gen: 0 }, { name: "Fit" }];
+		expect(getDestinationScrollTop(viewport(0), dest)).toBeNull();
 	});
 });

--- a/packages/lector/src/hooks/usePDFLinkService.test.ts
+++ b/packages/lector/src/hooks/usePDFLinkService.test.ts
@@ -50,6 +50,23 @@ describe("LinkService page navigation callbacks", () => {
 		expect(callback).not.toHaveBeenCalled();
 	});
 
+	it("rejects out-of-range page numbers in goToPage", () => {
+		const service = new LinkService();
+		const callback = vi.fn();
+
+		service.setDocument({ numPages: 10 } as never);
+		service.registerPageNavigationCallback(callback);
+
+		service.goToPage(0);
+		service.goToPage(-3);
+		service.goToPage(11);
+		service.goToPage(2.5);
+		expect(callback).not.toHaveBeenCalled();
+
+		service.goToPage(10);
+		expect(callback).toHaveBeenCalledWith(10, undefined);
+	});
+
 	it("resolves named destinations and forwards the explicit destination", async () => {
 		const service = new LinkService();
 		const callback = vi.fn();

--- a/packages/lector/src/hooks/usePDFLinkService.test.ts
+++ b/packages/lector/src/hooks/usePDFLinkService.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { LinkService } from "./usePDFLinkService";
+
+const xyzDest = (num: number) => [
+	{ num, gen: 0 },
+	{ name: "XYZ" },
+	100,
+	200,
+	null,
+];
+
+describe("LinkService page navigation callbacks", () => {
+	it("dispatches to the latest registrant", () => {
+		const service = new LinkService();
+		const first = vi.fn();
+		const second = vi.fn();
+
+		service.registerPageNavigationCallback(first);
+		service.registerPageNavigationCallback(second);
+		service.goToPage(3);
+
+		expect(first).not.toHaveBeenCalled();
+		expect(second).toHaveBeenCalledWith(3, undefined);
+	});
+
+	it("keeps a newer registration when an older layer unregisters", () => {
+		// Regression: with a single callback slot, any unmounting page layer
+		// wiped whatever callback was registered last, killing internal links.
+		const service = new LinkService();
+		const older = vi.fn();
+		const newer = vi.fn();
+
+		service.registerPageNavigationCallback(older);
+		service.registerPageNavigationCallback(newer);
+		service.unregisterPageNavigationCallback(older);
+		service.goToPage(5);
+
+		expect(newer).toHaveBeenCalledWith(5, undefined);
+	});
+
+	it("clears everything when unregistering without an argument", () => {
+		const service = new LinkService();
+		const callback = vi.fn();
+
+		service.registerPageNavigationCallback(callback);
+		service.unregisterPageNavigationCallback();
+		service.goToPage(2);
+
+		expect(callback).not.toHaveBeenCalled();
+	});
+
+	it("resolves named destinations and forwards the explicit destination", async () => {
+		const service = new LinkService();
+		const callback = vi.fn();
+		const explicitDest = xyzDest(7);
+
+		service.setDocument({
+			getDestination: vi.fn(async () => explicitDest),
+			getPageIndex: vi.fn(async () => 7),
+		} as never);
+
+		service.registerPageNavigationCallback(callback);
+		await service.goToDestination("bm_CR4");
+
+		expect(callback).toHaveBeenCalledWith(8, explicitDest);
+	});
+
+	it("forwards explicit array destinations without a document lookup", async () => {
+		const service = new LinkService();
+		const callback = vi.fn();
+		const explicitDest = xyzDest(2);
+
+		service.setDocument({
+			getPageIndex: vi.fn(async () => 2),
+		} as never);
+
+		service.registerPageNavigationCallback(callback);
+		await service.goToDestination(explicitDest);
+
+		expect(callback).toHaveBeenCalledWith(3, explicitDest);
+	});
+});

--- a/packages/lector/src/hooks/usePDFLinkService.test.ts
+++ b/packages/lector/src/hooks/usePDFLinkService.test.ts
@@ -40,6 +40,20 @@ describe("LinkService page navigation callbacks", () => {
 		expect(newer).toHaveBeenCalledWith(5, undefined);
 	});
 
+	it("re-registering an existing callback makes it the latest registrant", () => {
+		const service = new LinkService();
+		const first = vi.fn();
+		const second = vi.fn();
+
+		service.registerPageNavigationCallback(first);
+		service.registerPageNavigationCallback(second);
+		service.registerPageNavigationCallback(first);
+		service.goToPage(4);
+
+		expect(second).not.toHaveBeenCalled();
+		expect(first).toHaveBeenCalledWith(4, undefined);
+	});
+
 	it("clears everything when unregistering without an argument", () => {
 		const service = new LinkService();
 		const callback = vi.fn();

--- a/packages/lector/src/hooks/usePDFLinkService.test.ts
+++ b/packages/lector/src/hooks/usePDFLinkService.test.ts
@@ -129,6 +129,16 @@ describe("getDestinationScrollTop", () => {
 		expect(getDestinationScrollTop(viewport(90), dest)).toBe(50);
 	});
 
+	it("positions x-only FitV destinations on sideways pages", () => {
+		const dest = [{ num: 1, gen: 0 }, { name: "FitV" }, 50];
+		expect(getDestinationScrollTop(viewport(90), dest)).toBe(50);
+	});
+
+	it("falls back to a page jump for FitV destinations on upright pages", () => {
+		const dest = [{ num: 1, gen: 0 }, { name: "FitV" }, 50];
+		expect(getDestinationScrollTop(viewport(0), dest)).toBeNull();
+	});
+
 	it("ignores destinations without a position", () => {
 		const dest = [{ num: 1, gen: 0 }, { name: "Fit" }];
 		expect(getDestinationScrollTop(viewport(0), dest)).toBeNull();

--- a/packages/lector/src/hooks/usePDFLinkService.tsx
+++ b/packages/lector/src/hooks/usePDFLinkService.tsx
@@ -202,6 +202,13 @@ export class LinkService {
 	}
 
 	goToPage(pageNumber: number): void {
+		if (
+			!Number.isInteger(pageNumber) ||
+			pageNumber < 1 ||
+			(this.pagesCount > 0 && pageNumber > this.pagesCount)
+		) {
+			return;
+		}
 		this._dispatchPageNavigation(pageNumber);
 	}
 

--- a/packages/lector/src/hooks/usePDFLinkService.tsx
+++ b/packages/lector/src/hooks/usePDFLinkService.tsx
@@ -2,13 +2,30 @@ import type { PDFDocumentProxy } from "pdfjs-dist";
 import type { RefProxy } from "pdfjs-dist/types/src/display/api";
 import { createContext, useContext, useEffect, useRef } from "react";
 
+export type PageNavigationCallback = (
+	pageNumber: number,
+	explicitDest?: unknown[],
+) => void;
+
 export class LinkService {
 	_pdfDocumentProxy?: PDFDocumentProxy;
 	externalLinkEnabled = true;
 	isInPresentationMode = false;
 
 	_currentPageNumber = 0;
-	_pageNavigationCallback?: (pageNumber: number) => void;
+	// Every mounted AnnotationLayer registers a callback here. A single slot
+	// breaks under page virtualization: any layer unmounting would wipe the
+	// callback registered by a still-mounted layer, silently killing internal
+	// link navigation. Keep them all and dispatch to the latest registrant.
+	_pageNavigationCallbacks = new Set<PageNavigationCallback>();
+
+	_dispatchPageNavigation(pageNumber: number, explicitDest?: unknown[]): void {
+		let latest: PageNavigationCallback | undefined;
+		for (const callback of this._pageNavigationCallbacks) {
+			latest = callback;
+		}
+		latest?.(pageNumber, explicitDest);
+	}
 
 	get pdfDocumentProxy(): PDFDocumentProxy {
 		if (!this._pdfDocumentProxy) {
@@ -28,9 +45,7 @@ export class LinkService {
 
 	set page(value: number) {
 		this._currentPageNumber = value;
-		if (this._pageNavigationCallback) {
-			this._pageNavigationCallback(value);
-		}
+		this._dispatchPageNavigation(value);
 	}
 
 	// Required for link annotations to work
@@ -163,13 +178,10 @@ export class LinkService {
 			return;
 		}
 
-		// Navigate to the page
+		// Navigate to the page, forwarding the explicit destination so the
+		// handler can scroll to the destination's position within the page.
 		const pageNumber = pageIndex + 1;
-
-		// Trigger the navigation callback
-		if (this._pageNavigationCallback) {
-			this._pageNavigationCallback(pageNumber);
-		}
+		this._dispatchPageNavigation(pageNumber, explicitDest);
 	}
 
 	executeNamedAction(): void {
@@ -189,12 +201,8 @@ export class LinkService {
 		// Intentionally empty
 	}
 
-	goToPage(_page_valuer: number): void {
-		// if (pageNumber >= 1 && pageNumber <= this.pagesCount) {
-		// 	if (this._pageNavigationCallback) {
-		// 		this._pageNavigationCallback(pageNumber);
-		// 	}
-		// }
+	goToPage(pageNumber: number): void {
+		this._dispatchPageNavigation(pageNumber);
 	}
 
 	setHash(hash: string): void {
@@ -211,13 +219,18 @@ export class LinkService {
 	}
 
 	// Method to register navigation callback
-	registerPageNavigationCallback(callback: (pageNumber: number) => void): void {
-		this._pageNavigationCallback = callback;
+	registerPageNavigationCallback(callback: PageNavigationCallback): void {
+		this._pageNavigationCallbacks.add(callback);
 	}
 
-	// Method to unregister navigation callback
-	unregisterPageNavigationCallback(): void {
-		this._pageNavigationCallback = undefined;
+	// Method to unregister navigation callback. Only removes the caller's own
+	// callback so one layer's cleanup can't drop another layer's registration.
+	unregisterPageNavigationCallback(callback?: PageNavigationCallback): void {
+		if (!callback) {
+			this._pageNavigationCallbacks.clear();
+		} else {
+			this._pageNavigationCallbacks.delete(callback);
+		}
 	}
 }
 

--- a/packages/lector/src/hooks/usePDFLinkService.tsx
+++ b/packages/lector/src/hooks/usePDFLinkService.tsx
@@ -181,6 +181,7 @@ export class LinkService {
 		// Navigate to the page, forwarding the explicit destination so the
 		// handler can scroll to the destination's position within the page.
 		const pageNumber = pageIndex + 1;
+		this._currentPageNumber = pageNumber;
 		this._dispatchPageNavigation(pageNumber, explicitDest);
 	}
 
@@ -209,6 +210,7 @@ export class LinkService {
 		) {
 			return;
 		}
+		this._currentPageNumber = pageNumber;
 		this._dispatchPageNavigation(pageNumber);
 	}
 

--- a/packages/lector/src/hooks/usePDFLinkService.tsx
+++ b/packages/lector/src/hooks/usePDFLinkService.tsx
@@ -225,8 +225,10 @@ export class LinkService {
 		// Intentionally empty
 	}
 
-	// Method to register navigation callback
+	// Method to register navigation callback. Delete-then-add so re-registering
+	// an already-known callback still makes it the latest registrant.
 	registerPageNavigationCallback(callback: PageNavigationCallback): void {
+		this._pageNavigationCallbacks.delete(callback);
 		this._pageNavigationCallbacks.add(callback);
 	}
 


### PR DESCRIPTION
## Problem

Clicking an internal link inside a rendered PDF (citation markers like "[12]", table-of-contents entries, "see Section 3" references) does nothing in virtualized viewers, while external links work fine. Downstream: Anara PRD-5604.

## Root cause

pdf.js's `LinkAnnotationElement` calls `linkService.goToDestination(dest)` on click; lector resolves the page and invokes `_pageNavigationCallback`. Three defects broke the chain:

1. **Single callback slot vs. per-page layers.** Every mounted `AnnotationLayer` registers into one `_pageNavigationCallback` slot and unconditionally nulls it on unmount. Under page virtualization, layers unmount constantly — any unmount-only commit leaves the slot `undefined`, so subsequent clicks silently no-op. Traced live: after each navigation the register/unregister churn ends in `UNregister`, killing the next click.
2. **`goToPage()` was an empty stub**, so the `#page=N` container-handler fallback was dead code.
3. **Destination coordinates were discarded** — at best navigation landed at the top of the target page, not the referenced position.

## Fix

- `LinkService` keeps callbacks in a `Set`; dispatch goes to the latest registrant, and `unregisterPageNavigationCallback(cb)` removes only the caller's own callback (no-arg still clears all, preserving the old signature).
- `goToPage()` dispatches through the same path.
- `goToDestination()` forwards the resolved explicit destination; the annotation-layer handler converts XYZ/FitH/FitBH/FitR destinations to a scale-1 viewport offset via `PageViewport.convertToViewportPoint` (rotation-safe) and scrolls there with `scrollToHighlightRects`, falling back to a whole-page jump when the destination carries no position.

## Verification

- 5 new unit tests pin the register/unregister semantics and destination forwarding (`usePDFLinkService.test.ts`); 91/91 unit tests pass (the `useTextLayer.test.tsx` suite fails to import on clean `main` too — pre-existing, unrelated).
- Verified live in `examples/basic` (lector aliased to source) against a paper with 67 internal citation links: clicking "[4]" on page 1 scrolls to the exact reference position on page 7 (offset 141 → 4999 = page start 4805 + in-page 193.9), and clicks keep working after scrolling far enough to unmount/remount annotation layers — the case that previously left navigation dead.
- `tsc` clean, biome check has only the two pre-existing warnings, `tsup` build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- leo:summary-start -->
> [!NOTE]
> ### Fix PDF internal link navigation with `LinkService` destination scrolling
>
> - Changes `LinkService` navigation registration from a single callback slot to a `Set`, so virtualized annotation-layer unmounts only remove their own callback and dispatch still uses the latest mounted layer.
> - Implements guarded `goToPage()` navigation and forwards explicit PDF destinations from `goToDestination()`, keeping the current page in sync for link-driven jumps.
> - Adds `getDestinationScrollTop()` handling for positioned PDF destinations, including rotated pages and `FitR` rectangles, so internal links can scroll to the referenced spot instead of only the page top.
> - Updates annotation-layer click handling to avoid double-navigation for pdf.js internal links while preserving the `#page=N` fallback for literal hash links.
> - Adds unit coverage for callback lifetime, page-range validation, destination forwarding, and destination-to-scroll-offset conversion.
> - Behavioral change: PDF internal links now navigate in virtualized viewers and, when possible, scroll to the target position within the destination page.
>
> <sup>[Leo](https://anara.com) summarized `0ca73ca`</sup>
<!-- leo:summary-end -->